### PR TITLE
extend ?. short-circuit to the end of the chain

### DIFF
--- a/crates/by_transforms/src/transforms/none_chain.rs
+++ b/crates/by_transforms/src/transforms/none_chain.rs
@@ -1,19 +1,18 @@
 use std::fmt::Write as _;
 
-use ruff_diagnostics::{Edit, Fix};
 use ruff_python_ast::visitor::{Visitor, walk_expr, walk_stmt};
 use ruff_python_ast::{Expr, Stmt};
-use ruff_text_size::Ranged;
+use ruff_text_size::{Ranged, TextRange};
 
-use crate::transforms::ast_driver::{PassContext, TypeAwarePass};
+use crate::transforms::ast_driver::{Fragment, PassContext, TypeAwarePass};
 use crate::type_info::TypeInfo;
 
-/// rewrites `a?.b` to `None if a is None else a.b`
-/// and chains like `a?.b?.c` to `None if a is None else None if (_t := a.b) is None else _t.c`
+/// rewrites `a?.b` to `(None if a is None else a.b)`
+/// and chains like `a?.b?.c` to `(None if a is None else None if (_t := a.b) is None else _t.c)`
 pub(crate) struct NoneChain<'src> {
     source: &'src str,
     types: &'src dyn TypeInfo,
-    pub(crate) edits: Vec<Fix>,
+    pub(crate) template_edits: Vec<(TextRange, Vec<Fragment>)>,
 }
 
 impl<'src> NoneChain<'src> {
@@ -21,7 +20,7 @@ impl<'src> NoneChain<'src> {
         Self {
             source,
             types,
-            edits: Vec::new(),
+            template_edits: Vec::new(),
         }
     }
 }
@@ -112,6 +111,27 @@ pub(super) fn build_expansion(guards: &[String], result: &str, temp: &str) -> St
     s
 }
 
+/// the `?.` attribute chain at the base of `expr`, with its expansion, when `expr` is a
+/// link of an optional chain.
+///
+/// a chain runs from its first `?.` out through the trailers applied to it — `.attr`,
+/// `(...)`, `[...]`. only the attribute part expands; the trailers stay source
+fn chain_head<'a>(
+    expr: &'a Expr,
+    source: &str,
+    types: &dyn TypeInfo,
+) -> Option<(&'a Expr, String, Vec<String>)> {
+    if let Some((form, guards)) = expand_chain(expr, source, types) {
+        return Some((expr, form, guards));
+    }
+    match expr {
+        Expr::Attribute(attribute) => chain_head(&attribute.value, source, types),
+        Expr::Call(call) => chain_head(&call.func, source, types),
+        Expr::Subscript(subscript) => chain_head(&subscript.value, source, types),
+        _ => None,
+    }
+}
+
 pub(crate) struct NoneChainPass<'src> {
     source: &'src str,
 }
@@ -128,12 +148,34 @@ impl TypeAwarePass for NoneChainPass<'_> {
         for stmt in stmts {
             inner.visit_stmt(stmt);
         }
-        for fix in inner.edits {
-            for edit in fix.edits() {
-                let range = edit.range();
-                let repl = edit.content().unwrap_or_default().to_owned();
-                ctx.text_edits.push((range, repl));
+        ctx.template_edits.extend(inner.template_edits);
+    }
+}
+
+impl NoneChain<'_> {
+    /// visit the sub-expressions of the trailers between `head` and `expr` — the parts that
+    /// pass through as source and so can carry chains of their own. `head` itself is
+    /// rendered from its expansion, not walked
+    fn visit_trailers(&mut self, expr: &Expr, head: &Expr) {
+        if expr.range() == head.range() {
+            return;
+        }
+        match expr {
+            Expr::Attribute(attribute) => self.visit_trailers(&attribute.value, head),
+            Expr::Call(call) => {
+                self.visit_trailers(&call.func, head);
+                for arg in &*call.arguments.args {
+                    self.visit_expr(arg);
+                }
+                for keyword in &*call.arguments.keywords {
+                    self.visit_expr(&keyword.value);
+                }
             }
+            Expr::Subscript(subscript) => {
+                self.visit_trailers(&subscript.value, head);
+                self.visit_expr(&subscript.slice);
+            }
+            _ => {}
         }
     }
 }
