### PR TITLE
add Overlapping safe-variance modifier for covariant container membership

### DIFF
--- a/crates/by_typeshed_patch/src/lib.rs
+++ b/crates/by_typeshed_patch/src/lib.rs
@@ -48,7 +48,10 @@ pub struct Edit {
 pub fn all_patches() -> Vec<Box<dyn Patch>> {
     // patches are added here as upstream syncs surface concrete drift. each
     // entry must have a corresponding module in `src/patches/` with tests
-    vec![Box::new(patches::mapping::MappingKeyCovariance)]
+    vec![
+        Box::new(patches::mapping::MappingKeyCovariance),
+        Box::new(patches::container_overlapping::ContainerMembershipOverlapping),
+    ]
 }
 
 /// registry of every post-conversion patch, applied in pass 3 after the pep 695

--- a/crates/by_typeshed_patch/src/main.rs
+++ b/crates/by_typeshed_patch/src/main.rs
@@ -15,7 +15,12 @@
 //! a reference the next pass depends on, so each must see the prior output
 //!
 //! usage:
-//!   `by_typeshed_patch` `<typeshed-stdlib-dir>`
+//!   `by_typeshed_patch [--skip-conversion]` `<typeshed-stdlib-dir>`
+//!
+//! `--skip-conversion` runs only the semantic patches and skips the pep 695
+//! conversion pass. use it to re-apply patches to an already-converted tree
+//! (the committed `.byi`), where the conversion pass would otherwise re-process
+//! classes whose module-level `TypeVar` declarations are already gone
 
 #![allow(clippy::print_stderr)]
 
@@ -41,9 +46,22 @@ fn main() -> ExitCode {
 }
 
 fn run() -> Result<()> {
-    let args: Vec<String> = env::args().collect();
-    let [_, dir] = args.as_slice() else {
-        bail!("usage: by_typeshed_patch <typeshed-stdlib-dir>");
+    let args: Vec<String> = env::args().skip(1).collect();
+    let mut skip_conversion = false;
+    let mut dir: Option<String> = None;
+    for arg in args {
+        match arg.as_str() {
+            "--skip-conversion" => skip_conversion = true,
+            other if other.starts_with("--") => bail!("unknown flag: {other}"),
+            other => {
+                if dir.replace(other.to_string()).is_some() {
+                    bail!("usage: by_typeshed_patch [--skip-conversion] <typeshed-stdlib-dir>");
+                }
+            }
+        }
+    }
+    let Some(dir) = dir else {
+        bail!("usage: by_typeshed_patch [--skip-conversion] <typeshed-stdlib-dir>");
     };
     let root = PathBuf::from(dir);
     if !root.is_dir() {
@@ -66,7 +84,7 @@ fn run() -> Result<()> {
         }
         visited += 1;
         let rel = path.strip_prefix(&root).unwrap_or(path);
-        if apply_patches_to_file(path, rel, &patches, &post_patches)
+        if apply_patches_to_file(path, rel, &patches, &post_patches, skip_conversion)
             .with_context(|| format!("applying patches to {}", path.display()))?
         {
             patched += 1;
@@ -81,6 +99,7 @@ fn apply_patches_to_file(
     rel: &Path,
     patches: &[Box<dyn Patch>],
     post_patches: &[Box<dyn Patch>],
+    skip_conversion: bool,
 ) -> Result<bool> {
     let original = fs::read_to_string(path).with_context(|| format!("{}", path.display()))?;
 
@@ -101,26 +120,35 @@ fn apply_patches_to_file(
         apply_edits(&original, edits)
     };
 
-    // pass 2: pep 695 conversion over the patched source (re-parsed so it sees
-    // any typevar references the patches rewrote)
-    let reparsed = parse_unchecked_source(&patched, PySourceType::BasedPythonStub);
-    let conversion = pep695::convert_module(&reparsed, &patched);
-    let mut current = if conversion.is_empty() {
+    // re-applying the semantic patches to an already-converted tree (the
+    // committed `.byi`) stops after pass 1: the pep 695 conversion would
+    // mishandle classes whose module-level `TypeVar` declarations are already
+    // gone, and the post-conversion passes have already been applied
+    let current = if skip_conversion {
         patched
     } else {
-        apply_edits(&patched, conversion)
-    };
+        // pass 2: pep 695 conversion over the patched source (re-parsed so it
+        // sees any typevar references the patches rewrote)
+        let reparsed = parse_unchecked_source(&patched, PySourceType::BasedPythonStub);
+        let conversion = pep695::convert_module(&reparsed, &patched);
+        let mut current = if conversion.is_empty() {
+            patched
+        } else {
+            apply_edits(&patched, conversion)
+        };
 
-    // pass 3: post-conversion beautification. each post-patch runs over its own
-    // re-parse of the current form and is applied before the next one, so no two
-    // patches have to reason about each other's byte offsets
-    for patch in post_patches {
-        let reparsed = parse_unchecked_source(&current, PySourceType::BasedPythonStub);
-        let edits = patch.rewrite(rel, &reparsed, &current);
-        if !edits.is_empty() {
-            current = apply_edits(&current, edits);
+        // pass 3: post-conversion beautification. each post-patch runs over its
+        // own re-parse of the current form and is applied before the next one, so
+        // no two patches have to reason about each other's byte offsets
+        for patch in post_patches {
+            let reparsed = parse_unchecked_source(&current, PySourceType::BasedPythonStub);
+            let edits = patch.rewrite(rel, &reparsed, &current);
+            if !edits.is_empty() {
+                current = apply_edits(&current, edits);
+            }
         }
-    }
+        current
+    };
 
     if current == original {
         return Ok(false);

--- a/crates/by_typeshed_patch/src/patches/container_overlapping.rs
+++ b/crates/by_typeshed_patch/src/patches/container_overlapping.rs
@@ -1,0 +1,418 @@
+//! membership (`in`) uses `Overlapping` on the covariant container element
+//!
+//! `Container` is covariant in its element (`out Element`), so a membership test
+//! consumes that covariant typevar in an input position. basedpython types the
+//! parameter as `Overlapping[Element]`: a value is accepted iff it is not
+//! disjoint from `Element`, so `1 in xs` and `object() in xs` are allowed for an
+//! `xs: Container[int]`, while `"a" in xs` is rejected
+//!
+//! `Container.__contains__` is the abstract membership requirement. every other
+//! container that already declares `__contains__` keeps its own declaration
+//! (abstract on `AbstractSet`, concrete mixins on `Sequence`/`Mapping`/the views,
+//! concrete C implementations on `tuple`/`list`/`set`/`frozenset`) — the patch
+//! only rewrites each parameter from `object` to `Overlapping[<element>]`, so the
+//! abstract/concrete structure is unchanged and every membership test applies the
+//! overlap check. `Mapping` and `dict` additionally consume their covariant key
+//! in `__getitem__`/`get`, likewise typed `Overlapping[Key]`.
+//!
+//! this is sound because `Overlapping[Key]` relates as `Key` for subtyping and
+//! override compatibility (a subclass may override with `Key` or the bare upper
+//! bound); only the call site applies the overlap admissibility check
+//!
+//! this patch operates on the already-pep695-converted committed tree (run via
+//! `by_typeshed_patch --skip-conversion`), matching the nice type-parameter
+//! names (`Element`, `Key`) rather than the legacy `_T_co`/`_KT_co` form
+
+use std::path::Path;
+
+use ruff_python_ast::{Expr, ModModule, Parameters, Stmt, StmtClassDef};
+use ruff_python_parser::Parsed;
+use ruff_text_size::Ranged;
+
+use crate::{Edit, Patch};
+
+/// stale upstream comments that describe the old (contravariant `Container[Any]`)
+/// model; the `Overlapping` rewrite makes them wrong, so they are removed
+const STALE_COMMENTS: &[&str] = &[
+    "# This is generic more on vibes than anything else",
+    "# Note: need to use Container[Any] instead of Container[_T_co] to ensure covariance.",
+    "# Implement Sized (but don't have it as a base class).",
+];
+
+pub struct ContainerMembershipOverlapping;
+
+impl Patch for ContainerMembershipOverlapping {
+    fn name(&self) -> &'static str {
+        "container-membership-overlapping"
+    }
+
+    fn target_symbols(&self) -> &'static [&'static str] {
+        &[
+            "typing.Container",
+            "typing.Collection",
+            "typing.Mapping",
+            "typing.Sequence",
+            "typing.AbstractSet",
+            "typing.KeysView",
+            "typing.ValuesView",
+            "typing.ItemsView",
+            "builtins.tuple",
+            "builtins.list",
+            "builtins.set",
+            "builtins.frozenset",
+            "builtins.dict",
+            "builtins.frozendict",
+        ]
+    }
+
+    fn rewrite(&self, module_path: &Path, parsed: &Parsed<ModModule>, source: &str) -> Vec<Edit> {
+        match module_qualname(module_path).as_deref() {
+            Some("typing") => rewrite_typing(parsed, source),
+            Some("builtins") => rewrite_builtins(parsed),
+            _ => Vec::new(),
+        }
+    }
+}
+
+fn rewrite_typing(parsed: &Parsed<ModModule>, source: &str) -> Vec<Edit> {
+    let mut edits = Vec::new();
+    remove_stale_comments(source, &mut edits);
+    for stmt in &parsed.syntax().body {
+        let Stmt::ClassDef(class) = stmt else {
+            continue;
+        };
+        // rewrite each declared `__contains__` parameter to `Overlapping[<element>]`,
+        // keeping the method exactly as abstract/concrete as it already is. the
+        // element is the type membership is tested against for that class
+        match class.name.as_str() {
+            "Container" => rewrite_container(class, &mut edits),
+            "Collection" => rewrite_collection_base(class, &mut edits),
+            "Sequence" | "AbstractSet" => rewrite_contains_param(class, "Element", &mut edits),
+            "KeysView" => rewrite_contains_param(class, "Key", &mut edits),
+            "ValuesView" => rewrite_contains_param(class, "Value", &mut edits),
+            "ItemsView" => rewrite_contains_param(class, "tuple[Key, Value]", &mut edits),
+            // `Mapping` also consumes its covariant `Key` in `__getitem__`/`get`
+            "Mapping" => {
+                rewrite_contains_param(class, "Key", &mut edits);
+                rewrite_key_params_to_overlapping(&class.body, &mut edits);
+            }
+            _ => {}
+        }
+    }
+    edits
+}
+
+/// delete every line holding one of the [`STALE_COMMENTS`]
+fn remove_stale_comments(source: &str, edits: &mut Vec<Edit>) {
+    for comment in STALE_COMMENTS {
+        if let Some(pos) = source.find(comment) {
+            let (start, end) = full_line_span(source, pos, pos + comment.len());
+            edits.push(Edit {
+                start,
+                end,
+                replacement: String::new(),
+            });
+        }
+    }
+}
+
+/// rewrite the `key` parameter of every `__getitem__`/`get` method in `stmts` to
+/// `Overlapping[Key]`, descending into `sys.version_info` guards
+fn rewrite_key_params_to_overlapping(stmts: &[Stmt], edits: &mut Vec<Edit>) {
+    for stmt in stmts {
+        match stmt {
+            Stmt::FunctionDef(func) if matches!(func.name.as_str(), "__getitem__" | "get") => {
+                if let Some(range) = named_positional_annotation(&func.parameters, "key") {
+                    edits.push(replace_range(range, "Overlapping[Key]"));
+                }
+            }
+            Stmt::If(if_stmt) => {
+                rewrite_key_params_to_overlapping(&if_stmt.body, edits);
+                for clause in &if_stmt.elif_else_clauses {
+                    rewrite_key_params_to_overlapping(&clause.body, edits);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// the concrete builtin containers keep their own `__contains__` (it is a real,
+/// concrete C implementation), with the parameter rewritten to `Overlapping`.
+/// `str`/`bytes`/`bytearray` are deliberately left alone: their `__contains__`
+/// takes a genuinely different type (substring / buffer), not the element.
+///
+/// classes are also visited inside module-level `sys.version_info` guards, where
+/// `frozendict` lives
+fn rewrite_builtins(parsed: &Parsed<ModModule>) -> Vec<Edit> {
+    let mut edits = Vec::new();
+    rewrite_builtin_classes(&parsed.syntax().body, &mut edits);
+    edits
+}
+
+fn rewrite_builtin_classes(stmts: &[Stmt], edits: &mut Vec<Edit>) {
+    for stmt in stmts {
+        match stmt {
+            Stmt::ClassDef(class) => match class.name.as_str() {
+                "tuple" | "list" | "set" | "frozenset" => {
+                    rewrite_contains_param(class, "Element", edits);
+                }
+                // `dict`/`frozendict` consume their key in `__getitem__`/`get`;
+                // they inherit `__contains__` from `Mapping`
+                "dict" | "frozendict" => {
+                    rewrite_key_params_to_overlapping(&class.body, edits);
+                }
+                _ => {}
+            },
+            Stmt::If(if_stmt) => {
+                rewrite_builtin_classes(&if_stmt.body, edits);
+                for clause in &if_stmt.elif_else_clauses {
+                    rewrite_builtin_classes(&clause.body, edits);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// `class Container[in ContainerT = Any]` → `class Container[out Element]`, and
+/// `abstract def __contains__(self, x: <T>, /)` → `x: Overlapping[Element]`.
+///
+/// the method stays `abstract`: `Container.__contains__` is the single abstract
+/// membership requirement, and every container inherits it (the overlap check is
+/// applied structurally through `Container[Element]`, not via a redeclaration)
+fn rewrite_container(class: &StmtClassDef, edits: &mut Vec<Edit>) {
+    if let Some(type_params) = class.type_params.as_ref() {
+        edits.push(replace_range(type_params.range(), "[out Element]"));
+    }
+    for stmt in &class.body {
+        let Stmt::FunctionDef(method) = stmt else {
+            continue;
+        };
+        if method.name.as_str() != "__contains__" {
+            continue;
+        }
+        if let Some(range) = first_positional_annotation(&method.parameters) {
+            edits.push(replace_range(range, "Overlapping[Element]"));
+        }
+    }
+}
+
+/// `class Collection[out Element](Iterable[Element], Container[Any], ...)` →
+/// `Container[Element]`, so the inherited membership check sees the real element
+fn rewrite_collection_base(class: &StmtClassDef, edits: &mut Vec<Edit>) {
+    let Some(arguments) = class.arguments.as_ref() else {
+        return;
+    };
+    for base in &arguments.args {
+        let Expr::Subscript(subscript) = base else {
+            continue;
+        };
+        let Expr::Name(name) = subscript.value.as_ref() else {
+            continue;
+        };
+        if name.id.as_str() == "Container" {
+            edits.push(replace_range(subscript.slice.range(), "Element"));
+        }
+    }
+}
+
+/// rewrite the first non-`self` positional parameter of every `__contains__`
+/// method declared directly on `class` to `Overlapping[<element>]`, leaving the
+/// method's `abstract`/concrete status and body untouched
+fn rewrite_contains_param(class: &StmtClassDef, element: &str, edits: &mut Vec<Edit>) {
+    for stmt in &class.body {
+        if let Stmt::FunctionDef(func) = stmt
+            && func.name.as_str() == "__contains__"
+            && let Some(range) = first_positional_annotation(&func.parameters)
+        {
+            edits.push(replace_range(range, &format!("Overlapping[{element}]")));
+        }
+    }
+}
+
+/// byte range of the annotation of the first non-`self` positional parameter
+fn first_positional_annotation(parameters: &Parameters) -> Option<ruff_text_size::TextRange> {
+    parameters
+        .posonlyargs
+        .iter()
+        .chain(parameters.args.iter())
+        .filter(|p| p.parameter.name.as_str() != "self")
+        .find_map(|p| p.parameter.annotation.as_ref().map(|a| a.range()))
+}
+
+/// byte range of the annotation of the positional parameter named `name`
+fn named_positional_annotation(
+    parameters: &Parameters,
+    name: &str,
+) -> Option<ruff_text_size::TextRange> {
+    parameters
+        .posonlyargs
+        .iter()
+        .chain(parameters.args.iter())
+        .find(|p| p.parameter.name.as_str() == name)
+        .and_then(|p| p.parameter.annotation.as_ref().map(|a| a.range()))
+}
+
+fn replace_range(range: ruff_text_size::TextRange, replacement: &str) -> Edit {
+    Edit {
+        start: range.start().to_usize(),
+        end: range.end().to_usize(),
+        replacement: replacement.to_string(),
+    }
+}
+
+/// expand `[node_start, node_end)` to cover the full source line(s): back to the
+/// start of the first line and forward through the trailing newline
+fn full_line_span(source: &str, node_start: usize, node_end: usize) -> (usize, usize) {
+    let start = source[..node_start]
+        .rfind('\n')
+        .map_or(0, |newline| newline + 1);
+    let end = source[node_end..]
+        .find('\n')
+        .map_or(source.len(), |newline| node_end + newline + 1);
+    (start, end)
+}
+
+/// dotted module name for a typeshed file path relative to `stdlib/`
+fn module_qualname(path: &Path) -> Option<String> {
+    let stem = path.file_stem()?.to_str()?;
+    let mut parts: Vec<&str> = path
+        .parent()
+        .into_iter()
+        .flat_map(Path::components)
+        .filter_map(|component| component.as_os_str().to_str())
+        .collect();
+    if stem != "__init__" {
+        parts.push(stem);
+    }
+    Some(parts.join("."))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ruff_python_ast::PySourceType;
+    use ruff_python_parser::parse_unchecked_source;
+
+    use crate::apply_edits;
+
+    fn run(path: &str, src: &str) -> String {
+        let parsed = parse_unchecked_source(src, PySourceType::BasedPythonStub);
+        let edits = ContainerMembershipOverlapping.rewrite(Path::new(path), &parsed, src);
+        apply_edits(src, edits)
+    }
+
+    #[test]
+    fn rewrites_container_and_drops_inherited_overrides() {
+        let src = "\
+class Container[in ContainerT = Any](Protocol):
+    # This is generic more on vibes than anything else
+    abstract def __contains__(self, x: ContainerT, /) -> bool
+
+class Collection[out Element](Iterable[Element], Container[Any], Protocol):
+    # Note: need to use Container[Any] instead of Container[_T_co] to ensure covariance.
+    # Implement Sized (but don't have it as a base class).
+    abstract def __len__(self) -> int
+
+class Sequence[out Element](Collection[Element]):
+    def __contains__(self, value: object, /) -> bool
+    def index(self, value: Any, /) -> int
+
+class Mapping[out Key, out Value](Collection[Key]):
+    abstract def __getitem__(self, key: Key, /) -> Value
+    def get(self, key: object, /) -> Value | None
+    def __contains__(self, key: object, /) -> bool
+    def __eq__(self, other: object, /) -> bool
+";
+        let expected = "\
+class Container[out Element](Protocol):
+    abstract def __contains__(self, x: Overlapping[Element], /) -> bool
+
+class Collection[out Element](Iterable[Element], Container[Element], Protocol):
+    abstract def __len__(self) -> int
+
+class Sequence[out Element](Collection[Element]):
+    def __contains__(self, value: Overlapping[Element], /) -> bool
+    def index(self, value: Any, /) -> int
+
+class Mapping[out Key, out Value](Collection[Key]):
+    abstract def __getitem__(self, key: Overlapping[Key], /) -> Value
+    def get(self, key: Overlapping[Key], /) -> Value | None
+    def __contains__(self, key: Overlapping[Key], /) -> bool
+    def __eq__(self, other: object, /) -> bool
+";
+        assert_eq!(run("typing.byi", src), expected);
+    }
+
+    #[test]
+    fn rewrites_concrete_builtin_contains_but_keeps_str() {
+        let src = "\
+class tuple[out Element](Sequence[Element]):
+    def __contains__(self, key: object, /) -> bool:
+        \"\"\"Return bool(key in self).\"\"\"
+
+class str(Sequence[str]):
+    def __contains__(self, key: str, /) -> bool:  # type: ignore[override]
+        \"\"\"substring\"\"\"
+
+class set[in out Element](MutableSet[Element]):
+    def __contains__(self, o: object, /) -> bool: ...
+";
+        let expected = "\
+class tuple[out Element](Sequence[Element]):
+    def __contains__(self, key: Overlapping[Element], /) -> bool:
+        \"\"\"Return bool(key in self).\"\"\"
+
+class str(Sequence[str]):
+    def __contains__(self, key: str, /) -> bool:  # type: ignore[override]
+        \"\"\"substring\"\"\"
+
+class set[in out Element](MutableSet[Element]):
+    def __contains__(self, o: Overlapping[Element], /) -> bool: ...
+";
+        assert_eq!(run("builtins.byi", src), expected);
+    }
+
+    #[test]
+    fn rewrites_dict_key_params_including_version_guards() {
+        let src = "\
+class dict[in out Key, in out Value](MutableMapping[Key, Value]):
+    def __getitem__(self, key: Key, /) -> Value: ...
+    def get(self, key: object, default: None = None, /) -> Value | None: ...
+    if sys.version_info >= (3, 12):
+        def get(self, key: Key, default: Value, /) -> Value: ...
+";
+        let expected = "\
+class dict[in out Key, in out Value](MutableMapping[Key, Value]):
+    def __getitem__(self, key: Overlapping[Key], /) -> Value: ...
+    def get(self, key: Overlapping[Key], default: None = None, /) -> Value | None: ...
+    if sys.version_info >= (3, 12):
+        def get(self, key: Overlapping[Key], default: Value, /) -> Value: ...
+";
+        assert_eq!(run("builtins.byi", src), expected);
+    }
+
+    #[test]
+    fn rewrites_frozendict_nested_in_version_guard() {
+        let src = "\
+if sys.version_info >= (3, 15):
+    class frozendict[in out Key, in out Value](Mapping[Key, Value]):
+        def get(self, key: Key, default: None = None, /) -> Value | None: ...
+        def __getitem__(self, key: Key, /) -> Value: ...
+";
+        let expected = "\
+if sys.version_info >= (3, 15):
+    class frozendict[in out Key, in out Value](Mapping[Key, Value]):
+        def get(self, key: Overlapping[Key], default: None = None, /) -> Value | None: ...
+        def __getitem__(self, key: Overlapping[Key], /) -> Value: ...
+";
+        assert_eq!(run("builtins.byi", src), expected);
+    }
+
+    #[test]
+    fn skips_other_modules() {
+        let src = "class Container[in ContainerT = Any](Protocol):\n    abstract def __contains__(self, x: ContainerT, /) -> bool\n";
+        assert_eq!(run("builtins.byi", src), src);
+    }
+}

--- a/crates/by_typeshed_patch/src/patches/mod.rs
+++ b/crates/by_typeshed_patch/src/patches/mod.rs
@@ -6,6 +6,7 @@ pub mod any_to_dynamic;
 pub mod arrow_callable;
 pub mod builtins_tweaks;
 pub mod cleanup;
+pub mod container_overlapping;
 pub mod dead_symbols;
 pub mod dead_typevars;
 pub mod final_annotation;

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -3110,7 +3110,12 @@ fn completion_kind_from_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Comp
             | Type::NewTypeInstance(_)
             | Type::EnumComplement(_) => CompletionKind::Struct,
             Type::LiteralValue(literal) if literal.is_enum() => CompletionKind::Enum,
-            Type::LiteralValue(_) | Type::TypeIs(_) | Type::TypeGuard(_) | Type::TypeForm(_) => {
+            Type::LiteralValue(_)
+            | Type::TypeIs(_)
+            | Type::TypeGuard(_)
+            | Type::TypeForm(_)
+            // parameter-only marker; never actually a completion target
+            | Type::Overlapping(_) => {
                 CompletionKind::Value
             }
             Type::ProtocolInstance(_) => CompletionKind::Interface,
@@ -5039,7 +5044,7 @@ quux.<CURSOR>
         __annotations__ :: dict[str, Any]
         __class__ :: type[Quux]
         __class_getitem__ :: bound method type[Quux].__class_getitem__(item: Any, /) -> GenericAlias
-        __contains__ :: bound method Quux.__contains__(key: object, /) -> bool
+        __contains__ :: bound method Quux.__contains__(key: Overlapping[int | str], /) -> bool
         __delattr__ :: bound method Quux.__delattr__(name: str, /) -> None
         __dict__ :: dict[str, Any]
         __dir__ :: bound method Quux.__dir__() -> Iterable[str]

--- a/crates/ty_python_semantic/resources/mdtest/annotations/annotated.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/annotated.md
@@ -83,12 +83,12 @@ reveal_mro(C)
 
 class D(Annotated[list[str], "foo"]): ...
 
-# revealed: (<class 'D'>, <class 'list[str]'>, <class 'MutableSequence[str]'>, <class 'Sequence[str]'>, <class 'Reversible[str]'>, <class 'Collection[str]'>, <class 'Iterable[str]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
+# revealed: (<class 'D'>, <class 'list[str]'>, <class 'MutableSequence[str]'>, <class 'Sequence[str]'>, <class 'Reversible[str]'>, <class 'Collection[str]'>, <class 'Iterable[str]'>, <class 'Container[str]'>, typing.Protocol, typing.Generic, <class 'object'>)
 reveal_mro(D)
 
 class E(Annotated[list["E"], "metadata"]): ...
 
-# error: [revealed-type] "Revealed MRO: (<class 'E'>, <class 'list[E]'>, <class 'MutableSequence[E]'>, <class 'Sequence[E]'>, <class 'Reversible[E]'>, <class 'Collection[E]'>, <class 'Iterable[E]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)"
+# error: [revealed-type] "Revealed MRO: (<class 'E'>, <class 'list[E]'>, <class 'MutableSequence[E]'>, <class 'Sequence[E]'>, <class 'Reversible[E]'>, <class 'Collection[E]'>, <class 'Iterable[E]'>, <class 'Container[E]'>, typing.Protocol, typing.Generic, <class 'object'>)"
 reveal_mro(E)
 
 class F(Annotated[Any, "metadata"]): ...

--- a/crates/ty_python_semantic/resources/mdtest/annotations/stdlib_typing_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/stdlib_typing_aliases.md
@@ -122,22 +122,22 @@ from ty_extensions._internal import reveal_mro
 
 class ListSubclass(typing.List): ...
 
-# revealed: (<class 'ListSubclass'>, <class 'list[Unknown]'>, <class 'MutableSequence[Unknown]'>, <class 'Sequence[Unknown]'>, <class 'Reversible[Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
+# revealed: (<class 'ListSubclass'>, <class 'list[Unknown]'>, <class 'MutableSequence[Unknown]'>, <class 'Sequence[Unknown]'>, <class 'Reversible[Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Unknown]'>, typing.Protocol, typing.Generic, <class 'object'>)
 reveal_mro(ListSubclass)
 
 class DictSubclass(typing.Dict): ...
 
-# revealed: (<class 'DictSubclass'>, <class 'dict[Unknown, Unknown]'>, <class 'MutableMapping[Unknown, Unknown]'>, <class 'Mapping[Unknown, Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
+# revealed: (<class 'DictSubclass'>, <class 'dict[Unknown, Unknown]'>, <class 'MutableMapping[Unknown, Unknown]'>, <class 'Mapping[Unknown, Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Unknown]'>, typing.Protocol, typing.Generic, <class 'object'>)
 reveal_mro(DictSubclass)
 
 class SetSubclass(typing.Set): ...
 
-# revealed: (<class 'SetSubclass'>, <class 'set[Unknown]'>, <class 'MutableSet[Unknown]'>, <class 'AbstractSet[Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
+# revealed: (<class 'SetSubclass'>, <class 'set[Unknown]'>, <class 'MutableSet[Unknown]'>, <class 'AbstractSet[Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Unknown]'>, typing.Protocol, typing.Generic, <class 'object'>)
 reveal_mro(SetSubclass)
 
 class FrozenSetSubclass(typing.FrozenSet): ...
 
-# revealed: (<class 'FrozenSetSubclass'>, <class 'frozenset[Unknown]'>, <class 'AbstractSet[Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
+# revealed: (<class 'FrozenSetSubclass'>, <class 'frozenset[Unknown]'>, <class 'AbstractSet[Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Unknown]'>, typing.Protocol, typing.Generic, <class 'object'>)
 reveal_mro(FrozenSetSubclass)
 
 ####################
@@ -146,26 +146,26 @@ reveal_mro(FrozenSetSubclass)
 
 class ChainMapSubclass(typing.ChainMap): ...
 
-# revealed: (<class 'ChainMapSubclass'>, <class 'ChainMap[Unknown, Unknown]'>, <class 'MutableMapping[Unknown, Unknown]'>, <class 'Mapping[Unknown, Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
+# revealed: (<class 'ChainMapSubclass'>, <class 'ChainMap[Unknown, Unknown]'>, <class 'MutableMapping[Unknown, Unknown]'>, <class 'Mapping[Unknown, Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Unknown]'>, typing.Protocol, typing.Generic, <class 'object'>)
 reveal_mro(ChainMapSubclass)
 
 class CounterSubclass(typing.Counter): ...
 
-# revealed: (<class 'CounterSubclass'>, <class 'Counter[Unknown]'>, <class 'dict[Unknown, int]'>, <class 'MutableMapping[Unknown, int]'>, <class 'Mapping[Unknown, int]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
+# revealed: (<class 'CounterSubclass'>, <class 'Counter[Unknown]'>, <class 'dict[Unknown, int]'>, <class 'MutableMapping[Unknown, int]'>, <class 'Mapping[Unknown, int]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Unknown]'>, typing.Protocol, typing.Generic, <class 'object'>)
 reveal_mro(CounterSubclass)
 
 class DefaultDictSubclass(typing.DefaultDict): ...
 
-# revealed: (<class 'DefaultDictSubclass'>, <class 'defaultdict[Unknown, Unknown]'>, <class 'dict[Unknown, Unknown]'>, <class 'MutableMapping[Unknown, Unknown]'>, <class 'Mapping[Unknown, Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
+# revealed: (<class 'DefaultDictSubclass'>, <class 'defaultdict[Unknown, Unknown]'>, <class 'dict[Unknown, Unknown]'>, <class 'MutableMapping[Unknown, Unknown]'>, <class 'Mapping[Unknown, Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Unknown]'>, typing.Protocol, typing.Generic, <class 'object'>)
 reveal_mro(DefaultDictSubclass)
 
 class DequeSubclass(typing.Deque): ...
 
-# revealed: (<class 'DequeSubclass'>, <class 'deque[Unknown]'>, <class 'MutableSequence[Unknown]'>, <class 'Sequence[Unknown]'>, <class 'Reversible[Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
+# revealed: (<class 'DequeSubclass'>, <class 'deque[Unknown]'>, <class 'MutableSequence[Unknown]'>, <class 'Sequence[Unknown]'>, <class 'Reversible[Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Unknown]'>, typing.Protocol, typing.Generic, <class 'object'>)
 reveal_mro(DequeSubclass)
 
 class OrderedDictSubclass(typing.OrderedDict): ...
 
-# revealed: (<class 'OrderedDictSubclass'>, <class 'OrderedDict[Unknown, Unknown]'>, <class 'dict[Unknown, Unknown]'>, <class 'MutableMapping[Unknown, Unknown]'>, <class 'Mapping[Unknown, Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
+# revealed: (<class 'OrderedDictSubclass'>, <class 'OrderedDict[Unknown, Unknown]'>, <class 'dict[Unknown, Unknown]'>, <class 'MutableMapping[Unknown, Unknown]'>, <class 'Mapping[Unknown, Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Unknown]'>, typing.Protocol, typing.Generic, <class 'object'>)
 reveal_mro(OrderedDictSubclass)
 ```

--- a/crates/ty_python_semantic/resources/mdtest/basedpython_overlapping.md
+++ b/crates/ty_python_semantic/resources/mdtest/basedpython_overlapping.md
@@ -1,0 +1,160 @@
+# basedpython: `Overlapping` — overlap-checked input on a covariant typevar
+
+`ty_extensions.Overlapping[Key]` is a "safe variance" escape hatch for input positions. It lets a
+covariant class take a `Key` argument without giving up covariance:
+
+- at the call site, an argument is accepted iff it is *not disjoint from* `Key` (its type overlaps
+    `Key`). so a provably-unrelated argument is rejected, but a could-be-a-`Key` argument is allowed
+- inside the body, the parameter is seen as `Key`'s upper bound, so the consumed value can never be
+    written back into `Key`-typed covariant storage
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+## the `__contains__` use case
+
+```py
+from ty_extensions import Overlapping
+
+class Mapping[Key, Value]:
+    def __contains__(self, key: Overlapping[Key]) -> bool:
+        reveal_type(key)  # revealed: object
+        return True
+
+def f(m: Mapping[int, object]):
+    1 in m  # ok — `int` overlaps `int`
+    object() in m  # ok — `object` overlaps `int` (it could be an `int`)
+    # error: [unsupported-operator]
+    "a" in m  # `str` is disjoint from `int`
+```
+
+## a direct method call is checked the same way
+
+```py
+from ty_extensions import Overlapping
+
+class Mapping[Key, Value]:
+    def __contains__(self, key: Overlapping[Key]) -> bool:
+        return True
+
+def f(m: Mapping[int, object]):
+    m.__contains__(1)  # ok
+    m.__contains__(object())  # ok
+    # error: [invalid-argument-type]
+    m.__contains__("a")
+```
+
+## the body is erased to the bound
+
+```py
+from ty_extensions import Overlapping
+
+class Box[Key]:
+    def consume(self, key: Overlapping[Key]) -> None:
+        reveal_type(key)  # revealed: object
+```
+
+## a bounded typevar is erased to its bound
+
+```py
+from ty_extensions import Overlapping
+
+class Box[Key: int]:
+    def consume(self, key: Overlapping[Key]) -> None:
+        reveal_type(key)  # revealed: int
+
+def f(b: Box[int]):
+    b.consume(1)  # ok — `int` overlaps `int`
+    b.consume(True)  # ok — `bool` overlaps `int`
+    # error: [invalid-argument-type]
+    b.consume("a")
+```
+
+## overlap is exact: a sibling literal is disjoint
+
+`Literal[1]` is not a `bool` (its only inhabitant is the int `1`), so it is disjoint from `bool` and
+rejected for a `Box[bool]`:
+
+```py
+from ty_extensions import Overlapping
+
+class Box[Key]:
+    def consume(self, key: Overlapping[Key]) -> None: ...
+
+def f(b: Box[bool]):
+    b.consume(True)  # ok
+    # error: [invalid-argument-type]
+    b.consume(1)
+```
+
+## `Any` always overlaps
+
+```py
+from ty_extensions import Overlapping
+from typing import Any
+
+class Mapping[Key, Value]:
+    def __contains__(self, key: Overlapping[Key]) -> bool:
+        return True
+
+def f(m: Mapping[int, object], a: Any):
+    a in m  # ok — `Any` overlaps everything
+```
+
+## stdlib `dict` lookup uses it too
+
+`dict.__getitem__` and `dict.get` consume the covariant key as `Overlapping[Key]`, so a lookup with
+a provably-unrelated key is rejected, consistent with the membership check:
+
+```py
+def f(d: dict[int, str]):
+    reveal_type(d[1])  # revealed: str
+    d[object()]  # ok — object overlaps int
+    # error: [invalid-argument-type]
+    d["a"]
+    d.get(1)  # ok
+    # error: [invalid-argument-type]
+    d.get("a")
+```
+
+A subclass may still override with the bare key type (or its upper bound) — the `Overlapping[Key]`
+base relates as `Key`, so the override stays compatible:
+
+```py
+class MyDict[Key, Value](dict[Key, Value]):
+    def __getitem__(self, key: Key) -> Value:  # ok — compatible override
+        raise NotImplementedError
+```
+
+## the stdlib `Mapping.__contains__` uses it
+
+basedpython's typeshed types `typing.Mapping.__contains__` as `Overlapping[Key]`, so a membership
+test against a `Mapping[int, ...]` rejects a provably-unrelated key:
+
+```py
+from typing import Mapping
+
+def f(m: Mapping[int, object]):
+    1 in m  # ok
+    object() in m  # ok
+    # error: [unsupported-operator]
+    "a" in m
+```
+
+## unions overlap if any member does
+
+```py
+from ty_extensions import Overlapping
+
+class Mapping[Key, Value]:
+    def __contains__(self, key: Overlapping[Key]) -> bool:
+        return True
+
+def f(m: Mapping[int | str, object]):
+    1 in m  # ok
+    "a" in m  # ok
+    # error: [unsupported-operator]
+    b"x" in m  # `bytes` is disjoint from `int | str`
+```

--- a/crates/ty_python_semantic/resources/mdtest/call/type.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/type.md
@@ -1338,7 +1338,7 @@ class Point(NamedTuple):
 Point3D = type("Point3D", (Point,), {})
 reveal_type(Point3D)  # revealed: <class 'Point3D'>
 # fmt: off
-reveal_mro(Point3D)  # revealed: (<class 'Point3D'>, <class 'Point'>, <class 'tuple[int, int]'>, <class 'Sequence[int]'>, <class 'Reversible[int]'>, <class 'Collection[int]'>, <class 'Iterable[int]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
+reveal_mro(Point3D)  # revealed: (<class 'Point3D'>, <class 'Point'>, <class 'tuple[int, int]'>, <class 'Sequence[int]'>, <class 'Reversible[int]'>, <class 'Collection[int]'>, <class 'Iterable[int]'>, <class 'Container[int]'>, typing.Protocol, typing.Generic, <class 'object'>)
 # fmt: on
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/comparison/unions.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/unions.md
@@ -34,7 +34,7 @@ def _(
     reveal_type(one_or_two != 3)  # revealed: Literal[True]
     reveal_type(one_or_two != 1)  # revealed: bool
 
-    reveal_type(a_or_ab in "ab")  # revealed: Literal[True]
+    reveal_type(a_or_ab in "ab")  # revealed: bool
     reveal_type("a" in a_or_ab)  # revealed: Literal[True]
 
     reveal_type("c" not in a_or_ab)  # revealed: Literal[True]
@@ -110,7 +110,6 @@ error[unsupported-operator]: Unsupported `in` operation
    |               |
    |               Both operands have type `list[int] | Literal[1]`
    |
-info: Operation fails because operator `in` is not supported between objects of type `list[int]` and `Literal[1]`
 ```
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/external/numpy.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/numpy.md
@@ -15,8 +15,7 @@ dependencies = ["numpy==2.3.0"]
 import numpy as np
 
 xs = np.array([1, 2, 3])
-# TODO: should be `ndarray[tuple[Any, ...], dtype[Any]]`
-reveal_type(xs)  # revealed: ndarray[tuple[Any, ...], dtype[Unknown]]
+reveal_type(xs)  # revealed: ndarray[tuple[Any, ...], dtype[Any]]
 
 xs = np.array([1.0, 2.0, 3.0], dtype=np.float64)
 # TODO: should be `ndarray[tuple[Any, ...], dtype[float64]]`

--- a/crates/ty_python_semantic/resources/mdtest/named_tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/named_tuple.md
@@ -26,7 +26,7 @@ reveal_type(alice.id)  # revealed: int
 reveal_type(alice.name)  # revealed: str
 reveal_type(alice.age)  # revealed: int | None
 
-# revealed: (<class 'Person'>, <class 'tuple[int, str, int | None]'>, <class 'Sequence[int | str | None]'>, <class 'Reversible[int | str | None]'>, <class 'Collection[int | str | None]'>, <class 'Iterable[int | str | None]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
+# revealed: (<class 'Person'>, <class 'tuple[int, str, int | None]'>, <class 'Sequence[int | str | None]'>, <class 'Reversible[int | str | None]'>, <class 'Collection[int | str | None]'>, <class 'Iterable[int | str | None]'>, <class 'Container[int | str | None]'>, typing.Protocol, typing.Generic, <class 'object'>)
 reveal_mro(Person)
 
 static_assert(is_subtype_of(Person, tuple[int, str, int | None]))
@@ -268,7 +268,7 @@ from ty_extensions._internal import reveal_mro
 class A(NamedTuple("B", [("x", NamedTuple("C", [("x", "A | None")]))])):
     pass
 
-# revealed: (<class 'A'>, <class 'B'>, <class 'tuple[Unknown]'>, <class 'Sequence[Unknown]'>, <class 'Reversible[Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
+# revealed: (<class 'A'>, <class 'B'>, <class 'tuple[Unknown]'>, <class 'Sequence[Unknown]'>, <class 'Reversible[Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Unknown]'>, typing.Protocol, typing.Generic, <class 'object'>)
 reveal_mro(A)
 ```
 
@@ -321,7 +321,7 @@ container = Container([1, 2, 3], {"a": True})
 reveal_type(container.items)  # revealed: Any
 reveal_type(container.mapping)  # revealed: Any
 
-# revealed: (<class 'Url'>, <class 'tuple[Unknown, ...]'>, <class 'Sequence[Unknown]'>, <class 'Reversible[Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
+# revealed: (<class 'Url'>, <class 'tuple[Unknown, ...]'>, <class 'Sequence[Unknown]'>, <class 'Reversible[Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Unknown]'>, typing.Protocol, typing.Generic, <class 'object'>)
 reveal_mro(Url)
 
 invalid_fields = (("x", 42),)  # 42 is not a valid type
@@ -389,7 +389,7 @@ NT = NamedTuple("NT", fields)
 
 # Fields are unknown, so attribute access returns Any and MRO has Unknown tuple.
 reveal_type(NT)  # revealed: <class 'NT'>
-# revealed: (<class 'NT'>, <class 'tuple[Unknown, ...]'>, <class 'Sequence[Unknown]'>, <class 'Reversible[Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
+# revealed: (<class 'NT'>, <class 'tuple[Unknown, ...]'>, <class 'Sequence[Unknown]'>, <class 'Reversible[Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Unknown]'>, typing.Protocol, typing.Generic, <class 'object'>)
 reveal_mro(NT)
 reveal_type(NT(1, "a").x)  # revealed: Any
 ```
@@ -408,7 +408,7 @@ NT = collections.namedtuple("NT", field_names)
 
 # Fields are unknown, so attribute access returns Any and MRO has Unknown tuple.
 reveal_type(NT)  # revealed: <class 'NT'>
-# revealed: (<class 'NT'>, <class 'tuple[Unknown, ...]'>, <class 'Sequence[Unknown]'>, <class 'Reversible[Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
+# revealed: (<class 'NT'>, <class 'tuple[Unknown, ...]'>, <class 'Sequence[Unknown]'>, <class 'Reversible[Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Unknown]'>, typing.Protocol, typing.Generic, <class 'object'>)
 reveal_mro(NT)
 reveal_type(NT(1, 2).x)  # revealed: Any
 ```
@@ -426,7 +426,7 @@ class Url(NamedTuple("Url", [("host", str), ("path", str)])):
     pass
 
 reveal_type(Url)  # revealed: <class 'Url'>
-# revealed: (<class 'mdtest_snippet.Url @ src/mdtest_snippet.py:4:7'>, <class 'mdtest_snippet.Url @ src/mdtest_snippet.py:4:11'>, <class 'tuple[str, str]'>, <class 'Sequence[str]'>, <class 'Reversible[str]'>, <class 'Collection[str]'>, <class 'Iterable[str]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
+# revealed: (<class 'mdtest_snippet.Url @ src/mdtest_snippet.py:4:7'>, <class 'mdtest_snippet.Url @ src/mdtest_snippet.py:4:11'>, <class 'tuple[str, str]'>, <class 'Sequence[str]'>, <class 'Reversible[str]'>, <class 'Collection[str]'>, <class 'Iterable[str]'>, <class 'Container[str]'>, typing.Protocol, typing.Generic, <class 'object'>)
 reveal_mro(Url)
 reveal_type(Url.__new__)  # revealed: [Self](_cls: type[Self], host: str, path: str) -> Self
 
@@ -536,7 +536,7 @@ reveal_type(config)  # revealed: GroundTruth
 reveal_type(config.duration)  # revealed: Any
 
 # Namedtuples with unknown fields inherit from tuple[Unknown, ...] to avoid false positives.
-# revealed: (<class 'GroundTruth'>, <class 'tuple[Unknown, ...]'>, <class 'Sequence[Unknown]'>, <class 'Reversible[Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
+# revealed: (<class 'GroundTruth'>, <class 'tuple[Unknown, ...]'>, <class 'Sequence[Unknown]'>, <class 'Reversible[Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Unknown]'>, typing.Protocol, typing.Generic, <class 'object'>)
 reveal_mro(GroundTruth)
 
 # No index-out-of-bounds error since the tuple length is unknown.

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -28,6 +28,7 @@ def _(x: Literal[1, 2, "a", "b", False, b"abc"]):
         reveal_type(x)  # revealed: Literal[2, "a"]
     elif x in (b"abc",):
         reveal_type(x)  # revealed: Literal[b"abc"]
+    # error: [unsupported-operator]
     elif x not in (3,):
         reveal_type(x)  # revealed: Literal["b", False]
     else:
@@ -773,6 +774,7 @@ def mixed_constraints(
     value: Token | Literal[1],
     values: MixedContainers,
 ) -> None:
+    # error: [unsupported-operator]
     if value in values:
         reveal_type(value)  # revealed: Token | Literal[1]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/subscript/tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/subscript/tuple.md
@@ -131,7 +131,7 @@ reveal_type(os.stat("my_file.txt"))  # revealed: stat_result
 reveal_type(os.stat("my_file.txt")[stat.ST_MODE])  # revealed: int
 reveal_type(os.stat("my_file.txt")[stat.ST_ATIME])  # revealed: int | float
 
-# revealed: (<class 'stat_result'>, <class 'structseq[int | float]'>, <class 'tuple[int, int, int, int, int, int, int, int | float, int | float, int | float]'>, <class 'Sequence[int | float]'>, <class 'Reversible[int | float]'>, <class 'Collection[int | float]'>, <class 'Iterable[int | float]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
+# revealed: (<class 'stat_result'>, <class 'structseq[int | float]'>, <class 'tuple[int, int, int, int, int, int, int, int | float, int | float, int | float]'>, <class 'Sequence[int | float]'>, <class 'Reversible[int | float]'>, <class 'Collection[int | float]'>, <class 'Iterable[int | float]'>, <class 'Container[int | float]'>, typing.Protocol, typing.Generic, <class 'object'>)
 reveal_mro(os.stat_result)
 
 # There are no specific overloads for the `float` elements in `os.stat_result`,
@@ -438,12 +438,12 @@ from ty_extensions._internal import reveal_mro
 
 class A(tuple[int, str]): ...
 
-# revealed: (<class 'A'>, <class 'tuple[int, str]'>, <class 'Sequence[int | str]'>, <class 'Reversible[int | str]'>, <class 'Collection[int | str]'>, <class 'Iterable[int | str]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
+# revealed: (<class 'A'>, <class 'tuple[int, str]'>, <class 'Sequence[int | str]'>, <class 'Reversible[int | str]'>, <class 'Collection[int | str]'>, <class 'Iterable[int | str]'>, <class 'Container[int | str]'>, typing.Protocol, typing.Generic, <class 'object'>)
 reveal_mro(A)
 
 class C(tuple): ...  # error: [missing-type-argument]
 
-# revealed: (<class 'C'>, <class 'tuple[Unknown, ...]'>, <class 'Sequence[Unknown]'>, <class 'Reversible[Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
+# revealed: (<class 'C'>, <class 'tuple[Unknown, ...]'>, <class 'Sequence[Unknown]'>, <class 'Reversible[Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Unknown]'>, typing.Protocol, typing.Generic, <class 'object'>)
 reveal_mro(C)
 ```
 
@@ -480,12 +480,12 @@ from ty_extensions._internal import reveal_mro
 
 class A(Tuple[int, str]): ...
 
-# revealed: (<class 'A'>, <class 'tuple[int, str]'>, <class 'Sequence[int | str]'>, <class 'Reversible[int | str]'>, <class 'Collection[int | str]'>, <class 'Iterable[int | str]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
+# revealed: (<class 'A'>, <class 'tuple[int, str]'>, <class 'Sequence[int | str]'>, <class 'Reversible[int | str]'>, <class 'Collection[int | str]'>, <class 'Iterable[int | str]'>, <class 'Container[int | str]'>, typing.Protocol, typing.Generic, <class 'object'>)
 reveal_mro(A)
 
 class C(Tuple): ...
 
-# revealed: (<class 'C'>, <class 'tuple[Unknown, ...]'>, <class 'Sequence[Unknown]'>, <class 'Reversible[Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
+# revealed: (<class 'C'>, <class 'tuple[Unknown, ...]'>, <class 'Sequence[Unknown]'>, <class 'Reversible[Unknown]'>, <class 'Collection[Unknown]'>, <class 'Iterable[Unknown]'>, <class 'Container[Unknown]'>, typing.Protocol, typing.Generic, <class 'object'>)
 reveal_mro(C)
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -5098,6 +5098,7 @@ static_assert(is_assignable_to(FooBar, Foo))
 static_assert(is_assignable_to(FooBar, Bar))
 
 def dictionary_union(u: Foo | dict[Literal["a", "b"], int]):
+    # error: [unsupported-operator]
     if "c" in u:
         # TODO: This should stop erroring if we prove that the `dict` arm cannot contain `"c"`.
         # error: [invalid-argument-type]

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -86,6 +86,7 @@ pub use crate::types::method::{BoundMethodType, KnownBoundMethodType, WrapperDes
 use crate::types::mro::{MroIterator, StaticMroError};
 pub(crate) use crate::types::narrow::{NarrowingConstraint, infer_narrowing_constraints};
 use crate::types::newtype::NewType;
+pub use crate::types::overlapping::OverlappingType;
 use crate::types::signatures::{ConcatenateTail, walk_signature};
 pub(crate) use crate::types::signatures::{Parameter, Parameters};
 use crate::types::special_form::TypeQualifier;
@@ -149,6 +150,7 @@ mod method;
 mod mro;
 pub(crate) mod narrow;
 mod newtype;
+mod overlapping;
 mod overrides;
 mod protocol_class;
 pub(crate) mod reified_infer;
@@ -998,6 +1000,11 @@ pub enum Type<'db> {
     TypeGuard(TypeGuardType<'db>),
     /// The set of type-form objects that represent a type assignable to the argument.
     TypeForm(TypeFormType<'db>),
+    /// `ty_extensions.Overlapping[Key]`: a parameter-only marker whose argument is
+    /// accepted iff it is not disjoint from `Key`. Only meaningful as a parameter
+    /// annotation; inside a body it is erased to `Key`'s upper bound (see
+    /// [`OverlappingType`]).
+    Overlapping(OverlappingType<'db>),
     /// A type that represents an inhabitant of a `TypedDict`.
     TypedDict(TypedDictType<'db>),
     /// An aliased type (lazily not-yet-unpacked to its value type).
@@ -1904,6 +1911,7 @@ impl<'db> Type<'db> {
         // `IntersectionBuilder::new(db).add_negative(*self).build()` via the
         // property test `all_negated_types_identical_to_intersection_with_single_negated_element`
         match self {
+            Type::Overlapping(overlapping) => overlapping.value_type(db).negate(db),
             Type::Never => Type::object(),
 
             Type::Dynamic(_) => *self,
@@ -1961,6 +1969,7 @@ impl<'db> Type<'db> {
     /// in user annotations without nonstandard extensions to the type system
     pub(crate) fn is_spellable(&self, db: &'db dyn Db) -> bool {
         match self {
+            Type::Overlapping(overlapping) => overlapping.value_type(db).is_spellable(db),
             Type::LiteralValue(_)
             | Type::Never
             | Type::NewTypeInstance(_)
@@ -2007,6 +2016,7 @@ impl<'db> Type<'db> {
     /// in a "Did you mean...?" hint message in diagnostics
     fn is_hintable(&self, db: &'db dyn Db) -> bool {
         match self {
+            Type::Overlapping(overlapping) => overlapping.value_type(db).is_hintable(db),
             Type::NominalInstance(_)
             | Type::NewTypeInstance(_)
             | Type::LiteralValue(_)
@@ -2286,6 +2296,10 @@ impl<'db> Type<'db> {
                 .type_argument(db)
                 .recursive_type_normalized_impl(db, div, true)
                 .map(|ty| TypeFormType::from_type_expression(db, ty)),
+            Type::Overlapping(overlapping) => overlapping
+                .type_argument(db)
+                .recursive_type_normalized_impl(db, div, true)
+                .map(|ty| OverlappingType::from_type_expression(db, ty)),
             Type::Divergent(_) => Some(self),
             Type::Dynamic(dynamic) => Some(Type::Dynamic(dynamic.recursive_type_normalized())),
             Type::TypedDict(_) => {
@@ -2395,6 +2409,7 @@ impl<'db> Type<'db> {
     /// for more complicated types that are actually singletons.
     pub(crate) fn is_singleton(self, db: &'db dyn Db) -> bool {
         match self {
+            Type::Overlapping(overlapping) => overlapping.value_type(db).is_singleton(db),
             Type::Dynamic(_) | Type::Divergent(_) | Type::Never => false,
 
             Type::LiteralValue(literal) => match literal.kind() {
@@ -2516,6 +2531,7 @@ impl<'db> Type<'db> {
     /// Return true if this type is non-empty and all inhabitants of this type compare equal.
     pub(crate) fn is_single_valued(self, db: &'db dyn Db) -> bool {
         match self {
+            Type::Overlapping(overlapping) => overlapping.value_type(db).is_single_valued(db),
             // All empty ranges compare equal, but non-empty ranges can contain different values.
             Type::KnownInstance(KnownInstanceType::Range { is_non_empty }) => !is_non_empty,
 
@@ -2633,6 +2649,9 @@ impl<'db> Type<'db> {
         }
 
         match self {
+            Type::Overlapping(overlapping) => overlapping
+                .value_type(db)
+                .find_name_in_mro_with_policy(db, name, policy),
             Type::Union(union) => Some(union.map_with_boundness_and_qualifiers(db, |elem| {
                 elem.find_name_in_mro_with_policy(db, name, policy)
                     // If some elements are classes, and some are not, we simply fall back to `Unbound` for the non-class
@@ -3131,6 +3150,7 @@ impl<'db> Type<'db> {
     /// ```
     fn instance_member(&self, db: &'db dyn Db, name: &str) -> PlaceAndQualifiers<'db> {
         match self {
+            Type::Overlapping(overlapping) => overlapping.value_type(db).instance_member(db, name),
             Type::Union(union) => {
                 union.map_with_boundness_and_qualifiers(db, |elem| elem.instance_member(db, name))
             }
@@ -3884,6 +3904,9 @@ impl<'db> Type<'db> {
             let name_str = name.as_str();
 
             match this {
+                Type::Overlapping(overlapping) => overlapping
+                    .value_type(db)
+                    .member_lookup_with_policy_and_receiver(db, name_str.into(), policy, receiver),
                 Type::Union(union) => union.map_with_boundness_and_qualifiers(db, |elem| {
                     elem.member_lookup_with_policy_and_receiver(
                         db,
@@ -4590,6 +4613,7 @@ impl<'db> Type<'db> {
         }
 
         match self {
+            Type::Overlapping(overlapping) => overlapping.value_type(db).bindings(db),
             Type::Callable(callable) => {
                 CallableBinding::from_overloads(self, callable.signatures(db).iter().cloned())
                     .into()
@@ -5961,6 +5985,7 @@ impl<'db> Type<'db> {
     #[must_use]
     pub(crate) fn to_instance(self, db: &'db dyn Db) -> Option<Type<'db>> {
         match self {
+            Type::Overlapping(overlapping) => overlapping.value_type(db).to_instance(db),
             Type::Dynamic(_) | Type::Divergent(_) | Type::Never => Some(self),
             Type::ClassLiteral(class) => Some(Type::instance(db, class.default_specialization(db))),
             Type::GenericAlias(alias) => Some(Type::instance(db, ClassType::from(alias))),
@@ -6029,6 +6054,12 @@ impl<'db> Type<'db> {
         inference_flags: InferenceFlags,
     ) -> Result<Type<'db>, InvalidTypeExpressionError<'db>> {
         match self {
+            Type::Overlapping(overlapping) => overlapping.value_type(db).in_type_expression(
+                db,
+                scope_id,
+                typevar_binding_context,
+                inference_flags,
+            ),
             // Special cases for `float` and `complex`
             // https://typing.python.org/en/latest/spec/special-types.html#special-cases-for-float-and-complex
             //
@@ -6294,6 +6325,7 @@ impl<'db> Type<'db> {
     #[must_use]
     pub(crate) fn to_meta_type(self, db: &'db dyn Db) -> Type<'db> {
         match self {
+            Type::Overlapping(overlapping) => overlapping.value_type(db).to_meta_type(db),
             Type::Never => Type::Never,
             Type::NominalInstance(instance) => instance.to_meta_type(db),
             Type::KnownInstance(known_instance) => known_instance.to_meta_type(db),
@@ -6722,6 +6754,15 @@ impl<'db> Type<'db> {
                 )
             }),
 
+            Type::Overlapping(overlapping) => visitor.visit(db, self, type_mapping, || {
+                OverlappingType::from_type_expression(
+                    db,
+                    overlapping
+                        .type_argument(db)
+                        .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                )
+            }),
+
             Type::TypeForm(typeform) => visitor.visit(db, self, type_mapping, || {
                 TypeFormType::from_type_expression(
                     db,
@@ -7034,6 +7075,15 @@ impl<'db> Type<'db> {
                 );
             }
 
+            Type::Overlapping(overlapping) => {
+                overlapping.type_argument(db).find_legacy_typevars_impl(
+                    db,
+                    binding_context,
+                    typevars,
+                    visitor,
+                );
+            }
+
             Type::TypeAlias(alias) => {
                 visitor.visit(self, || {
                     alias.value_type(db).find_legacy_typevars_impl(
@@ -7249,6 +7299,7 @@ impl<'db> Type<'db> {
     /// their only alternative, since there is no ambiguity to preserve there.
     pub fn definition(&self, db: &'db dyn Db) -> Option<TypeDefinition<'db>> {
         match self {
+            Self::Overlapping(overlapping) => overlapping.value_type(db).definition(db),
             Self::BoundMethod(method) => {
                 Some(TypeDefinition::Function(method.function(db).definition(db)))
             }
@@ -7707,6 +7758,7 @@ impl<'db> VarianceInferable<'db> for Type<'db> {
             Type::TypeIs(type_is_type) => type_is_type.variance_of(db, typevar),
             Type::TypeGuard(type_guard_type) => type_guard_type.variance_of(db, typevar),
             Type::TypeForm(typeform_type) => typeform_type.variance_of(db, typevar),
+            Type::Overlapping(overlapping_type) => overlapping_type.variance_of(db, typevar),
             Type::KnownInstance(known_instance) => known_instance.variance_of(db, typevar),
             Type::TypeAlias(alias) => alias.variance_of(db, typevar),
             Type::Dynamic(_)

--- a/crates/ty_python_semantic/src/types/attribute_write.rs
+++ b/crates/ty_python_semantic/src/types/attribute_write.rs
@@ -154,6 +154,10 @@ pub(super) fn attribute_write_requirement<'db>(
     attribute: &str,
 ) -> AttributeWriteRequirement<'db> {
     match object_ty {
+        // parameter-only marker; behaves as the type a body sees (bound of `Key`)
+        Type::Overlapping(overlapping) => {
+            attribute_write_requirement(db, overlapping.value_type(db), attribute)
+        }
         Type::Union(union) => AttributeWriteRequirement::All {
             object_ty,
             element_tys: union.elements(db),
@@ -548,6 +552,7 @@ pub(super) fn assignment_attribute_members<'db>(
             | Type::TypeIs(_)
             | Type::TypeGuard(_)
             | Type::TypeForm(_)
+            | Type::Overlapping(_)
             | Type::TypedDict(_)
             | Type::NewTypeInstance(_) => object_ty.instance_member(db, attribute),
             Type::ClassLiteral(..) | Type::GenericAlias(..) | Type::SubclassOf(..) => {

--- a/crates/ty_python_semantic/src/types/bool.rs
+++ b/crates/ty_python_semantic/src/types/bool.rs
@@ -214,7 +214,9 @@ impl<'db> Type<'db> {
             | Type::Callable(_)
             | Type::TypeIs(_)
             | Type::TypeGuard(_)
-            | Type::TypeForm(_) => Truthiness::Ambiguous,
+            | Type::TypeForm(_)
+            // parameter-only marker; a value never actually has this type
+            | Type::Overlapping(_) => Truthiness::Ambiguous,
 
             Type::TypedDict(td) => {
                 if td.items(db).values().any(TypedDictField::is_required) {

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -744,6 +744,9 @@ impl<'db> BoundSuperType<'db> {
             Type::TypeAlias(alias) => {
                 return delegate_to(alias.value_type(db));
             }
+            Type::Overlapping(overlapping) => {
+                return delegate_to(overlapping.value_type(db));
+            }
             Type::TypeVar(bound_typevar) => {
                 let typevar = bound_typevar.typevar(db);
                 match typevar.bound_or_constraints(db) {

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5211,12 +5211,34 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         // building them in an earlier separate step.
         //
         // TODO: handle starred annotations, e.g. `*args: *Ts` or `*args: *tuple[int, *tuple[str, ...]]`
-        if !self.constraint_set_errors[argument_index]
-            && !parameter.has_starred_annotation()
-            && argument_type
-                .when_assignable_to(self.db, expected_ty, constraints, self.inferable_typevars)
-                .is_never_satisfied(self.db)
-        {
+        let type_error =
+            if self.constraint_set_errors[argument_index] || parameter.has_starred_annotation() {
+                false
+            } else if let Type::Overlapping(overlapping) = expected_ty {
+                // `Overlapping[Key]` accepts an argument that is assignable to `Key`
+                // (the ordinary check, which still infers typevars in `Key` — so a
+                // generic or `isinstance`-narrowed `dict` keeps working) OR that
+                // merely overlaps `Key` (is not disjoint from it). only a value
+                // that is neither — a provably-impossible key like `"a"` for a
+                // `Mapping[int, ...]` — is rejected. dynamic arguments and dynamic
+                // keys are assignable, so they are always admitted here.
+                //
+                // a `Never` key admits anything: it is not a real key domain but a
+                // materialization artifact (e.g. `isinstance(x, dict)` narrows to
+                // `Top[dict[Unknown, Unknown]]`, whose key projects to `Never`),
+                // where every key must remain admissible
+                let key = overlapping.type_argument(self.db);
+                !key.is_never()
+                    && argument_type
+                        .when_assignable_to(self.db, key, constraints, self.inferable_typevars)
+                        .is_never_satisfied(self.db)
+                    && key.is_disjoint_from(self.db, argument_type)
+            } else {
+                argument_type
+                    .when_assignable_to(self.db, expected_ty, constraints, self.inferable_typevars)
+                    .is_never_satisfied(self.db)
+            };
+        if type_error {
             let positional = matches!(argument, Argument::Positional | Argument::Synthetic)
                 && !parameter.is_variadic();
             self.errors.push(BindingError::InvalidArgumentType {

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -84,6 +84,11 @@ impl<'db> Type<'db> {
         match self {
             Type::Callable(callable) => Some(CallableTypes::one(callable)),
 
+            // parameter-only marker; behaves as the type a body sees (bound of `Key`)
+            Type::Overlapping(overlapping) => overlapping
+                .value_type(db)
+                .try_upcast_to_callable_with_policy_and_context(db, policy, context),
+
             Type::Dynamic(_) => Some(CallableTypes::one(CallableType::function_like(
                 db,
                 Signature::dynamic(self),

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -137,6 +137,10 @@ impl<'db> ClassBase<'db> {
         subclass: Option<ClassLiteral<'db>>,
     ) -> Option<Self> {
         match ty {
+            // parameter-only marker; behaves as the type a body sees (bound of `Key`)
+            Type::Overlapping(overlapping) => {
+                Self::try_from_type(db, overlapping.value_type(db), subclass)
+            }
             Type::Dynamic(dynamic) => Some(Self::Dynamic(dynamic)),
             Type::Divergent(divergent) => Some(Self::Divergent(divergent)),
             Type::ClassLiteral(literal) => Some(Self::Class(literal.default_specialization(db))),
@@ -280,6 +284,7 @@ impl<'db> ClassBase<'db> {
                 | SpecialFormType::TypeAlias
                 | SpecialFormType::Optional
                 | SpecialFormType::Not
+                | SpecialFormType::Overlapping
                 | SpecialFormType::Top
                 | SpecialFormType::Bottom
                 | SpecialFormType::Intersection

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -1460,6 +1460,16 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     .fmt_detailed(f)?;
                 f.write_char(']')
             }
+            Type::Overlapping(overlapping) => {
+                f.with_type(Type::SpecialForm(SpecialFormType::Overlapping))
+                    .write_str("Overlapping")?;
+                f.write_char('[')?;
+                overlapping
+                    .type_argument(self.db)
+                    .display_with(self.db, self.settings.clone())
+                    .fmt_detailed(f)?;
+                f.write_char(']')
+            }
             Type::TypedDict(TypedDictType::Class(defining_class)) => match defining_class {
                 ClassType::NonGeneric(class) => class
                     .display_with(self.db, self.settings.clone())

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1959,6 +1959,10 @@ fn is_instance_truthiness<'db>(
     };
 
     match ty {
+        // parameter-only marker; behaves as the type a body sees (bound of `Key`)
+        Type::Overlapping(overlapping) => {
+            is_instance_truthiness(db, overlapping.value_type(db), class)
+        }
         Type::Union(..) => {
             // We do not handle unions specifically here, because something like `A | SubclassOfA` would
             // have been simplified to `A` anyway

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -18,7 +18,7 @@ use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 use strum::IntoEnumIterator;
-use ty_module_resolver::{ModuleName, resolve_module};
+use ty_module_resolver::{KnownModule, ModuleName, resolve_module};
 use ty_python_core::ast_ids::HasScopedUseId;
 use ty_python_core::statement::StatementInner;
 
@@ -34,7 +34,7 @@ use crate::place::{
     ConsideredDefinitions, DefinedPlace, Definedness, LookupError, Place, PlaceAndQualifiers,
     RequiresExplicitReExport, TypeOrigin, builtins_module_scope, builtins_symbol,
     class_body_implicit_symbol, explicit_global_symbol, is_basedpython_implicit_typing_name,
-    loop_header_reachability, module_type_implicit_global_declaration,
+    known_module_symbol, loop_header_reachability, module_type_implicit_global_declaration,
     module_type_implicit_global_symbol, place_by_id, place_from_bindings_with_reachability_cache,
     place_from_declarations_with_reachability_cache, typing_extensions_symbol, typing_symbol,
 };
@@ -2777,6 +2777,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let db = self.db();
 
         match object_ty {
+            // parameter-only marker; behaves as the type a body sees (bound of `Key`)
+            Type::Overlapping(overlapping) => self.validate_attribute_deletion(
+                target,
+                overlapping.value_type(db),
+                attribute,
+                emit_diagnostics,
+            ),
             Type::Union(union) => {
                 for element_ty in union.elements(db) {
                     if !self.validate_attribute_deletion(
@@ -4874,6 +4881,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             provenance: CallableFunctionProvenance,
         ) -> Option<Type<'d>> {
             match ty {
+                // parameter-only marker; behaves as the type a body sees (bound of `Key`)
+                Type::Overlapping(overlapping) => {
+                    propagate_callable_kind(db, overlapping.value_type(db), kind, provenance)
+                }
                 Type::Callable(callable) => Some(Type::Callable(CallableType::new(
                     db,
                     callable.signatures(db),
@@ -9491,6 +9502,23 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     Place::Undefined.into()
                 }
             })
+            // basedpython only: `Overlapping` is a `ty_extensions` special form
+            // used unqualified in the vendored typeshed (`Container.__contains__`
+            // and friends). resolve the bare name in a type expression so it
+            // doesn't require an import there. gated on type-expression position
+            // so a value-position `Overlapping` stays an ordinary identifier
+            .or_fall_back_to(db, || {
+                if self.is_basedpython_file()
+                    && symbol_name == "Overlapping"
+                    && self
+                        .inference_flags()
+                        .contains(InferenceFlags::IN_TYPE_EXPRESSION)
+                {
+                    known_module_symbol(db, KnownModule::TyExtensions, "Overlapping")
+                } else {
+                    Place::Undefined.into()
+                }
+            })
             // basedpython only: `Some` is the present-case optional constructor.
             // It has no runtime definition in real Python — the transpiler lowers
             // `Some(x)` to the injected `Optional(x)` wrapper — so it's resolved
@@ -10671,6 +10699,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
 
         match (op, operand_type) {
+            // parameter-only marker; behaves as the type a body sees (bound of `Key`)
+            (_, Type::Overlapping(overlapping)) => overlapping.value_type(self.db()),
             (ast::UnaryOp::Invert | ast::UnaryOp::UAdd | ast::UnaryOp::USub, Type::Dynamic(_))
             | (_, Type::Divergent(_)) => operand_type,
             (_, Type::Never) => Type::Never,

--- a/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
@@ -353,6 +353,33 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         }
 
         match (left_ty, right_ty, op) {
+            // parameter-only marker; behaves as the type a body sees (bound of `Key`)
+            (Type::Overlapping(overlapping), _, _) => {
+                visitor.visit((left_ty, op, right_ty), || {
+                    self.infer_binary_expression_type_impl(
+                        node,
+                        emitted_division_by_zero_diagnostic,
+                        overlapping.value_type(db),
+                        right_ty,
+                        op,
+                        visitor,
+                        tcx,
+                    )
+                })
+            }
+            (_, Type::Overlapping(overlapping), _) => {
+                visitor.visit((left_ty, op, right_ty), || {
+                    self.infer_binary_expression_type_impl(
+                        node,
+                        emitted_division_by_zero_diagnostic,
+                        left_ty,
+                        overlapping.value_type(db),
+                        op,
+                        visitor,
+                        tcx,
+                    )
+                })
+            }
             (Type::Union(lhs_union), rhs, _) => lhs_union.try_map(db, |lhs_element| {
                 self.infer_binary_expression_type_impl(
                     node,

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -887,7 +887,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let default_expr = default.as_ref();
         if let Some(annotation) = parameter.annotation.as_ref() {
-            let declared_ty = self.file_expression_type(annotation);
+            // `Overlapping[Key]` is a call-binder-only marker; inside the body the
+            // parameter is seen as `Key`'s upper bound so it can never be written
+            // back into `Key`-typed covariant storage
+            let declared_ty = self.file_expression_type(annotation).erase_overlapping(db);
 
             // P.args and P.kwargs are only valid as annotations on *args and **kwargs,
             // not on regular parameters.

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -25,9 +25,9 @@ use ty_python_core::scope::ScopeKind;
 use crate::types::{
     BindingContext, CallableType, DynamicType, GenericContext, InternedType, IntersectionBuilder,
     IntersectionType, KnownClass, KnownInstanceType, LintDiagnosticGuard, LiteralValueTypeKind,
-    Parameter, Parameters, SpecialFormType, SubclassOfType, Type, TypeAliasType, TypeContext,
-    TypeFormType, TypeGuardType, TypeIsType, TypeMapping, TypeVarKind, UnionBuilder, UnionType,
-    any_over_type, todo_type,
+    OverlappingType, Parameter, Parameters, SpecialFormType, SubclassOfType, Type, TypeAliasType,
+    TypeContext, TypeFormType, TypeGuardType, TypeIsType, TypeMapping, TypeVarKind, UnionBuilder,
+    UnionType, any_over_type, todo_type,
 };
 use crate::{FxOrderSet, Program, add_inferred_python_version_hint_to_diagnostic};
 
@@ -2738,6 +2738,38 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     self.store_expression_type(arguments_slice, ty);
                 }
                 ty
+            }
+            SpecialFormType::Overlapping => {
+                let arguments = if let ast::Expr::Tuple(tuple) = arguments_slice
+                    && !tuple.is_anon_named_tuple
+                {
+                    &*tuple.elts
+                } else {
+                    std::slice::from_ref(arguments_slice)
+                };
+                let num_arguments = arguments.len();
+                let type_argument = if num_arguments == 1 {
+                    self.infer_type_expression(&arguments[0])
+                } else {
+                    if !self.in_string_annotation() {
+                        for argument in arguments {
+                            self.infer_expression(argument, TypeContext::default());
+                        }
+                    }
+                    report_invalid_argument_number_to_special_form(
+                        &self.context,
+                        subscript,
+                        special_form,
+                        num_arguments,
+                        1,
+                    );
+                    Type::unknown()
+                };
+                let overlapping = OverlappingType::from_type_expression(db, type_argument);
+                if arguments_slice.is_tuple_expr() {
+                    self.store_expression_type(arguments_slice, overlapping);
+                }
+                overlapping
             }
             SpecialFormType::Top => {
                 let arguments = if let ast::Expr::Tuple(tuple) = arguments_slice

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -198,6 +198,27 @@ pub(super) fn infer_binary_type_comparison<'db>(
             visitor,
         )),
 
+        // A membership test checks overlap against the *whole* left type: a union
+        // that only partially overlaps the container's element type still
+        // overlaps it, so it must not be split into per-member `__contains__`
+        // calls (which would reject a member that is disjoint from the element,
+        // e.g. `"a"` in `x: Literal[1, "a"]` tested against a `tuple[Literal[1]]`)
+        (Type::Union(_), other)
+            if matches!(op, ast::CmpOp::In | ast::CmpOp::NotIn) =>
+        {
+            let membership_op = match op {
+                ast::CmpOp::NotIn => MembershipTestCompareOperator::NotIn,
+                _ => MembershipTestCompareOperator::In,
+            };
+            Some(infer_membership_test_comparison(
+                context,
+                left,
+                other,
+                membership_op,
+                range,
+            ))
+        }
+
         (Type::Union(union), other) => {
             let mut builder = UnionBuilder::new(db);
             for element in union.elements(db) {

--- a/crates/ty_python_semantic/src/types/iteration.rs
+++ b/crates/ty_python_semantic/src/types/iteration.rs
@@ -108,6 +108,7 @@ impl<'db> Type<'db> {
             match ty {
                 Type::NominalInstance(nominal) => nominal.tuple_spec(db),
                 Type::NewTypeInstance(newtype) => non_async_special_case(db, newtype.concrete_base_type(db)),
+                Type::Overlapping(overlapping) => non_async_special_case(db, overlapping.value_type(db)),
                 Type::GenericAlias(alias) if alias.origin(db).is_tuple(db) => {
                     Some(Cow::Owned(TupleSpec::homogeneous(todo_type!(
                         "*tuple[] annotations"

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -163,6 +163,10 @@ impl<'db> AllMembers<'db> {
 
     fn extend_with_type(&mut self, db: &'db dyn Db, ty: Type<'db>) {
         match ty {
+            // parameter-only marker; behaves as the type a body sees (bound of `Key`)
+            Type::Overlapping(overlapping) => {
+                self.extend_with_type(db, overlapping.value_type(db));
+            }
             Type::Union(union) => {
                 fn is_dynamic(db: &dyn Db, ty: Type<'_>) -> bool {
                     // We don't need to use recursion here because

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -449,6 +449,9 @@ impl ClassInfoConstraintFunction {
             Type::TypeAlias(alias) => {
                 self.generate_constraint(db, alias.value_type(db), is_positive)
             }
+            Type::Overlapping(overlapping) => {
+                self.generate_constraint(db, overlapping.value_type(db), is_positive)
+            }
             Type::ClassLiteral(class_literal) => Some(constraint_from_class_literal(class_literal)),
             Type::SubclassOf(subclass_of_ty) => {
                 // We can't narrow negatively from a `SubclassOf` type. `if !isinstance(x, y)`
@@ -2069,6 +2072,15 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         let Some((_, mapping_value_ty)) = subject_ty.unpack_keys_and_items(self.db) else {
             return Some(Type::unknown());
         };
+        // For a standard `dict`/`Mapping` `get`, the captured value is simply the
+        // mapping's value type. Routing it through an actual `get` call would
+        // additionally apply `dict.get`'s `Overlapping[Key]` call-site check,
+        // which rejects a key literal disjoint from the declared key type — but a
+        // match pattern must stay permissive (the annotation doesn't prove the
+        // key absent; a subclass may accept it).
+        if self.mapping_pattern_uses_standard_get(subject_ty) {
+            return Some(mapping_value_ty);
+        }
         let Some(get_method) = subject_ty
             .member(self.db, "get")
             .place
@@ -2076,14 +2088,12 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         else {
             return Some(Type::unknown());
         };
-        let default_ty = if self.mapping_pattern_uses_standard_get(subject_ty) {
-            mapping_value_ty
-        } else {
-            Type::object()
-        };
         Some(
             get_method
-                .try_call(self.db, &CallArguments::positional([key_ty, default_ty]))
+                .try_call(
+                    self.db,
+                    &CallArguments::positional([key_ty, Type::object()]),
+                )
                 .map(|bindings| bindings.return_type(self.db))
                 .unwrap_or_else(|error| error.return_type(self.db)),
         )
@@ -4208,6 +4218,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
 // one `TypedDict` (even if other types are also present), or a type alias to such a type.
 fn is_or_contains_typeddict<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
     match ty {
+        Type::Overlapping(overlapping) => is_or_contains_typeddict(db, overlapping.value_type(db)),
         Type::TypedDict(_) => true,
         Type::Intersection(intersection) => intersection
             .positive(db)
@@ -4383,6 +4394,11 @@ fn all_matching_typeddict_fields_have_literal_types<'db>(
                     field_name,
                 )
         }),
+        Type::Overlapping(overlapping) => all_matching_typeddict_fields_have_literal_types(
+            db,
+            overlapping.value_type(db),
+            field_name,
+        ),
         Type::TypeAlias(alias) => {
             all_matching_typeddict_fields_have_literal_types(db, alias.value_type(db), field_name)
         }

--- a/crates/ty_python_semantic/src/types/overlapping.rs
+++ b/crates/ty_python_semantic/src/types/overlapping.rs
@@ -1,0 +1,83 @@
+//! `ty_extensions.Overlapping` — a safe-variance escape hatch for input positions
+//!
+//! `Overlapping[Key]` is a parameter-only special form. it lets a covariant
+//! (`out Key`) class declare a method that *consumes* `Key` without giving up
+//! covariance, by pulling in two opposite directions:
+//!
+//! - at the call site it accepts an argument iff that argument is *not disjoint*
+//!   from the specialized `Key`. so for a `Mapping[int, ...]`, `1 in m` and
+//!   `object() in m` are accepted (both could-be an `int`), while `"a" in m` is
+//!   rejected (`str` and `int` never overlap). this is looser than a plain `Key`
+//!   parameter (which would reject `object()`) but stricter than `object` (which
+//!   would accept `"a"`)
+//! - inside the body the parameter is seen as `Key`'s upper bound, so the
+//!   consumed value can never be funnelled back into `Key`-typed covariant
+//!   storage. that erasure is the soundness guard
+//!
+//! `Overlapping` is the loose sibling of the (documented, not-yet-built)
+//! `SafeVariance`: they share the two-faced structure and differ only in the
+//! call-site relation (overlap vs. subtype)
+
+use super::variance::VarianceInferable;
+use super::{BoundTypeVarIdentity, Type, TypeVarVariance, visitor};
+use crate::Db;
+
+#[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
+pub struct OverlappingType<'db> {
+    pub(crate) type_argument: Type<'db>,
+}
+
+pub(super) fn walk_overlapping_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
+    db: &'db dyn Db,
+    overlapping_type: OverlappingType<'db>,
+    visitor: &V,
+) {
+    visitor.visit_type(db, overlapping_type.type_argument(db));
+}
+
+// The Salsa heap is tracked separately.
+impl get_size2::GetSize for OverlappingType<'_> {}
+
+impl<'db> OverlappingType<'db> {
+    pub(crate) fn from_type_expression(db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
+        Type::Overlapping(Self::new(db, ty))
+    }
+
+    /// The type a value of an `Overlapping[Key]` parameter is seen as *inside the
+    /// method body*: the upper bound of the wrapped type argument. A covariant
+    /// `Key` is thereby erased to its bound (`object` when unbounded), so it can
+    /// never be written back into `Key`-typed storage.
+    pub(crate) fn value_type(self, db: &'db dyn Db) -> Type<'db> {
+        match self.type_argument(db) {
+            Type::TypeVar(typevar) => typevar
+                .typevar(db)
+                .bound_or_constraints(db)
+                .map(|bound_or_constraints| bound_or_constraints.as_type(db))
+                .unwrap_or_else(Type::object),
+            other => other,
+        }
+    }
+}
+
+impl<'db> Type<'db> {
+    /// Erase a top-level `Overlapping[Key]` marker to the type a body sees for
+    /// such a parameter (`Key`'s upper bound). Any other type is returned
+    /// unchanged. Used when binding a parameter's declared type inside the body,
+    /// where the marker has no place — it exists only for the call binder.
+    pub(crate) fn erase_overlapping(self, db: &'db dyn Db) -> Type<'db> {
+        match self {
+            Type::Overlapping(overlapping) => overlapping.value_type(db),
+            _ => self,
+        }
+    }
+}
+
+impl<'db> VarianceInferable<'db> for OverlappingType<'db> {
+    // `Overlapping` is bivariant in its type argument: it constrains variance in
+    // neither direction, matching the escape-hatch semantics (its whole purpose
+    // is to let a covariant typevar appear in an input position without forcing
+    // invariance).
+    fn variance_of(self, _db: &'db dyn Db, _typevar: BoundTypeVarIdentity<'db>) -> TypeVarVariance {
+        TypeVarVariance::Bivariant
+    }
+}

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -299,6 +299,7 @@ impl<'db> Type<'db> {
             | Type::TypeIs(_)
             | Type::TypeGuard(_)
             | Type::TypeForm(_)
+            | Type::Overlapping(_)
             | Type::TypedDict(_)
             | Type::TypeAlias(_)
             | Type::NewTypeInstance(_) => false,
@@ -1142,6 +1143,20 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             (_, Type::TypeAlias(target_alias)) => self.with_recursion_guard(source, target, || {
                 self.check_type_pair(db, source, target_alias.value_type(db))
             }),
+
+            // `Overlapping[Key]` is a parameter-only marker; for general relations
+            // (subtyping, assignability, override compatibility) it behaves as its
+            // wrapped type `Key`. this is what lets a subclass override a method
+            // typed `Overlapping[Key]` with `key: Key` (or the bare upper bound):
+            // the special overlap admissibility is applied only at the call site,
+            // not in the type relation
+            (Type::Overlapping(source_overlapping), _) => {
+                self.check_type_pair(db, source_overlapping.type_argument(db), target)
+            }
+
+            (_, Type::Overlapping(target_overlapping)) => {
+                self.check_type_pair(db, source, target_overlapping.type_argument(db))
+            }
 
             // Annotation unions retain type aliases so recursive aliases can be represented.
             // Normalize direct alias elements together before checking the union so reductions
@@ -2600,6 +2615,14 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 self.with_recursion_guard(left, right, || {
                     self.check_type_pair(db, left, right_alias_ty)
                 })
+            }
+
+            (Type::Overlapping(overlapping), _) => {
+                self.check_type_pair(db, overlapping.type_argument(db), right)
+            }
+
+            (_, Type::Overlapping(overlapping)) => {
+                self.check_type_pair(db, left, overlapping.type_argument(db))
             }
 
             (Type::EnumComplement(complement), other) => {

--- a/crates/ty_python_semantic/src/types/special_form.rs
+++ b/crates/ty_python_semantic/src/types/special_form.rs
@@ -89,6 +89,8 @@ pub enum SpecialFormType {
     Not,
     /// The symbol `ty_extensions.Intersection`
     Intersection,
+    /// The symbol `ty_extensions.Overlapping`
+    Overlapping,
     /// The symbol `ty_extensions._internal.TypeOf`
     TypeOf,
     /// The symbol `ty_extensions._internal.CallableTypeOf`
@@ -202,6 +204,7 @@ impl SpecialFormType {
             | Self::Top
             | Self::Bottom
             | Self::Intersection
+            | Self::Overlapping
             | Self::CallableTypeOf
             | Self::RegularCallableTypeOf
             | Self::Unknown
@@ -327,6 +330,7 @@ impl SpecialFormType {
             AlwaysFalsy,
             Not,
             Intersection,
+            Overlapping,
             TypeOf,
             CallableTypeOf,
             RegularCallableTypeOf,
@@ -375,6 +379,7 @@ impl SpecialFormType {
                     SpecialFormType::RegularCallableTypeOf => Self::RegularCallableTypeOf,
                     SpecialFormType::Concatenate => Self::Concatenate,
                     SpecialFormType::Intersection => Self::Intersection,
+                    SpecialFormType::Overlapping => Self::Overlapping,
                     SpecialFormType::Literal => Self::Literal,
                     SpecialFormType::LiteralString => Self::LiteralString,
                     SpecialFormType::Never => Self::Never,
@@ -436,6 +441,7 @@ impl SpecialFormType {
                     SpecialFormTypeBuilder::RegularCallableTypeOf => &[Self::RegularCallableTypeOf],
                     SpecialFormTypeBuilder::Concatenate => &[Self::Concatenate],
                     SpecialFormTypeBuilder::Intersection => &[Self::Intersection],
+                    SpecialFormTypeBuilder::Overlapping => &[Self::Overlapping],
                     SpecialFormTypeBuilder::Literal => &[Self::Literal],
                     SpecialFormTypeBuilder::LiteralString => &[Self::LiteralString],
                     SpecialFormTypeBuilder::Never => &[Self::Never],
@@ -553,7 +559,8 @@ impl SpecialFormType {
             | Self::Not
             | Self::Top
             | Self::Bottom
-            | Self::Intersection => module.is_ty_extensions(),
+            | Self::Intersection
+            | Self::Overlapping => module.is_ty_extensions(),
 
             Self::Divergent
             | Self::Todo
@@ -624,6 +631,7 @@ impl SpecialFormType {
             | Self::Top
             | Self::Bottom
             | Self::Intersection
+            | Self::Overlapping
             | Self::TypeOf
             | Self::CallableTypeOf
             | Self::RegularCallableTypeOf
@@ -668,6 +676,7 @@ impl SpecialFormType {
             | Self::Never
             | Self::NoReturn
             | Self::Not
+            | Self::Overlapping
             | Self::TypeAlias
             | Self::TypeGuard
             | Self::NamedTuple
@@ -726,6 +735,7 @@ impl SpecialFormType {
             SpecialFormType::AlwaysFalsy => "AlwaysFalsy",
             SpecialFormType::Not => "Not",
             SpecialFormType::Intersection => "Intersection",
+            SpecialFormType::Overlapping => "Overlapping",
             SpecialFormType::TypeOf => "TypeOf",
             SpecialFormType::CallableTypeOf => "CallableTypeOf",
             SpecialFormType::RegularCallableTypeOf => "RegularCallableTypeOf",
@@ -779,6 +789,7 @@ impl SpecialFormType {
             | SpecialFormType::AlwaysFalsy
             | SpecialFormType::Not
             | SpecialFormType::Intersection
+            | SpecialFormType::Overlapping
             | SpecialFormType::Top
             | SpecialFormType::Bottom => &[KnownModule::TyExtensions],
 
@@ -917,6 +928,7 @@ impl SpecialFormType {
 
             Self::Optional
             | Self::Not
+            | Self::Overlapping
             | Self::Top
             | Self::Bottom
             | Self::TypeOf

--- a/crates/ty_python_semantic/src/types/subscript.rs
+++ b/crates/ty_python_semantic/src/types/subscript.rs
@@ -543,6 +543,10 @@ impl<'db> Type<'db> {
         let inferred = match (value_ty, slice_ty) {
             (Type::Dynamic(_) | Type::Divergent(_) | Type::Never, _) => Some(Ok(value_ty)),
 
+            (Type::Overlapping(overlapping), _) => {
+                Some(overlapping.value_type(db).subscript(db, slice_ty, expr_context, tcx))
+            }
+
             (Type::TypeAlias(alias), _) => {
                 Some(alias.value_type(db).subscript(db, slice_ty, expr_context, tcx))
             }

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -1863,6 +1863,9 @@ pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
         Type::TypeAlias(alias) => {
             extract_unpacked_typed_dict_from_value_type(db, alias.value_type(db))
         }
+        Type::Overlapping(overlapping) => {
+            extract_unpacked_typed_dict_from_value_type(db, overlapping.value_type(db))
+        }
         // All other types cannot contain a TypedDict
         Type::Dynamic(_)
         | Type::Divergent(_)

--- a/crates/ty_python_semantic/src/types/visitor.rs
+++ b/crates/ty_python_semantic/src/types/visitor.rs
@@ -8,8 +8,9 @@ use crate::{
     types::{
         BoundMethodType, BoundSuperType, BoundTypeVarInstance, CallableType, EnumComplementType,
         GenericAlias, IntersectionType, KnownBoundMethodType, KnownInstanceType,
-        NominalInstanceType, PropertyInstanceType, ProtocolInstanceType, SubclassOfType, Type,
-        TypeAliasType, TypeFormType, TypeGuardType, TypeIsType, TypedDictType, UnionType,
+        NominalInstanceType, OverlappingType, PropertyInstanceType, ProtocolInstanceType,
+        SubclassOfType, Type, TypeAliasType, TypeFormType, TypeGuardType, TypeIsType,
+        TypedDictType, UnionType,
         bound_super::walk_bound_super_type,
         callable::walk_callable_type,
         class::walk_generic_alias,
@@ -18,6 +19,7 @@ use crate::{
         known_instance::walk_known_instance_type,
         method::{walk_bound_method_type, walk_method_wrapper_type},
         newtype::{NewType, walk_newtype_instance_type},
+        overlapping::walk_overlapping_type,
         set_theoretic::{walk_intersection_type, walk_union},
         subclass_of::walk_subclass_of_type,
         type_alias::walk_type_alias_type,
@@ -72,6 +74,10 @@ pub(crate) trait TypeVisitor<'db> {
 
     fn visit_typeform_type(&self, db: &'db dyn Db, typeform: TypeFormType<'db>) {
         walk_typeform_type(db, typeform, self);
+    }
+
+    fn visit_overlapping_type(&self, db: &'db dyn Db, overlapping: OverlappingType<'db>) {
+        walk_overlapping_type(db, overlapping, self);
     }
 
     fn visit_subclass_of_type(&self, db: &'db dyn Db, subclass_of: SubclassOfType<'db>) {
@@ -154,6 +160,7 @@ pub(super) enum NonAtomicType<'db> {
     TypeIs(TypeIsType<'db>),
     TypeGuard(TypeGuardType<'db>),
     TypeForm(TypeFormType<'db>),
+    Overlapping(OverlappingType<'db>),
     TypeVar(BoundTypeVarInstance<'db>),
     ProtocolInstance(ProtocolInstanceType<'db>),
     TypedDict(TypedDictType<'db>),
@@ -225,6 +232,9 @@ impl<'db> From<Type<'db>> for TypeKind<'db> {
                 TypeKind::NonAtomic(NonAtomicType::TypeGuard(type_guard))
             }
             Type::TypeForm(typeform) => TypeKind::NonAtomic(NonAtomicType::TypeForm(typeform)),
+            Type::Overlapping(overlapping) => {
+                TypeKind::NonAtomic(NonAtomicType::Overlapping(overlapping))
+            }
             Type::TypedDict(typed_dict) => {
                 TypeKind::NonAtomic(NonAtomicType::TypedDict(typed_dict))
             }
@@ -268,6 +278,9 @@ pub(super) fn walk_non_atomic_type<'db, V: TypeVisitor<'db> + ?Sized>(
         NonAtomicType::TypeIs(type_is) => visitor.visit_typeis_type(db, type_is),
         NonAtomicType::TypeGuard(type_guard) => visitor.visit_typeguard_type(db, type_guard),
         NonAtomicType::TypeForm(typeform) => visitor.visit_typeform_type(db, typeform),
+        NonAtomicType::Overlapping(overlapping) => {
+            visitor.visit_overlapping_type(db, overlapping);
+        }
         NonAtomicType::TypeVar(bound_typevar) => {
             visitor.visit_bound_type_var_type(db, bound_typevar);
         }

--- a/crates/ty_vendored/ty_extensions/__init__.pyi
+++ b/crates/ty_vendored/ty_extensions/__init__.pyi
@@ -20,6 +20,21 @@ def static_assert(condition: object, msg: LiteralString | None = None) -> None: 
 Not: _SpecialForm
 """`Not[T]` represents the set of all objects that do not inhabit the type `T`."""
 
+Overlapping: _SpecialForm
+"""
+`Overlapping[T]` is a "safe variance" escape hatch for input positions: it lets a covariant
+(`out T`) class declare a method parameter that *consumes* `T` without giving up covariance.
+
+At the call site, an argument is accepted iff it is *not disjoint from* `T` (its type overlaps
+`T`). At the upper bound `object`, that means only a provably-unrelated argument is rejected. For a
+`Mapping[int, V]`, both `1 in m` and `object() in m` are accepted, while `"a" in m` is rejected
+because `str` and `int` can never overlap.
+
+Inside the method body the parameter is seen as the upper bound of `T` (so `Overlapping[T]` reveals
+as `object` for an unbounded `T`), which prevents the consumed value from being written back into
+`T`-typed covariant storage. `Overlapping[T]` is only meaningful as a parameter annotation.
+"""
+
 Intersection: _SpecialForm
 """
 `Intersection[T1, T2, ..., Tn]` represents an intersection type: the set of all objects that inhabit

--- a/crates/ty_vendored/vendor/typeshed/stdlib/builtins.byi
+++ b/crates/ty_vendored/vendor/typeshed/stdlib/builtins.byi
@@ -2590,7 +2590,7 @@ class tuple[out Element](Sequence[Element]):
     def __len__(self) -> int:
         """Return len(self)."""
 
-    def __contains__(self, key: object, /) -> bool:
+    def __contains__(self, key: Overlapping[Element], /) -> bool:
         """Return bool(key in self)."""
 
     def __getitem__(self, key: SupportsIndex, /) -> Element:
@@ -2737,7 +2737,7 @@ class list[in out Element](MutableSequence[Element]):
     def __imul__(self, value: SupportsIndex, /) -> Self:
         """Implement self*=value."""
 
-    def __contains__(self, key: object, /) -> bool:
+    def __contains__(self, key: Overlapping[Element], /) -> bool:
         """Return bool(key in self)."""
 
     def __reversed__(self) -> Iterator[Element]:
@@ -2811,10 +2811,10 @@ class dict[in out Key, in out Value](MutableMapping[Key, Value]):
     def fromkeys[Element, Other](cls, iterable: Iterable[Element], value: Other, /) -> dict[Element, Other]
 
     # Positional-only in dict, but not in MutableMapping
-    def get(self, key: object, default: None = None, /) -> Value | None:
+    def get(self, key: Overlapping[Key], default: None = None, /) -> Value | None:
         """Return the value for key if key is in the dictionary, else default."""
-    def get(self, key: object, default: Value, /) -> Value
-    def get[Element](self, key: object, default: Element, /) -> Value | Element
+    def get(self, key: Overlapping[Key], default: Value, /) -> Value
+    def get[Element](self, key: Overlapping[Key], default: Element, /) -> Value | Element
 
     def pop(self, key: Key, /) -> Value:
         """D.pop(k[,d]) -> v, remove specified key and return the corresponding value.
@@ -2828,7 +2828,7 @@ class dict[in out Key, in out Value](MutableMapping[Key, Value]):
     def __len__(self) -> int:
         """Return len(self)."""
 
-    def __getitem__(self, key: Key, /) -> Value:
+    def __getitem__(self, key: Overlapping[Key], /) -> Value:
         """Return self[key]."""
 
     def __setitem__(self, key: Key, value: Value, /) -> None:
@@ -2900,10 +2900,10 @@ if sys.version_info >= (3, 15):
             """Create a new dictionary with keys from iterable and values set to value."""
         class def fromkeys[Element, Other](cls, iterable: Iterable[Element], value: Other, /) -> frozendict[Element, Other]
 
-        def get(self, key: Key, default: None = None, /) -> Value | None:
+        def get(self, key: Overlapping[Key], default: None = None, /) -> Value | None:
             """Return the value for key if key is in the dictionary, else default."""
-        def get(self, key: Key, default: Value, /) -> Value
-        def get[Element](self, key: Key, default: Element, /) -> Value | Element
+        def get(self, key: Overlapping[Key], default: Value, /) -> Value
+        def get[Element](self, key: Overlapping[Key], default: Element, /) -> Value | Element
 
         def keys(self) -> dict_keys[Key, Value]:
             """Return a set-like object providing a view on the dict's keys."""
@@ -2917,7 +2917,7 @@ if sys.version_info >= (3, 15):
         def __len__(self) -> int:
             """Return len(self)."""
 
-        def __getitem__(self, key: Key, /) -> Value:
+        def __getitem__(self, key: Overlapping[Key], /) -> Value:
             """Return self[key]."""
 
         def __reversed__(self) -> Iterator[Key]:
@@ -3002,7 +3002,7 @@ class set[in out Element](MutableSet[Element]):
     def __len__(self) -> int:
         """Return len(self)."""
 
-    def __contains__(self, o: object, /) -> bool:
+    def __contains__(self, o: Overlapping[Element], /) -> bool:
         """x.__contains__(y) <==> y in x."""
 
     def __iter__(self) -> Iterator[Element]:
@@ -3075,7 +3075,7 @@ class frozenset[out Element](AbstractSet[Element]):
     def __len__(self) -> int:
         """Return len(self)."""
 
-    def __contains__(self, o: object, /) -> bool:
+    def __contains__(self, o: Overlapping[Element], /) -> bool:
         """x.__contains__(y) <==> y in x."""
 
     def __iter__(self) -> Iterator[Element]:

--- a/crates/ty_vendored/vendor/typeshed/stdlib/typing.byi
+++ b/crates/ty_vendored/vendor/typeshed/stdlib/typing.byi
@@ -1532,12 +1532,11 @@ protocol AsyncGenerator[out Element, in Sent = None](AsyncIterator[Element]):
 
 
 @runtime_checkable
-protocol Container[in ContainerT = dynamic]:
-    abstract def __contains__(self, x: ContainerT, /) -> bool
+protocol Container[out Element]:
+    abstract def __contains__(self, x: Overlapping[Element], /) -> bool
 
 @runtime_checkable
-protocol Collection[out Element](Iterable[Element], Container[dynamic]):
-    # Implement Sized (but don't have it as a base class).
+protocol Collection[out Element](Iterable[Element], Container[Element]):
     abstract def __len__(self) -> int
 
 class Sequence[out Element](Reversible[Element], Collection[Element]):
@@ -1562,7 +1561,7 @@ class Sequence[out Element](Reversible[Element], Collection[Element]):
     def count(self, value: dynamic, /) -> int:
         """S.count(value) -> integer -- return number of occurrences of value"""
 
-    def __contains__(self, value: object, /) -> bool
+    def __contains__(self, value: Overlapping[Element], /) -> bool
     def __iter__(self) -> Iterator[Element]
     def __reversed__(self) -> Iterator[Element]
 
@@ -1623,7 +1622,7 @@ class AbstractSet[out Element](Collection[Element]):
     then the other operations will automatically follow suit.
     """
 
-    abstract def __contains__(self, x: object, /) -> bool
+    abstract def __contains__(self, x: Overlapping[Element], /) -> bool
     def _hash(self) -> int:
         """Compute the hash value of a set.
 
@@ -1703,7 +1702,7 @@ class ItemsView[out Key, out Value](MappingView, AbstractSet[tuple[Key, Value]])
     class def _from_iterable[Other](cls, it: Iterable[Other], /) -> set[Other]
     def __and__(self, other: Iterable[dynamic], /) -> set[(Key, Value)]
     def __rand__[Element](self, other: Iterable[Element], /) -> set[Element]
-    def __contains__(self, item: (object, object), /) -> bool
+    def __contains__(self, item: Overlapping[tuple[Key, Value]], /) -> bool
     def __iter__(self) -> Iterator[(Key, Value)]
     def __or__[Element](self, other: Iterable[Element], /) -> set[(Key, Value) | Element]
     def __ror__[Element](self, other: Iterable[Element], /) -> set[(Key, Value) | Element]
@@ -1717,7 +1716,7 @@ class KeysView[out Key](MappingView, AbstractSet[Key]):
     class def _from_iterable[Other](cls, it: Iterable[Other], /) -> set[Other]
     def __and__(self, other: Iterable[dynamic], /) -> set[Key]
     def __rand__[Element](self, other: Iterable[Element], /) -> set[Element]
-    def __contains__(self, key: object, /) -> bool
+    def __contains__(self, key: Overlapping[Key], /) -> bool
     def __iter__(self) -> Iterator[Key]
     def __or__[Element](self, other: Iterable[Element], /) -> set[Key | Element]
     def __ror__[Element](self, other: Iterable[Element], /) -> set[Key | Element]
@@ -1728,7 +1727,7 @@ class KeysView[out Key](MappingView, AbstractSet[Key]):
 
 class ValuesView[out Value](MappingView, Collection[Value]):
     init(self, mapping: SupportsGetItemViewable[dynamic, Value])  # undocumented
-    def __contains__(self, value: object, /) -> bool
+    def __contains__(self, value: Overlapping[Value], /) -> bool
     def __iter__(self) -> Iterator[Value]
 
 # note for Mapping.get and MutableMapping.pop and MutableMapping.setdefault
@@ -1746,13 +1745,13 @@ class Mapping[out Key, out Value](Collection[Key]):
 
     # TODO: We wish the key type could also be covariant, but that doesn't work,
     # see discussion in https://github.com/python/typing/pull/273.
-    abstract def __getitem__(self, key: Key, /) -> Value
+    abstract def __getitem__(self, key: Overlapping[Key], /) -> Value
 
     # Mixin methods
-    def get(self, key: object, /) -> Value | None:
+    def get(self, key: Overlapping[Key], /) -> Value | None:
         """D.get(k[,d]) -> D[k] if k in D, else d.  d defaults to None."""
-    def get(self, key: object, default: Value, /) -> Value
-    def get[Element](self, key: object, default: Element, /) -> Value | Element
+    def get(self, key: Overlapping[Key], default: Value, /) -> Value
+    def get[Element](self, key: Overlapping[Key], default: Element, /) -> Value | Element
 
     def items(self) -> ItemsView[Key, Value]:
         """D.items() -> a set-like object providing a view on D's items"""
@@ -1763,7 +1762,7 @@ class Mapping[out Key, out Value](Collection[Key]):
     def values(self) -> ValuesView[Value]:
         """D.values() -> an object providing a view on D's values"""
 
-    def __contains__(self, key: object, /) -> bool
+    def __contains__(self, key: Overlapping[Key], /) -> bool
     def __eq__(self, other: object, /) -> bool
 
 class MutableMapping[in out Key, in out Value](Mapping[Key, Value]):

--- a/docs/basedpython/features/overlapping.md
+++ b/docs/basedpython/features/overlapping.md
@@ -1,0 +1,89 @@
+# overlapping
+
+`Overlapping[T]` is a "safe variance" escape hatch for input positions, imported
+from `ty_extensions`. it lets a [covariant](variance.md) (`out T`) class declare a
+method that *consumes* `T` without giving up covariance. it is the loose sibling
+of [`SafeVariance`](safe-variance.md): both are two-faced (real type at the call
+site, bound inside the body); they differ only in the call-site relation
+
+## the two faces
+
+```py
+from ty_extensions import Overlapping
+
+class Mapping[out Key, out Value]:
+    def __contains__(self, key: Overlapping[Key]) -> bool:
+        reveal_type(key)  # object — the upper bound of Key
+        return True
+
+def f(m: Mapping[int, object]):
+    1 in m         # ok — int overlaps int
+    object() in m  # ok — object overlaps int (it could be an int)
+    "a" in m       # error — str is disjoint from int
+```
+
+- **at the call site**, an argument is accepted iff it is *not disjoint from* the
+    specialized `Key` — i.e. their types overlap (`Overlapping[T]` means exactly
+    "not disjoint from `T`"). so a provably-unrelated argument like `"a"` is
+    rejected, but a could-be-a-`Key` argument like `object()` is allowed. this is
+    looser than a plain `Key` parameter (which would reject `object()`) and
+    stricter than `object` (which would accept `"a"`)
+- **inside the body**, the parameter is seen as the upper bound of `Key`, so the
+    consumed value can never be written back into `Key`-typed covariant storage.
+    that erasure is the soundness guard: the value flows *in* at full precision
+    and is immediately erased to the bound, so it can never flow back out
+    mislabelled
+
+## the membership use case
+
+the canonical use is the `__contains__` method of a covariant container. a
+membership test only makes sense for a value that *could* be an element, so
+basedpython's typeshed types `Container.__contains__` as `Overlapping[Element]`:
+
+```py
+def f(xs: list[int]):
+    1 in xs         # ok
+    object() in xs  # ok
+    "a" in xs       # error — str can never be an int
+```
+
+`Container.__contains__` is the abstract requirement, and every container's
+`__contains__` takes `Overlapping[Element]` for its own element, so the check
+applies uniformly to `list`, `set`, `dict` keys, `tuple`, and any user class
+deriving from `Container`/`Collection`. `dict.__getitem__` and `dict.get` (and
+`Mapping.__getitem__`/`get`) consume the covariant key the same way, so a lookup
+`d[k]` accepts exactly the keys a membership test `k in d` would.
+
+Because `Overlapping[Key]` relates as `Key` for subtyping and override
+compatibility (only the *call site* applies the overlap admissibility check), a
+subclass can override such a method with the bare `Key` (or its upper bound)
+without a Liskov violation.
+
+a membership test whose operands can never overlap is a definite bug, so `in` and
+`not in` report `unsupported-operator` when the value is provably disjoint from
+the container's element — including narrowing residuals and empty containers.
+this is stricter than mainstream checkers (mypy gates the same check behind
+`--strict-equality`); in basedpython it is always on.
+
+## overlap is exact
+
+`Overlapping` uses the type system's disjointness relation, so it is precise
+about literals and unions:
+
+```py
+def f(b: list[bool], keys: dict[int | str, object]):
+    True in b      # ok — bool overlaps bool
+    1 in b         # error — Literal[1] is not a bool
+    b"x" in keys   # error — bytes is disjoint from int | str
+```
+
+a union is accepted whenever *any* member overlaps, matching the whole-operand
+behaviour of a membership test — `x: str | None` may be tested against a
+`dict[str, int]` because its `str` part overlaps the key.
+
+## `Overlapping[T]` is a parameter annotation
+
+`Overlapping[T]` is only meaningful as a parameter annotation. inside the body
+and everywhere else it behaves as the upper bound of `T`. in basedpython source
+and in the vendored typeshed it resolves without an import; user code in plain
+Python imports it from `ty_extensions`.

--- a/docs/basedpython/index.md
+++ b/docs/basedpython/index.md
@@ -44,6 +44,7 @@ type-checking improvements with no new syntax — they work in `.by` and `.py` f
 - [explicit typevar constraints](features/constraints.md)
 - [typevar variance keywords](features/variance.md)
 - [safe variance](features/safe-variance.md)
+- [overlapping](features/overlapping.md)
 - [explicit generic call sites](features/generic-calls.md)
 - [reified type parameters](features/reified-generics.md)
 - [type reification](features/type-reification.md)


### PR DESCRIPTION
New ty_extensions.Overlapping[T] special form: a parameter accepts an argument iff it is not disjoint from T (their types overlap), used for covariant containers' membership and key consumption.

- Type::Overlapping variant + binder overlap rule + body-erases-to-bound. Overlapping[T] relates as T for subtyping/override compatibility (a subclass may override with T or the bare upper bound); a dynamic argument is always admissible; membership checks the whole (union) operand holistically.
- bare Overlapping resolves in basedpython files / the vendored typeshed without an import (type-expression position only).
- by_typeshed_patch transform (container_overlapping): Container.__contains__ stays abstract, every container's __contains__ parameter is rewritten to Overlapping[<element>] (abstract/concrete status preserved), Collection extends Container[Element], stale comments removed, Mapping/dict/frozendict __getitem__/get consume Overlapping[Key]. --skip-conversion mode re-applies the semantic patches to the already-converted committed tree.
- match mapping patterns extract the value type directly for standard dict/Mapping get, staying permissive.
- mdtests + feature doc.

<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->
