### PR TITLE
project use-site variance member projection

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/basedpython_variance.md
+++ b/crates/ty_python_semantic/resources/mdtest/basedpython_variance.md
@@ -81,6 +81,77 @@ def _(a: list[out int | str]):
     reveal_type(a[0])  # revealed: int | str
 ```
 
+The same holds under `in` — writes accept the whole union, reads still project to `object`:
+
+```by
+def _(a: list[in int | str]):
+    reveal_type(a)  # revealed: list[in int | str]
+    a[0] = 1  # ok
+    a[0] = "ok"  # ok
+    # error: [invalid-assignment]
+    a[0] = b"bad"
+    reveal_type(a[0])  # revealed: object
+```
+
+and under `in out`, which reads and writes the union like the plain form:
+
+```by
+def _(a: list[in out int | str]):
+    a[0] = 1  # ok
+    # error: [invalid-assignment]
+    a[0] = b"bad"
+    reveal_type(a[0])  # revealed: int | str
+```
+
+## mutating methods under `out`
+
+The projection is not limited to subscripts and attributes — it reaches every member. A method that
+consumes the element type (like `list.append`) takes it in a contravariant position, which projects
+to `Never` under `out`, so no argument can be written:
+
+```by
+def f(a: list[out int | str]):
+    reveal_type(a.append)  # revealed: bound method list[out int | str].append(object: Never, /) -> None
+    # error: [invalid-argument-type] "Argument to bound method `list.append` is incorrect: Expected `Never`, found `"a"`"
+    a.append("a")
+    # even a value of the element type is rejected — an `out` view writes nothing
+    # error: [invalid-argument-type]
+    a.append(1)
+    # error: [invalid-argument-type]
+    a.extend([1, 2])
+```
+
+A method that *produces* the element type reads it back covariantly, so it is unaffected:
+
+```by
+def f(a: list[out int]):
+    reveal_type(a.pop())  # revealed: int
+```
+
+## mutating methods under `in`
+
+`in` is the mirror image: writes are accepted at the element type, reads project to `object`.
+
+```by
+def f(a: list[in int]):
+    a.append(1)  # ok
+    # error: [invalid-argument-type]
+    a.append("bad")
+    reveal_type(a.pop())  # revealed: object
+```
+
+Union element types are consumed whole:
+
+```by
+def f(a: list[in int | str]):
+    reveal_type(a.append)  # revealed: bound method list[in int | str].append(object: int | str, /) -> None
+    a.append(1)  # ok
+    a.append("ok")  # ok
+    # error: [invalid-argument-type] "Argument to bound method `list.append` is incorrect: Expected `int | str`, found `b"bad"`"
+    a.append(b"bad")
+    reveal_type(a.pop())  # revealed: object
+```
+
 ## subtyping under projection
 
 Use-site projections promote an invariant generic to covariant or contravariant *at the call site*,

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6354,6 +6354,47 @@ impl<'db> Type<'db> {
         }
     }
 
+    /// basedpython: applies `specialization` to a member type, honoring any
+    /// use-site variance projections it carries. with no projections this is
+    /// exactly [`Type::apply_specialization`]; with projections, projected
+    /// typevars are substituted directionally by position — see
+    /// [`TypeMapping::ProjectUseSiteVariance`]. this is how `Container[out T]`
+    /// rejects writes (and `Container[in T]` rejects reads) through *methods*,
+    /// not just subscripts and attributes
+    #[must_use]
+    pub(crate) fn apply_projected_specialization(
+        self,
+        db: &'db dyn Db,
+        specialization: Specialization<'db>,
+    ) -> Type<'db> {
+        if specialization.projections(db).iter().any(Option::is_some) {
+            self.apply_type_mapping(
+                db,
+                &TypeMapping::ProjectUseSiteVariance {
+                    specialization: ApplySpecialization::Specialization(specialization),
+                    position: TypeVarVariance::Covariant,
+                },
+                TypeContext::default(),
+            )
+        } else {
+            self.apply_specialization(db, specialization)
+        }
+    }
+
+    /// basedpython: the `Option` analogue of [`Type::apply_projected_specialization`]
+    #[must_use]
+    pub(crate) fn apply_projected_optional_specialization(
+        self,
+        db: &'db dyn Db,
+        specialization: Option<Specialization<'db>>,
+    ) -> Type<'db> {
+        if let Some(specialization) = specialization {
+            self.apply_projected_specialization(db, specialization)
+        } else {
+            self
+        }
+    }
+
     /// Applies a specialization to this type, replacing any typevars with the types that they are
     /// specialized to.
     ///
@@ -6716,6 +6757,7 @@ impl<'db> Type<'db> {
             Type::LiteralValue(_) => match type_mapping {
                 TypeMapping::ApplySpecialization(_) |
                 TypeMapping::ApplySpecializationWithMaterialization { .. } |
+                TypeMapping::ProjectUseSiteVariance { .. } |
                 TypeMapping::BindLegacyTypevars(_) |
                 TypeMapping::FreshenBoundTypeVars { .. } |
                 TypeMapping::BindSelf { .. } |
@@ -6735,6 +6777,7 @@ impl<'db> Type<'db> {
             Type::Dynamic(_) => match type_mapping {
                 TypeMapping::ApplySpecialization(_) |
                 TypeMapping::ApplySpecializationWithMaterialization { .. } |
+                TypeMapping::ProjectUseSiteVariance { .. } |
                 TypeMapping::BindLegacyTypevars(_) |
                 TypeMapping::FreshenBoundTypeVars { .. } |
                 TypeMapping::BindSelf(..) |
@@ -7786,6 +7829,18 @@ pub enum TypeMapping<'a, 'db> {
         specialization: ApplySpecialization<'a, 'db>,
         materialization_kind: MaterializationKind,
     },
+    /// basedpython use-site variance projection: applies `specialization` but
+    /// substitutes use-site-projected typevars directionally by `position`.
+    /// `position` is composed through the surrounding type as we recurse (a
+    /// method parameter flips it, an invariant argument seals it). under an `out`
+    /// projection a typevar reads (covariant) as its value and writes
+    /// (contravariant) as `Never`; under `in` it reads as `object` and writes as
+    /// its value; an invariant occurrence takes the value unchanged. non-projected
+    /// typevars substitute normally in every position
+    ProjectUseSiteVariance {
+        specialization: ApplySpecialization<'a, 'db>,
+        position: TypeVarVariance,
+    },
     /// Replaces any literal types with their corresponding promoted type form (e.g. `Literal["string"]`
     /// to `str`, or `def _() -> int` to `Callable[[], int]`).
     Promote(PromotionMode, PromotionKind),
@@ -7832,7 +7887,8 @@ impl<'db> TypeMapping<'_, 'db> {
                 }),
             ),
             TypeMapping::ApplySpecialization(specialization)
-            | TypeMapping::ApplySpecializationWithMaterialization { specialization, .. } => {
+            | TypeMapping::ApplySpecializationWithMaterialization { specialization, .. }
+            | TypeMapping::ProjectUseSiteVariance { specialization, .. } => {
                 // Filter out type variables that are already specialized
                 // (i.e., mapped to a non-TypeVar type)
                 GenericContext::from_typevar_instances(
@@ -7893,6 +7949,13 @@ impl<'db> TypeMapping<'_, 'db> {
             } => TypeMapping::ApplySpecializationWithMaterialization {
                 specialization: *specialization,
                 materialization_kind: materialization_kind.flip(),
+            },
+            TypeMapping::ProjectUseSiteVariance {
+                specialization,
+                position,
+            } => TypeMapping::ProjectUseSiteVariance {
+                specialization: *specialization,
+                position: position.flip(),
             },
             TypeMapping::Promote(mode, kind) => TypeMapping::Promote(mode.flip(), *kind),
             TypeMapping::ApplySpecialization(_)

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1692,7 +1692,7 @@ impl<'db> ClassType<'db> {
         let fallback_member_lookup = || {
             class_literal
                 .own_class_member(db, inherited_generic_context, specialization, name)
-                .map_type(|ty| ty.apply_optional_specialization(db, specialization))
+                .map_type(|ty| ty.apply_projected_optional_specialization(db, specialization))
         };
 
         match name {
@@ -1981,15 +1981,15 @@ impl<'db> ClassType<'db> {
             }
             Self::Generic(generic) => {
                 let class_literal = generic.origin(db);
-                let specialization = Some(generic.specialization(db));
+                let specialization = generic.specialization(db);
 
                 if class_literal.is_typed_dict(db) {
                     return Place::Undefined.into();
                 }
 
                 class_literal
-                    .instance_member(db, specialization, name)
-                    .map_type(|ty| ty.apply_optional_specialization(db, specialization))
+                    .instance_member(db, Some(specialization), name)
+                    .map_type(|ty| ty.apply_projected_specialization(db, specialization))
             }
         }
     }

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1289,6 +1289,21 @@ impl<'db> Specialization<'db> {
         self.types(db).get(index).copied()
     }
 
+    /// basedpython: returns the use-site variance projection recorded for
+    /// `bound_typevar`, or `None` when the typevar carries no projection (or is
+    /// not part of this specialization)
+    pub(crate) fn projection_for(
+        self,
+        db: &'db dyn Db,
+        bound_typevar: BoundTypeVarInstance<'db>,
+    ) -> Option<ruff_python_ast::helpers::UseSiteVariance> {
+        let index = self
+            .generic_context(db)
+            .variables_inner(db)
+            .get_index_of(&bound_typevar.identity(db))?;
+        self.projections(db).get(index).copied().flatten()
+    }
+
     /// Applies a specialization to this specialization. This is used, for instance, when a generic
     /// class inherits from a generic alias:
     ///
@@ -1388,6 +1403,26 @@ impl<'db> Specialization<'db> {
 
                     specialized
                 }
+                // basedpython use-site variance: compose the projection position
+                // with this argument's declared variance so an invariant argument
+                // (e.g. the `T` in a returned `list[T]`) is sealed rather than
+                // flipped. this cannot go through the generic covariant/flip arms
+                // below, which have no way to represent an invariant position
+                (
+                    variance,
+                    TypeMapping::ProjectUseSiteVariance {
+                        specialization,
+                        position,
+                    },
+                ) => ty.apply_type_mapping_impl(
+                    db,
+                    &TypeMapping::ProjectUseSiteVariance {
+                        specialization: *specialization,
+                        position: position.compose(variance),
+                    },
+                    tcx,
+                    visitor,
+                ),
                 (variance, _) if variance.is_covariant() => {
                     ty.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
                 }

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -403,6 +403,7 @@ impl<'db> KnownInstanceType<'db> {
                 }
                 TypeMapping::ApplySpecialization(_)
                 | TypeMapping::ApplySpecializationWithMaterialization { .. }
+                | TypeMapping::ProjectUseSiteVariance { .. }
                 | TypeMapping::Promote(..)
                 | TypeMapping::FreshenBoundTypeVars { .. }
                 | TypeMapping::BindSelf(..)

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -1115,6 +1115,54 @@ impl<'db> BoundTypeVarInstance<'db> {
             TypeMapping::ApplySpecialization(specialization) => {
                 mapped_specialization_type(specialization).unwrap_or(Type::TypeVar(self))
             }
+            TypeMapping::ProjectUseSiteVariance {
+                specialization,
+                position,
+            } => {
+                use crate::types::TypeVarVariance;
+                use ruff_python_ast::helpers::UseSiteVariance;
+
+                let Some(value) = mapped_specialization_type(specialization) else {
+                    return Type::TypeVar(self);
+                };
+                let projection = match specialization {
+                    ApplySpecialization::Specialization(specialization) => {
+                        specialization.projection_for(db, self)
+                    }
+                    _ => None,
+                };
+                match projection {
+                    None | Some(UseSiteVariance::InOut) => value,
+                    // an invariant or bivariant occurrence (e.g. the element of a
+                    // returned `list[T]`) is sealed: it takes the value unchanged,
+                    // in neither the read nor the write direction
+                    _ if !matches!(
+                        position,
+                        TypeVarVariance::Covariant | TypeVarVariance::Contravariant
+                    ) =>
+                    {
+                        value
+                    }
+                    // `out`: covariant (read) yields the value; contravariant
+                    // (write) yields `Never`, so no argument can be written
+                    Some(UseSiteVariance::Out) => {
+                        if matches!(position, TypeVarVariance::Contravariant) {
+                            Type::Never
+                        } else {
+                            value
+                        }
+                    }
+                    // `in`: contravariant (write) yields the value; covariant
+                    // (read) projects through to `object`
+                    Some(UseSiteVariance::In) => {
+                        if matches!(position, TypeVarVariance::Contravariant) {
+                            value
+                        } else {
+                            Type::object()
+                        }
+                    }
+                }
+            }
             TypeMapping::ApplySpecializationWithMaterialization {
                 specialization,
                 materialization_kind,


### PR DESCRIPTION
`Container[out T]` now rejects writes (and `Container[in T]` rejects reads) through methods and attributes, so `list[out int].append(...)` errors. adds a `ProjectUseSiteVariance` type-mapping that substitutes projected typevars directionally by composed position: out reads as its value / writes as `Never`, in reads as `object` / writes as its value, invariant occurrences are sealed to the value so returned `list[T]` stays usable