@@ -144,15 +186,26 @@ impl<'ast> Visitor<'ast> for NoneChain<'_> {
     }
 
     fn visit_expr(&mut self, expr: &'ast Expr) {
-        if let Expr::Attribute(_) = expr {
-            if let Some((form, guards)) = expand_chain(expr, self.source, self.types) {
-                let temp = pick_temp_var(self.types, expr);
-                self.edits.push(Fix::safe_edit(Edit::range_replacement(
-                    build_expansion(&guards, &form, temp),
-                    expr.range(),
-                )));
-                return;
-            }
+        // top-down, so the first link of a chain we reach is its outermost: the edit spans
+        // the whole chain, not just the `?.` access. a conditional binds looser than every
+        // operator, so an expansion that stopped at the access would regroup whatever
+        // followed into its `else` branch — `not a?.b` would yield `a.b`, and
+        // `[i for i in a?.b]` would not even parse. the parentheses keep the emitted tree
+        // the one that was parsed
+        if let Some((head, form, guards)) = chain_head(expr, self.source, self.types) {
+            let temp = pick_temp_var(self.types, expr);
+            let expansion = build_expansion(&guards, &form, temp);
+            let trailers = TextRange::new(head.range().end(), expr.range().end());
+            self.template_edits.push((
+                expr.range(),
+                vec![
+                    Fragment::Lit(format!("({expansion}")),
+                    Fragment::Src(trailers),
+                    Fragment::Lit(")".to_owned()),
+                ],
+            ));
+            self.visit_trailers(expr, head);
+            return;
         }
         walk_expr(self, expr);
     }
@@ -181,21 +234,21 @@ mod tests {
         )
         .unwrap();
         assert!(
-            out.contains("x = None if w is None else w.value.bit_length\n"),
+            out.contains("x = (None if w is None else w.value.bit_length)\n"),
             "got: {out}"
         );
     }
 
     #[test]
     fn basic_chain() {
-        check("x = a?.b\n", "x = None if a is None else a.b\n");
+        check("x = a?.b\n", "x = (None if a is None else a.b)\n");
     }
 
     #[test]
     fn double_chain() {
         check(
             "x = a?.a?.b\n",
-            "x = None if a is None else None if (_t := a.a) is None else _t.b\n",
+            "x = (None if a is None else None if (_t := a.a) is None else _t.b)\n",
         );
     }
 
@@ -203,7 +256,7 @@ mod tests {
     fn double_chain_t_taken() {
         check(
             "_t = 1\nx = a?.a?.b\n",
-            "_t = 1\nx = None if a is None else None if (_t0 := a.a) is None else _t0.b\n",
+            "_t = 1\nx = (None if a is None else None if (_t0 := a.a) is None else _t0.b)\n",
         );
     }
 
@@ -211,21 +264,139 @@ mod tests {
     fn triple_chain() {
         check(
             "x = a?.b?.c?.d\n",
-            "x = None if a is None else None if (_t := a.b) is None else None if (_t := _t.c) is None else _t.d\n",
+            "x = (None if a is None else None if (_t := a.b) is None else None if (_t := _t.c) is None else _t.d)\n",
         );
     }
 
     #[test]
     fn mixed_chain() {
-        check("x = a?.b.c\n", "x = None if a is None else a.b.c\n");
+        check("x = a?.b.c\n", "x = (None if a is None else a.b.c)\n");
     }
 
     #[test]
     fn optional_after_plain_attr() {
         check(
             "x = a.b?.c\n",
-            "x = None if (_t := a.b) is None else _t.c\n",
+            "x = (None if (_t := a.b) is None else _t.c)\n",
         );
+    }
+
+    // the edit spans the whole chain — the `?.` access plus the trailers applied to it — and
+    // parenthesizes it, so the emitted tree is the one that was parsed. the trailers pass
+    // through as source, so chains nested in them still expand on their own
+
+    #[test]
+    fn call_on_chain() {
+        check("x = a?.b()\n", "x = (None if a is None else a.b())\n");
+    }
+
+    #[test]
+    fn call_on_double_chain() {
+        check(
+            "x = a?.b?.c()\n",
+            "x = (None if a is None else None if (_t := a.b) is None else _t.c())\n",
+        );
+    }
+
+    #[test]
+    fn call_with_args_on_chain() {
+        check(
+            "x = a?.b(1, k=2)\n",
+            "x = (None if a is None else a.b(1, k=2))\n",
+        );
+    }
+
+    #[test]
+    fn chain_in_call_argument_expands_separately() {
+        // the outer edit replaces only `a?.b`, so a chain nested in an argument is a
+        // non-overlapping edit of its own rather than text copied verbatim
+        check(
+            "x = a?.b(c?.d)\n",
+            "x = (None if a is None else a.b((None if c is None else c.d)))\n",
+        );
+    }
+
+    #[test]
+    fn trailers_after_call_on_chain() {
+        check(
+            "x = a?.b().c[0]\n",
+            "x = (None if a is None else a.b().c[0])\n",
+        );
+    }
+
+    #[test]
+    fn subscript_on_chain() {
+        check("x = a?.b[0]\n", "x = (None if a is None else a.b[0])\n");
+    }
+
+    #[test]
+    fn call_on_chain_with_coalesce() {
+        check(
+            "x = a?.b() ?? c\n",
+            "x = _t if (_t := (None if a is None else a.b())) is not None else c\n",
+        );
+    }
+
+    // a conditional binds looser than every operator, so an expansion that stopped at the
+    // `?.` access regrouped whatever followed into its `else` branch. each of these was
+    // wrong before the chain got its own parentheses — silently, in code ty accepts
+
+    #[test]
+    fn operand_of_a_binary_op() {
+        // was `None if a is None else a.b + 1` — the `+ 1` moved inside the else
+        check("x = a?.b + 1\n", "x = (None if a is None else a.b) + 1\n");
+    }
+
+    #[test]
+    fn operand_of_a_unary_op() {
+        // was `-None if a is None else a.b`, which evaluates `-None` and raises
+        check("x = -a?.b\n", "x = -(None if a is None else a.b)\n");
+    }
+
+    #[test]
+    fn operand_of_not() {
+        // was `not None if a is None else a.b`, which yields `a.b` — not `not a.b`
+        check("x = not a?.b\n", "x = not (None if a is None else a.b)\n");
+    }
+
+    #[test]
+    fn operand_of_a_comparison() {
+        // was `None if a is None else a.b == z`, yielding `None` rather than `None == z`
+        check("x = a?.b == z\n", "x = (None if a is None else a.b) == z\n");
+    }
+
+    #[test]
+    fn body_of_a_conditional() {
+        // was `None if a is None else a.b if z else w`, which ignored `z` entirely
+        check(
+            "x = a?.b if z else w\n",
+            "x = (None if a is None else a.b) if z else w\n",
+        );
+    }
+
+    #[test]
+    fn test_of_a_conditional() {
+        // an unparenthesized conditional is not a valid `if` test — this did not parse
+        check(
+            "x = z if a?.b else w\n",
+            "x = z if (None if a is None else a.b) else w\n",
+        );
+    }
+
+    #[test]
+    fn comprehension_iterable() {
+        // an unparenthesized conditional is not a valid comprehension iterable — this did
+        // not parse
+        check(
+            "x = [i for i in a?.b]\n",
+            "x = [i for i in (None if a is None else a.b)]\n",
+        );
+    }
+
+    #[test]
+    fn delimited_positions_stay_correct() {
+        check("x = [a?.b]\n", "x = [(None if a is None else a.b)]\n");
+        check("x = z[a?.b]\n", "x = z[(None if a is None else a.b)]\n");
     }
 
     #[test]

--- a/crates/by_transforms/src/transforms/optional_type.rs
+++ b/crates/by_transforms/src/transforms/optional_type.rs
@@ -390,7 +390,7 @@ class Optional:
             "},
             indoc! {"
                 def f(a: str | None):
-                    return None if a is None else a.b
+                    return (None if a is None else a.b)
             "},
         );
     }

--- a/crates/ty_python_core/src/ast_ids.rs
+++ b/crates/ty_python_core/src/ast_ids.rs
@@ -164,6 +164,18 @@ pub(crate) mod node_key {
         }
     }
 
+    impl From<&ast::ExprAttribute> for ExpressionNodeKey {
+        fn from(value: &ast::ExprAttribute) -> Self {
+            Self(NodeKey::from_node(value))
+        }
+    }
+
+    impl From<&ast::ExprSubscript> for ExpressionNodeKey {
+        fn from(value: &ast::ExprSubscript) -> Self {
+            Self(NodeKey::from_node(value))
+        }
+    }
+
     impl From<&ast::ExprLambda> for ExpressionNodeKey {
         fn from(value: &ast::ExprLambda) -> Self {
             Self(NodeKey::from_node(value))

--- a/crates/ty_python_semantic/resources/mdtest/basedpython_optional_chain.md
+++ b/crates/ty_python_semantic/resources/mdtest/basedpython_optional_chain.md
@@ -3,6 +3,12 @@
 `a?.b` short-circuits to `None` when `a is None`, otherwise evaluates `a.b`. the result type is the
 attribute type unioned with `None`.
 
+a `?.` opens a chain that runs out through every trailer that follows it — `.attr`, `(...)` and
+`[...]` — because that is exactly how far the `None if a is None else <rest of chain>` lowering
+short-circuits. the `None` therefore belongs to the *last* link of the chain, not to each link: in
+`a?.b.c`, an absent `a` skips `.c` too, so the rest of the chain is resolved against `b`'s present
+type and only the end result is unioned with `None`.
+
 ```toml
 [environment]
 python-version = "3.12"
@@ -19,6 +25,131 @@ def f(c: C | None) -> None:
     reveal_type(result)  # revealed: str | None
 ```
 
+## chain continues through a plain attribute
+
+```by
+class Address:
+    zip: str
+
+class C:
+    address: Address
+
+def f(c: C | None) -> None:
+    reveal_type(c?.address)       # revealed: Address | None
+    reveal_type(c?.address.zip)   # revealed: str | None
+```
+
+## chain continues through a method call
+
+```by
+class C:
+    def greet(self) -> str:
+        return "hi"
+
+def f(c: C | None) -> None:
+    reveal_type(c?.greet())  # revealed: str | None
+```
+
+## chain continues through a subscript
+
+```by
+class C:
+    items: list[str]
+
+def f(c: C | None) -> None:
+    reveal_type(c?.items[0])  # revealed: str | None
+```
+
+## chain continues past a call
+
+trailers keep chaining after a call, so the whole tail short-circuits together.
+
+```by
+class Inner:
+    code: str
+
+    def tag(self) -> int:
+        return 1
+
+class C:
+    def get(self) -> Inner:
+        return Inner()
+
+def f(c: C | None) -> None:
+    reveal_type(c?.get().code)    # revealed: str | None
+    reveal_type(c?.get().tag())   # revealed: int | None
+```
+
+## several `?.` links in one chain
+
+a chain short-circuits once no matter how many of its links are optional, so the result is unioned
+with `None` a single time.
+
+```by
+class Inner:
+    def tag(self) -> int:
+        return 1
+
+class Mid:
+    inner: Inner | None
+
+class C:
+    mid: Mid | None
+
+def f(c: C | None) -> None:
+    reveal_type(c?.mid?.inner?.tag())  # revealed: int | None
+```
+
+## a `?.` on a receiver that cannot be absent
+
+`?.` only contributes a `None` when its receiver can actually be absent, so a chain over a
+non-optional receiver stays non-optional.
+
+```by
+class C:
+    name: str
+
+def f(c: C) -> None:
+    reveal_type(c?.name)  # revealed: str
+```
+
+## an optional attribute inside a chain is still an error
+
+the chain's `None` is the receiver's, not the attribute's. an attribute that is optional in its own
+right stays optional, so calling or dereferencing it is still reported: `?.` guards `c`, not `cb`.
+
+```by
+from typing import Callable
+
+class Inner:
+    code: str
+
+class C:
+    cb: Callable[[], int] | None
+    inner: Inner | None
+
+def f(c: C | None) -> None:
+    # error: [call-non-callable]
+    c?.cb()
+    # error: [unresolved-attribute]
+    c?.inner.code
+```
+
+## guarding an optional attribute inside a chain
+
+writing a second `?.` guards the attribute's own `None`.
+
+```by
+class Inner:
+    code: str
+
+class C:
+    inner: Inner | None
+
+def f(c: C | None) -> None:
+    reveal_type(c?.inner?.code)  # revealed: str | None
+```
+
 ## composes with `??`
 
 ```by
@@ -27,4 +158,34 @@ class C:
 
 def f(c: C | None) -> str:
     return c?.name ?? "anonymous"
+```
+
+## `??` collapses a chain that ends in a call
+
+```by
+class C:
+    def greet(self) -> str:
+        return "hi"
+
+def f(c: C | None) -> None:
+    reveal_type(c?.greet() ?? "anonymous")  # revealed: str
+```
+
+## chains as call arguments
+
+a chain nested in an argument keeps its own short-circuit, and the argument sees the chain's full
+type.
+
+```by
+class C:
+    def greet(self) -> str:
+        return "hi"
+
+def takes_optional(value: str | None) -> None: ...
+def takes_str(value: str) -> None: ...
+
+def f(c: C | None) -> None:
+    takes_optional(c?.greet())
+    # error: [invalid-argument-type]
+    takes_str(c?.greet())
 ```

--- a/crates/ty_python_semantic/resources/mdtest/basedpython_optional_type.md
+++ b/crates/ty_python_semantic/resources/mdtest/basedpython_optional_type.md
@@ -120,6 +120,31 @@ def g(a: A):
     reveal_type(w?.v)  # revealed: int | None
 ```
 
+## a chain over a wrapped optional runs to the end of its trailers
+
+peeling the wrapper opens a chain like any other `?.`, so the trailers that follow are resolved
+against the present value and only the end result is unioned with `None`.
+
+```by
+class Inner:
+    code: str
+
+class A:
+    inner: Inner = Inner()
+
+    def get(self) -> Inner:
+        return self.inner
+
+def f[T](t: T) -> T?:
+    return Some(t)
+
+def g(a: A):
+    w = f(a)
+    reveal_type(w?.inner.code)  # revealed: str | None
+    reveal_type(w?.get())       # revealed: Inner | None
+    reveal_type(w?.get().code)  # revealed: str | None
+```
+
 ## force-unwrap `!` peels one optional layer
 
 `expr!` removes one layer of optionality: a wrapped optional yields the next layer in, and a plain

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -289,6 +289,21 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
     /// bidirectional type context, the contextual type.
     fluid_adoptions: FxHashMap<ExpressionNodeKey, Type<'db>>,
 
+    /// basedpython `?.`: for each link of an optional chain, the type that link has
+    /// when every `?.` receiver in the chain is present.
+    ///
+    /// A link's own expression type carries the `None` it short-circuits to, but the rest
+    /// of the chain must resolve against the present type: `a?.b.c` lowers to
+    /// `None if a is None else a.b.c`, which never reaches `.c` with an absent `a`. Folding
+    /// the `None` into each link instead would leave every later `.attr`, `(...)` or `[...]`
+    /// in the chain resolving against a value the lowering never produces.
+    ///
+    /// Only populated for links that can short-circuit, so a hit here doubles as "this
+    /// expression is a chain link that contributes a `None` to the end of its chain". An
+    /// attribute that is optional in its *own* right stays optional in the recorded type,
+    /// so `a?.cb()` still reports a possibly-`None` `cb`.
+    basedpython_chain_present: FxHashMap<ExpressionNodeKey, Type<'db>>,
+
     /// The creation-time type of a fluid specialization candidate, with literal types
     /// retained. Only set when this region is the standalone inference of the
     /// candidate's assigned value; uses of the binding re-solve their own prefix of the
@@ -421,6 +436,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             type_expression_flags: FxHashMap::default(),
             collection_use_constraints: FxHashMap::default(),
             fluid_adoptions: FxHashMap::default(),
+            basedpython_chain_present: FxHashMap::default(),
             fluid_creation: None,
             fluid_timeline: None,
             string_annotations: FxHashSet::default(),
@@ -5581,18 +5597,54 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
     }
 
+    /// Whether `expression`'s type may be shared through the multi-inference expression cache.
+    ///
+    /// A basedpython optional-chain link carries the present-receiver type that the rest of its
+    /// chain resolves against out of band, in [`Self::basedpython_chain_present`], which the
+    /// cache does not hold. Serving a link from the cache would strand the next link with the
+    /// short-circuit `None`, and would do so only on whichever speculative attempt happened to
+    /// miss the cache first.
+    fn is_expression_cacheable(&self, expression: &ast::Expr) -> bool {
+        !(self.is_basedpython_file() && is_basedpython_chain_link(expression))
+    }
+
+    fn cached_expression_type(
+        &self,
+        expression: &ast::Expr,
+        tcx: TypeContext<'db>,
+    ) -> Option<Type<'db>> {
+        let expression_cache = self.expression_cache.as_ref()?;
+        if !self.is_expression_cacheable(expression) {
+            return None;
+        }
+        expression_cache
+            .borrow()
+            .get(&(expression.into(), tcx))
+            .copied()
+    }
+
+    fn cache_expression_type(
+        &mut self,
+        expression: &ast::Expr,
+        tcx: TypeContext<'db>,
+        ty: Type<'db>,
+    ) {
+        if let Some(expression_cache) = &self.expression_cache
+            && self.is_expression_cacheable(expression)
+        {
+            expression_cache
+                .borrow_mut()
+                .insert((expression.into(), tcx), ty);
+        }
+    }
+
     /// Infer the type of an expression.
     fn infer_expression_impl(
         &mut self,
         expression: &ast::Expr,
         tcx: TypeContext<'db>,
     ) -> Type<'db> {
-        if let Some(ty) = self.expression_cache.as_ref().and_then(|expression_cache| {
-            expression_cache
-                .borrow()
-                .get(&(expression.into(), tcx))
-                .copied()
-        }) {
+        if let Some(ty) = self.cached_expression_type(expression, tcx) {
             self.store_expression_type(expression, ty);
             return ty;
         }
@@ -5601,12 +5653,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             && let Some(ty) = self.infer_type_form_contextual_expression(expression, target)
         {
             self.store_expression_type(expression, ty);
-
-            if let Some(expression_cache) = &self.expression_cache {
-                expression_cache
-                    .borrow_mut()
-                    .insert((expression.into(), tcx), ty);
-            }
+            self.cache_expression_type(expression, tcx, ty);
 
             return ty;
         }
@@ -5698,12 +5745,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         self.store_expression_type(expression, ty);
-
-        if let Some(expression_cache) = &self.expression_cache {
-            expression_cache
-                .borrow_mut()
-                .insert((expression.into(), tcx), ty);
-        }
+        self.cache_expression_type(expression, tcx, ty);
 
         ty
     }
@@ -8333,7 +8375,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let callable_type =
             self.infer_maybe_standalone_expression(&call_expression.func, TypeContext::default());
 
-        self.infer_call_expression_impl(call_expression, callable_type, tcx)
+        // basedpython `a?.b()`: the `?.` short-circuit covers the call too, matching the
+        // `None if a is None else a.b()` lowering, so call the present-receiver callable and
+        // let the `None` ride out to the end of the chain
+        let (callable_type, in_chain) =
+            self.basedpython_chain_receiver(&call_expression.func, callable_type);
+
+        let return_type = self.infer_call_expression_impl(call_expression, callable_type, tcx);
+
+        self.basedpython_chain_result(call_expression, return_type, in_chain)
     }
 
     fn infer_empty_list_or_set_constructor(
@@ -10257,18 +10307,75 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         crate::types::bound_super::BoundSuperType::build(db, pivot_class_type, owner_type).ok()
     }
 
+    /// Resolve `receiver` to the type the next link of a basedpython optional chain must be
+    /// looked up against, and report whether that chain can short-circuit.
+    ///
+    /// `receiver_type` is the receiver's own type, which already carries any short-circuit
+    /// `None`. See [`Self::basedpython_chain_present`].
+    fn basedpython_chain_receiver(
+        &self,
+        receiver: &ast::Expr,
+        receiver_type: Type<'db>,
+    ) -> (Type<'db>, bool) {
+        // every attribute, call and subscript asks; only a `.by` file that has already walked
+        // a `?.` can answer
+        if self.basedpython_chain_present.is_empty() {
+            return (receiver_type, false);
+        }
+        match self
+            .basedpython_chain_present
+            .get(&ExpressionNodeKey::from(receiver))
+        {
+            Some(present) => (*present, true),
+            None => (receiver_type, false),
+        }
+    }
+
+    /// Record a basedpython optional-chain link's present-receiver type and return the type
+    /// the link itself evaluates to.
+    ///
+    /// `short_circuits` is whether a `?.` anywhere in the chain can be absent; when it is,
+    /// the link evaluates to `present | None` and the chain carries on from `present`.
+    fn basedpython_chain_result(
+        &mut self,
+        link: impl Into<ExpressionNodeKey>,
+        present: Type<'db>,
+        short_circuits: bool,
+    ) -> Type<'db> {
+        if !short_circuits {
+            return present;
+        }
+        self.basedpython_chain_present.insert(link.into(), present);
+        UnionType::from_two_elements(self.db(), present, Type::none(self.db()))
+    }
+
     /// Infer the type of a [`ast::ExprAttribute`] expression, assuming a load context.
     fn infer_attribute_load(&mut self, attribute: &ast::ExprAttribute) -> Type<'db> {
         let value_type =
             self.infer_maybe_standalone_expression(&attribute.value, TypeContext::default());
-        self.infer_attribute_load_impl(attribute, value_type)
+        let (value_type, in_chain) = self.basedpython_chain_receiver(&attribute.value, value_type);
+        self.infer_attribute_load_chained(attribute, value_type, in_chain)
     }
 
-    /// Infer the type of a [`ast::ExprAttribute`] expression, assuming a load context.
+    /// Infer the type of a [`ast::ExprAttribute`] expression, assuming a load context and a
+    /// receiver that does not continue a basedpython optional chain.
     fn infer_attribute_load_impl(
         &mut self,
         attribute: &ast::ExprAttribute,
+        value_type: Type<'db>,
+    ) -> Type<'db> {
+        self.infer_attribute_load_chained(attribute, value_type, false)
+    }
+
+    /// Infer the type of a [`ast::ExprAttribute`] expression, assuming a load context.
+    ///
+    /// `in_chain` is whether `value_type` came from an already-short-circuiting basedpython
+    /// optional chain, which this access extends.
+    fn infer_attribute_load_chained(
+        &mut self,
+        attribute: &ast::ExprAttribute,
         mut value_type: Type<'db>,
+        in_chain: bool,
     ) -> Type<'db> {
         fn union_elements_missing_attribute<'db>(
             db: &'db dyn Db,
@@ -10294,7 +10401,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // narrow value_type to its non-None component for the attribute
         // lookup, then re-union with None at the end. records whether we
         // performed the narrowing so we know to re-add None
-        let mut none_chain_was_optional = false;
+        let mut none_chain_was_optional = in_chain;
         if self.is_basedpython_file() && attribute.optional {
             // a wrapped optional's present value is its inner type — peel the
             // wrapper before the lookup (the runtime reads `.value`); the
@@ -10341,7 +10448,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             && let Some(spec) = value_type.exact_tuple_instance_spec(db)
             && let Ok(element_ty) = (&*spec).py_index(db, index)
         {
-            return element_ty;
+            return self.basedpython_chain_result(attribute, element_ty, none_chain_was_optional);
         }
 
         if let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) = value_type
@@ -10628,10 +10735,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         // basedpython `?.`: short-circuit returns None on a None receiver, so
         // the overall expression type is the attribute type unioned with None
-        if none_chain_was_optional {
-            return UnionType::from_two_elements(db, final_type, Type::none(db));
-        }
-        final_type
+        self.basedpython_chain_result(attribute, final_type, none_chain_was_optional)
     }
 
     fn infer_attribute_expression(&mut self, attribute: &ast::ExprAttribute) -> Type<'db> {
@@ -11266,6 +11370,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // builder only state
             expression_cache: _,
+            basedpython_chain_present: _,
             reachability_cache: _,
             typevar_binding_context: _,
             deferred_state: _,
@@ -11358,6 +11463,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // builder only state
             expression_cache: _,
+            basedpython_chain_present: _,
             reachability_cache: _,
             dataclass_field_specifiers: _,
             slice_materialization: _,
@@ -11457,6 +11563,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             bindings,
             called_functions,
             expression_cache: _,
+            basedpython_chain_present: _,
             reachability_cache: _,
             declarations: _,
             deferred: _,
@@ -11522,6 +11629,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // builder only state
             expression_cache: _,
+            basedpython_chain_present: _,
             reachability_cache: _,
             dataclass_field_specifiers: _,
             slice_materialization: _,
@@ -11671,6 +11779,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // Builder only state
             expression_cache: _,
+            basedpython_chain_present: _,
             reachability_cache: _,
             dataclass_field_specifiers: _,
             slice_materialization: _,
@@ -11742,6 +11851,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             fluid_creation: _,
             fluid_timeline: _,
             fluid_adoptions: _,
+            basedpython_chain_present: _,
             collection_use_constraints: _,
             expressions: _,
             string_annotations: _,
@@ -11812,6 +11922,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // builder only state
             expression_cache: _,
+            basedpython_chain_present,
             reachability_cache: _,
             typevar_binding_context: _,
             deferred_state: _,
@@ -11850,6 +11961,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         self.fluid_adoptions.extend(fluid_adoptions);
+
+        // adopting the speculative builder's expression types means adopting the optional-chain
+        // provenance of those same expressions, or a chain this region goes on to extend would
+        // resolve its next link against a short-circuit `None`
+        self.basedpython_chain_present
+            .extend(basedpython_chain_present);
 
         #[expect(
             clippy::iter_over_hash_type,
@@ -11939,6 +12056,23 @@ fn is_collection_literal(expression: &ast::Expr) -> bool {
         expression,
         ast::Expr::List(_) | ast::Expr::Set(_) | ast::Expr::Dict(_)
     )
+}
+
+/// Returns `true` if `expression` is a link of a basedpython optional chain: a `?.` access, or a
+/// trailer applied to one.
+///
+/// A chain runs from its first `?.` out through the trailers that follow it, exactly as far as the
+/// `None if a is None else <rest of chain>` lowering short-circuits. `a?.b.c()[0]` is one chain of
+/// four links, so an absent `a` skips all of `.b`, `.c`, `()` and `[0]`.
+fn is_basedpython_chain_link(expression: &ast::Expr) -> bool {
+    match expression {
+        ast::Expr::Attribute(attribute) => {
+            attribute.optional || is_basedpython_chain_link(&attribute.value)
+        }
+        ast::Expr::Call(call) => is_basedpython_chain_link(&call.func),
+        ast::Expr::Subscript(subscript) => is_basedpython_chain_link(&subscript.value),
+        _ => false,
+    }
 }
 
 /// Returns `true` if applying type context to the given expression may be deferred after inference.

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -187,14 +187,21 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     ) -> Type<'db> {
         let value_ty = self.infer_expression(&subscript.value, TypeContext::default());
 
+        // basedpython `a?.b[0]`: the `?.` short-circuit covers the subscript too, matching the
+        // `None if a is None else a.b[0]` lowering, so index the present-receiver value and
+        // let the `None` ride out to the end of the chain
+        let (value_ty, in_chain) = self.basedpython_chain_receiver(&subscript.value, value_ty);
+
         // If we have an implicit type alias like `MyList = list[T]`, and if `MyList` is being
         // used in another implicit type alias like `Numbers = MyList[int]`, then we infer the
         // right hand side as a value expression, and need to handle the specialization here.
-        if value_ty.is_generic_alias() {
-            return self.infer_explicit_type_alias_specialization(subscript, value_ty, false);
-        }
+        let ty = if value_ty.is_generic_alias() {
+            self.infer_explicit_type_alias_specialization(subscript, value_ty, false)
+        } else {
+            self.infer_subscript_load_impl(value_ty, subscript, tcx)
+        };
 
-        self.infer_subscript_load_impl(value_ty, subscript, tcx)
+        self.basedpython_chain_result(subscript, ty, in_chain)
     }
 
     pub(super) fn infer_subscript_load_impl(

--- a/docs/basedpython/features/optional-chaining.md
+++ b/docs/basedpython/features/optional-chaining.md
@@ -9,8 +9,13 @@ city = user?.address.city
 transpiles to:
 
 ```python
-city = None if user is None else user.address.city
+city = (None if user is None else user.address.city)
 ```
+
+the expansion is always parenthesized. a conditional expression binds looser
+than every operator, so without them the chain would swallow whatever followed
+it — `not user?.name` would evaluate to `user.name` rather than to
+`not user.name`
 
 ## chains
 
@@ -24,7 +29,7 @@ country = user?.address?.country
 transpiles to:
 
 ```python
-country = None if user is None else None if (_t := user.address) is None else _t.country
+country = (None if user is None else None if (_t := user.address) is None else _t.country)
 ```
 
 mixed chains — `?.` followed by regular `.` — only guard at the explicit
@@ -32,19 +37,71 @@ optional steps:
 
 ```by
 zip = user?.address.zip
-# → None if user is None else user.address.zip
+# → (None if user is None else user.address.zip)
 ```
 
 `a.b?.c` works in the obvious way: only the part after `a.b` is short-circuited
 through a temp variable
 
+## the chain runs to the end of the trailers
+
+a `?.` opens a chain that runs out through every trailer that follows it —
+`.attr`, `(...)` and `[...]`. an absent receiver skips the whole rest of the
+chain, so the `None` belongs to the chain's last link rather than to each link:
+
+```by
+name = user?.profile.display_name()
+# → (None if user is None else user.profile.display_name())
+```
+
+method calls, subscripts and further attribute access all chain, in any
+combination:
+
+```by
+first = user?.orders[0].total()
+# → (None if user is None else user.orders[0].total())
+```
+
+the type of a chain is the type of its last link unioned with `None`, so
+`user?.profile.display_name()` is `str | None`. `?.` only contributes a `None`
+when its receiver can actually be absent — a chain over a non-optional receiver
+stays non-optional
+
+## `?.` guards its own receiver, not the rest of the chain
+
+each `?.` guards the value immediately to its left. an attribute that is
+optional in its *own* right is still reported:
+
+```by
+class User:
+    cb: Callable[[], int] | None
+    address: Address | None
+
+user?.cb()          # error: `cb` may be None
+user?.address.city  # error: `address` may be None
+```
+
+add a `?.` at the step that needs guarding — `user?.address?.city` is
+`str | None`
+
 ## scope
 
-`?.` is recognized in attribute-access expressions only. method calls,
-subscripts, and arbitrary call expressions on the optional value are not yet
-supported in the surface syntax — fall back to a guard expression
+`?.` is recognized in attribute-access expressions only. there is no optional
+call (`a?.()`) or optional subscript (`a?.[k]`) — those would guard the
+*callable* or the *container* rather than a receiver, and are a syntax error.
+where you need them, fall back to a guard expression
+
+a chain covers the trailers that follow it, and stops there — it does not
+extend over the enclosing expression. `user?.age + 1` is rejected, because the
+chain ends at `user?.age` and `int | None` has no `+`. write
+`(user?.age ?? 0) + 1`
 
 ## interaction with `??`
 
 see [none-coalesce operator](none-coalesce.md). `?.` composes with `??`
-without re-evaluating the chained prefix
+without re-evaluating the chained prefix, including when the chain ends in a
+call:
+
+```by
+name = user?.profile.display_name() ?? "anonymous"
+```


### PR DESCRIPTION
the chain-None was folded in at each link, so every trailer after a `?.` — `.attr`, `()`, `[...]` — resolved against a `None` the lowering never produces. `a?.b()` reported call-non-callable and the documented `user?.address.zip` didn't check either.

links now carry their present-receiver type out of band and union `None` once, at the end of the chain. an attribute optional in its own right stays optional, so `a?.cb()` still reports a possibly-None `cb`.

the lowering already emitted correct python (the conditional binds looser than any trailer); tests lock that in.

parenthesize the optional chain so it matches its parse

the expansion covered only the `?.` access and let python's precedence swallow the trailers. a conditional binds looser than every operator, so anything after the chain was regrouped into the else branch, against the tree that was parsed:

    not a?.b        -> not None if a is None else a.b     # yields a.b
    a?.b == z       -> None if a is None else a.b == z    # yields None
    a?.b if z else w                                      # ignored z
    -a?.b                                                 # evaluates -None
    [i for i in a?.b]                                     # did not parse

ty accepts the first three, so they were silent wrong answers. the edit now spans the whole chain and parenthesizes it; trailers pass through as `Src` so chains nested in them still expand.

cover wrapped-optional chains through calls and trailers
