### PR TITLE
implement a lot more parametric type tests

### DIFF
--- a/crates/by_transforms/src/transforms/ast_driver.rs
+++ b/crates/by_transforms/src/transforms/ast_driver.rs
@@ -16,9 +16,9 @@
 //!   particular original statement — e.g. anon-NT class synthesis)
 //! - declare required imports (full `import …` / `from … import …` lines
 //!   that the driver prepends to the source)
-//! - declare pre-source text deletions for pure-deletion rewrites that
-//!   would otherwise leak when an outer transform copies operand source
-//!   verbatim (variance keyword stripping)
+//! - declare sub-statement text edits, for rewrites that would otherwise leak
+//!   when an outer transform copies operand source verbatim (variance keyword
+//!   blanking)
 //!
 //! AST passes always engage — there is no gate. The text-edit pipeline
 //! is intentionally not invoked for any construct an AST pass handles.
@@ -309,30 +309,29 @@ fn merge_from_imports(lines: Vec<String>) -> Vec<String> {
 ///
 /// `project`, when `Some`, supplies the real project db + file so type-aware
 /// passes resolve cross-module imports (e.g. an imported generic function for
-/// `generic_call`). It is used only when use-site variance stripping is a
-/// no-op — a variance rewrite shifts byte positions, so the project parse
-/// would no longer align with `source_ref` and we fall back to a single-file
-/// db. The chosen db owns the parse the type-aware passes query: `inferred_type`
-/// does AST node-identity lookups, so the model and the walked suite must come
-/// from one db
+/// `generic_call`). The chosen db owns the parse the type-aware passes query:
+/// `inferred_type` does AST node-identity lookups, so the model and the walked
+/// suite must come from one db
 pub(crate) fn run_against_source<'a>(
     source: &'a str,
     config: &Config,
     project: Option<(&dyn ty_python_semantic::Db, ruff_db::files::File)>,
 ) -> (Cow<'a, str>, Vec<String>, Vec<Option<u32>>) {
-    // strip use-site variance up front; downstream passes (callable,
+    // blank use-site variance out up front; downstream passes (callable,
     // intersection) copy operand source verbatim and would leak `out`/`in`
-    // keywords otherwise
-    let stripped = use_site_variance::strip(source);
-    let source_ref: &str = stripped.as_ref();
+    // keywords otherwise. blanking is length-preserving, so every range below
+    // is valid in both the original and the blanked source
+    let blanked = use_site_variance::blank(source);
+    let source_ref: &str = blanked.source.as_ref();
 
-    // pick the db backing the type-aware passes: the project db when present
-    // and the source is byte-identical after stripping (so cross-module
-    // imports resolve), otherwise a single-file in-memory db
+    // the db keeps the *original* source, markers and all, so ty can answer
+    // questions that depend on a use-site projection (`x is A[out int]`).
+    // that's sound precisely because blanking preserves byte positions: the
+    // db's parse and the blanked parse below agree on every node's range
     let sem = match project {
-        Some((pdb, pfile)) if matches!(stripped, Cow::Borrowed(_)) => SemDb::Project(pdb, pfile),
-        _ => {
-            let (db, file) = crate::make_in_memory_db(source_ref);
+        Some((pdb, pfile)) => SemDb::Project(pdb, pfile),
+        None => {
+            let (db, file) = crate::make_in_memory_db(source);
             SemDb::Local(db, file)
         }
     };
@@ -346,19 +345,13 @@ pub(crate) fn run_against_source<'a>(
     // identity line table for the no-change early returns: stripping variance
     // is within-line, so every line still maps to itself
     if !parsed_handle.errors().is_empty() {
-        let cow = match stripped {
-            Cow::Borrowed(_) => Cow::Borrowed(source),
-            Cow::Owned(s) => Cow::Owned(s),
-        };
+        let cow = blanked.stripped(source);
         let table = crate::source_map::line_table(cow.as_ref(), &[]);
         return (cow, Vec::new(), table);
     }
     let parsed = parse_unchecked_source(source_ref, PySourceType::BasedPython);
     if !parsed.errors().is_empty() {
-        let cow = match stripped {
-            Cow::Borrowed(_) => Cow::Borrowed(source),
-            Cow::Owned(s) => Cow::Owned(s),
-        };
+        let cow = blanked.stripped(source);
         let table = crate::source_map::line_table(cow.as_ref(), &[]);
         return (cow, Vec::new(), table);
     }
@@ -633,6 +626,16 @@ pub(crate) fn run_against_source<'a>(
             .push("from typing_extensions import Sentinel".to_owned());
     }
 
+    // collapse the padding `blank` left behind. these are ordinary edits, so a
+    // statement an AST pass re-rendered (which never had the marker in its
+    // AST) and a wider template edit (which materializes them inside its `Src`
+    // spans) both come out clean; only a wider *plain* text edit keeps the
+    // padding, which is valid Python either way
+    for range in &blanked.ranges {
+        ctx.text_edits
+            .push((*range, use_site_variance::collapsed_to(source_ref, *range)));
+    }
+
     ctx.required_imports.sort();
     ctx.required_imports.dedup();
     ctx.required_imports = merge_from_imports(std::mem::take(&mut ctx.required_imports));
@@ -646,10 +649,7 @@ pub(crate) fn run_against_source<'a>(
         && ctx.template_edits.is_empty()
         && ctx.epilogue.is_empty()
     {
-        let cow = match stripped {
-            Cow::Borrowed(_) => Cow::Borrowed(source),
-            Cow::Owned(s) => Cow::Owned(s),
-        };
+        let cow = blanked.stripped(source);
         let table = crate::source_map::line_table(cow.as_ref(), &[]);
         return (cow, ctx.errors, table);
     }

--- a/crates/by_transforms/src/transforms/identity_swap.rs
+++ b/crates/by_transforms/src/transforms/identity_swap.rs
@@ -6,11 +6,19 @@
 use ruff_python_ast::visitor::{Visitor, walk_expr, walk_stmt};
 use ruff_python_ast::{
     Arguments, AtomicNodeIndex, CmpOp, Expr, ExprCall, ExprContext, ExprName, ExprUnaryOp,
-    ModModule, Stmt, UnaryOp, name::Name,
+    ModModule, Operator, Stmt, UnaryOp, name::Name,
 };
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use super::ast_driver::{AstPass, PassContext, render_expr};
+
+/// whether the type-aware `parametric_is` pass owns lowering this `is`-rhs, so
+/// `identity_swap` must leave it alone. it owns a name / attribute / subscript
+/// target (may name a specialization or alias) and a `|` union of them
+fn owned_by_parametric_is(rhs: &Expr) -> bool {
+    matches!(rhs, Expr::Name(_) | Expr::Attribute(_) | Expr::Subscript(_))
+        || matches!(rhs, Expr::BinOp(binop) if binop.op == Operator::BitOr)
+}
 
 pub(crate) struct IdentitySwap<'src> {
     source: &'src str,
@@ -59,11 +67,7 @@ impl State<'_> {
                         }
                     } else if trimmed == "is"
                         && !rhs.is_literal_expr()
-                        // a subscripted rhs may be a parametric type test
-                        // (`x is list[int]`); the type-aware parametric_is
-                        // pass lowers those (and falls back to isinstance
-                        // for value subscripts)
-                        && !matches!(rhs, Expr::Subscript(_))
+                        && !owned_by_parametric_is(rhs)
                     {
                         let call = isinstance_call(lhs.clone(), rhs.clone(), false);
                         let pair_range = TextRange::new(lhs.range().start(), rhs.range().end());
@@ -78,7 +82,7 @@ impl State<'_> {
                                 TextRange::new(op_start, op_start + TextSize::from(3u32));
                             self.edits.push((op_range, "is not".to_owned()));
                         }
-                    } else if !rhs.is_literal_expr() && !matches!(rhs, Expr::Subscript(_)) {
+                    } else if !rhs.is_literal_expr() && !owned_by_parametric_is(rhs) {
                         let call = isinstance_call(lhs.clone(), rhs.clone(), true);
                         let pair_range = TextRange::new(lhs.range().start(), rhs.range().end());
                         self.edits.push((pair_range, render_expr(&call)));

--- a/crates/by_transforms/src/transforms/parametric_is.rs
+++ b/crates/by_transforms/src/transforms/parametric_is.rs
@@ -23,6 +23,10 @@
 //!   no element-witness heuristic: an empty `list[int]` has no element, and a
 //!   builtin's element type is erased, so "check the first item" is unsound
 //!
+//! a union rhs (`x is A[int] | object`) is the disjunction of its arms — each
+//! arm lowered by its own kind — never a runtime `isinstance(x, A[int] |
+//! object)`, which a parameterized arm makes a `TypeError`
+//!
 //! a subscripted rhs that is *not* a generic class (`x is candidates[0]`)
 //! falls back to the ordinary `isinstance` lowering that
 //! [`identity_swap`](super::identity_swap) applies to every other rhs
@@ -33,7 +37,7 @@ use ruff_text_size::{Ranged, TextRange};
 use ty_python_semantic::reified::is_keyword_comparison;
 use ty_python_semantic::{ArgVariance, ParametricIsPlan};
 
-use super::ast_driver::{PassContext, TypeAwarePass};
+use super::ast_driver::{Fragment, PassContext, TypeAwarePass};
 use crate::type_info::TypeInfo;
 
 /// probes a value's `__orig_class__` against a target alias — the runtime
@@ -62,6 +66,7 @@ pub(crate) fn variance_tuple(variances: &[u8]) -> String {
 
 pub(crate) const PARAMETRIC_IS_RUNTIME: &str = "\
 def _parametric_is(value, alias, variances):
+    alias = getattr(alias, \"__value__\", alias)
     origin = getattr(alias, \"__origin__\", alias)
     if not isinstance(value, origin):
         return False
@@ -98,15 +103,11 @@ def _parametric_is_sub(a, b):
 struct ParametricIs<'src, 'ti> {
     source: &'src str,
     types: &'ti dyn TypeInfo,
-    edits: Vec<(TextRange, String)>,
+    edits: Vec<(TextRange, Vec<Fragment>)>,
     needs_probe: bool,
 }
 
 impl ParametricIs<'_, '_> {
-    fn src(&self, range: TextRange) -> &str {
-        &self.source[usize::from(range.start())..usize::from(range.end())]
-    }
-
     /// whether replacing the pair may drop the lhs without losing effects
     fn effect_free(lhs: &Expr) -> bool {
         matches!(lhs, Expr::Name(_)) || lhs.is_literal_expr()
@@ -114,51 +115,57 @@ impl ParametricIs<'_, '_> {
 
     /// the folded / token result expression, with the lhs kept alive when it
     /// may have effects (`(g(), True)[1]` evaluates then discards it)
-    fn with_lhs_effects(&self, lhs: &Expr, result: String) -> String {
+    fn with_lhs_effects(lhs: &Expr, result: Vec<Fragment>) -> Vec<Fragment> {
         if Self::effect_free(lhs) {
-            result
-        } else {
-            format!("({}, {result})[1]", self.src(lhs.range()))
+            return result;
         }
+        let mut frags = vec![Fragment::Lit("(".to_owned()), Fragment::Src(lhs.range())];
+        frags.push(Fragment::Lit(", ".to_owned()));
+        frags.extend(result);
+        frags.push(Fragment::Lit(")[1]".to_owned()));
+        frags
     }
 
-    fn lower_pair(&mut self, lhs: &Expr, rhs: &ast::ExprSubscript, negate: bool) -> String {
+    fn lower_pair(&mut self, lhs: &Expr, rhs: &Expr, negate: bool) -> Vec<Fragment> {
         let Some(plan) = self.types.parametric_is_plan(lhs, rhs) else {
-            // not a generic-class rhs — the ordinary isinstance lowering
-            // identity_swap applies everywhere else
-            let call = format!(
-                "isinstance({}, {})",
-                self.src(lhs.range()),
-                self.src(rhs.range())
-            );
-            return if negate { format!("not {call}") } else { call };
+            // rhs is a bare class or a plain value, not a specialization — the
+            // ordinary isinstance lowering that identity_swap used to emit
+            let open = if negate {
+                "not isinstance("
+            } else {
+                "isinstance("
+            };
+            return vec![
+                Fragment::Lit(open.to_owned()),
+                Fragment::Src(lhs.range()),
+                Fragment::Lit(", ".to_owned()),
+                Fragment::Src(rhs.range()),
+                Fragment::Lit(")".to_owned()),
+            ];
         };
         match plan {
-            // a builtin-target probe can never be true (ty reports the
-            // error); lower it to the constant it always is
-            ParametricIsPlan::Fold(false) | ParametricIsPlan::ErasedTarget => {
+            // an erased-target probe (builtin or protocol) can never be true
+            // (ty reports the error); lower it to the constant it always is
+            ParametricIsPlan::Fold(false) | ParametricIsPlan::ErasedTarget(_) => {
                 let value = if negate { "True" } else { "False" };
-                self.with_lhs_effects(lhs, value.to_owned())
+                Self::with_lhs_effects(lhs, vec![Fragment::Lit(value.to_owned())])
             }
             ParametricIsPlan::Fold(true) => {
                 let value = if negate { "False" } else { "True" };
-                self.with_lhs_effects(lhs, value.to_owned())
+                Self::with_lhs_effects(lhs, vec![Fragment::Lit(value.to_owned())])
             }
             ParametricIsPlan::TokenEq(tokens) => {
-                let comparisons = tokens
-                    .iter()
-                    .map(|(name, target)| format!("{name} == {}", self.src(*target)))
-                    .collect::<Vec<_>>()
-                    .join(" and ");
-                let check = if negate {
-                    format!("not ({comparisons})")
-                } else {
-                    format!("({comparisons})")
-                };
-                self.with_lhs_effects(lhs, check)
+                let mut frags = vec![Fragment::Lit(if negate { "not (" } else { "(" }.to_owned())];
+                for (index, (name, target)) in tokens.iter().enumerate() {
+                    let lead = if index == 0 { "" } else { " and " };
+                    frags.push(Fragment::Lit(format!("{lead}{name} == ")));
+                    frags.push(Fragment::Src(*target));
+                }
+                frags.push(Fragment::Lit(")".to_owned()));
+                Self::with_lhs_effects(lhs, frags)
             }
             // a user-defined generic target carries `__orig_class__`; probe it,
-            // matching each type argument by the target's declared variance
+            // matching each type argument by the target's effective variance
             ParametricIsPlan::Probe(variances) => {
                 self.needs_probe = true;
                 let codes = variances
@@ -175,29 +182,172 @@ impl ParametricIs<'_, '_> {
                     [single] => format!("({single},)"),
                     _ => format!("({})", codes.join(", ")),
                 };
-                let call = format!(
-                    "_parametric_is({}, {}, {tuple})",
-                    self.src(lhs.range()),
-                    self.src(rhs.range())
-                );
-                if negate { format!("not {call}") } else { call }
+                let open = if negate {
+                    "not _parametric_is("
+                } else {
+                    "_parametric_is("
+                };
+                vec![
+                    Fragment::Lit(open.to_owned()),
+                    Fragment::Src(lhs.range()),
+                    Fragment::Lit(", ".to_owned()),
+                    Fragment::Src(rhs.range()),
+                    Fragment::Lit(format!(", {tuple})")),
+                ]
             }
         }
+    }
+
+    /// one arm of a union `is`-target: its bare (non-negated) test, referencing
+    /// the value through `value` rather than the lhs directly so the caller can
+    /// bind the lhs once and share it across arms. no lhs-effect wrapping here —
+    /// the union combiner evaluates the lhs exactly once for the whole test
+    fn lower_arm(&mut self, value: &dyn Fn() -> Fragment, lhs: &Expr, arm: &Expr) -> Vec<Fragment> {
+        // a `None` arm (an `X | None` optional) is an identity check, not
+        // `isinstance(_, None)` — `None` is a value, not a class
+        if matches!(arm, Expr::NoneLiteral(_)) {
+            return vec![value(), Fragment::Lit(" is None".to_owned())];
+        }
+        let Some(plan) = self.types.parametric_is_plan(lhs, arm) else {
+            return vec![
+                Fragment::Lit("isinstance(".to_owned()),
+                value(),
+                Fragment::Lit(", ".to_owned()),
+                Fragment::Src(arm.range()),
+                Fragment::Lit(")".to_owned()),
+            ];
+        };
+        match plan {
+            // an erased arm can't be checked at runtime; ty reports the error
+            // (a union arm may not silently fold to `False` — that would be
+            // unsound — so the checker rejects it), and the lowering is the
+            // constant the standalone form uses
+            ParametricIsPlan::Fold(false) | ParametricIsPlan::ErasedTarget(_) => {
+                vec![Fragment::Lit("False".to_owned())]
+            }
+            ParametricIsPlan::Fold(true) => vec![Fragment::Lit("True".to_owned())],
+            ParametricIsPlan::TokenEq(tokens) => {
+                let mut frags = vec![Fragment::Lit("(".to_owned())];
+                for (index, (name, target)) in tokens.iter().enumerate() {
+                    let lead = if index == 0 { "" } else { " and " };
+                    frags.push(Fragment::Lit(format!("{lead}{name} == ")));
+                    frags.push(Fragment::Src(*target));
+                }
+                frags.push(Fragment::Lit(")".to_owned()));
+                frags
+            }
+            ParametricIsPlan::Probe(variances) => {
+                self.needs_probe = true;
+                let codes: Vec<u8> = variances
+                    .iter()
+                    .map(|variance| match variance {
+                        ArgVariance::Invariant => 0,
+                        ArgVariance::Covariant => 1,
+                        ArgVariance::Contravariant => 2,
+                        ArgVariance::Bivariant => 3,
+                    })
+                    .collect();
+                vec![
+                    Fragment::Lit("_parametric_is(".to_owned()),
+                    value(),
+                    Fragment::Lit(", ".to_owned()),
+                    Fragment::Src(arm.range()),
+                    Fragment::Lit(format!(", {})", variance_tuple(&codes))),
+                ]
+            }
+        }
+    }
+
+    /// `lhs is (T1 | T2 | …)` — a test against a union type — is the disjunction
+    /// of the per-arm tests (`type(lhs) <: Ti` for any arm). the lhs is bound
+    /// once: referenced directly when it has no effects, else through a lambda
+    /// parameter so the arms share a single evaluation
+    fn lower_union(&mut self, lhs: &Expr, arms: &[&Expr], negate: bool) -> Vec<Fragment> {
+        let via_lambda = !Self::effect_free(lhs);
+        let value = || {
+            if via_lambda {
+                Fragment::Lit(UNION_VALUE_PARAM.to_owned())
+            } else {
+                Fragment::Src(lhs.range())
+            }
+        };
+        let mut inner: Vec<Fragment> = Vec::new();
+        for (index, arm) in arms.iter().enumerate() {
+            if index > 0 {
+                inner.push(Fragment::Lit(" or ".to_owned()));
+            }
+            inner.extend(self.lower_arm(&value, lhs, arm));
+        }
+        let mut frags = Vec::new();
+        if via_lambda {
+            frags.push(Fragment::Lit(format!(
+                "{}(lambda {UNION_VALUE_PARAM}: ",
+                if negate { "not " } else { "" }
+            )));
+            frags.extend(inner);
+            frags.push(Fragment::Lit(")(".to_owned()));
+            frags.push(Fragment::Src(lhs.range()));
+            frags.push(Fragment::Lit(")".to_owned()));
+        } else {
+            frags.push(Fragment::Lit(if negate { "not (" } else { "(" }.to_owned()));
+            frags.extend(inner);
+            frags.push(Fragment::Lit(")".to_owned()));
+        }
+        frags
     }
 
     fn process_compare(&mut self, compare: &ast::ExprCompare) {
         let mut lhs: &Expr = &compare.left;
         for (op, rhs) in compare.ops.iter().zip(&compare.comparators) {
+            // identity_swap defers every non-literal name/attribute/subscript
+            // and union `is`-rhs to this pass, which owns the
+            // isinstance-vs-parametric decision (a bare class → isinstance, a
+            // specialization or an alias to one → a parametric test, a union →
+            // the disjunction of the arms)
             if matches!(op, CmpOp::Is | CmpOp::IsNot)
-                && let Expr::Subscript(subscript) = rhs
                 && is_keyword_comparison(self.source, *op, lhs, rhs)
             {
-                let replacement = self.lower_pair(lhs, subscript, matches!(op, CmpOp::IsNot));
-                let pair_range = TextRange::new(lhs.range().start(), rhs.range().end());
-                self.edits.push((pair_range, replacement));
+                let negate = matches!(op, CmpOp::IsNot);
+                let replacement =
+                    if matches!(rhs, Expr::Name(_) | Expr::Attribute(_) | Expr::Subscript(_)) {
+                        Some(self.lower_pair(lhs, rhs, negate))
+                    } else {
+                        union_arms(rhs).map(|arms| self.lower_union(lhs, &arms, negate))
+                    };
+                if let Some(replacement) = replacement {
+                    let pair_range = TextRange::new(lhs.range().start(), rhs.range().end());
+                    self.edits.push((pair_range, replacement));
+                }
             }
             lhs = rhs;
         }
+    }
+}
+
+/// the lambda parameter that binds an effectful union-test lhs for its arms.
+/// unlikely to collide: an `is`-target arm is a type expression, and this name
+/// would have to appear free inside one
+const UNION_VALUE_PARAM: &str = "_by_is_value";
+
+/// the flat arms of a union type expression (`A | B | C` → `[A, B, C]`), or
+/// `None` when `expr` is not a `|` union
+fn union_arms(expr: &Expr) -> Option<Vec<&Expr>> {
+    if !matches!(expr, Expr::BinOp(binop) if binop.op == ast::Operator::BitOr) {
+        return None;
+    }
+    let mut arms = Vec::new();
+    collect_union_arms(expr, &mut arms);
+    Some(arms)
+}
+
+fn collect_union_arms<'a>(expr: &'a Expr, arms: &mut Vec<&'a Expr>) {
+    if let Expr::BinOp(binop) = expr
+        && binop.op == ast::Operator::BitOr
+    {
+        collect_union_arms(&binop.left, arms);
+        collect_union_arms(&binop.right, arms);
+    } else {
+        arms.push(expr);
     }
 }
 
@@ -243,7 +393,7 @@ impl TypeAwarePass for ParametricIsPass<'_> {
         if inner.needs_probe {
             ctx.required_imports.push(PARAMETRIC_IS_RUNTIME.to_owned());
         }
-        ctx.text_edits.extend(inner.edits);
+        ctx.template_edits.extend(inner.edits);
     }
 }
 
@@ -323,6 +473,333 @@ mod tests {
         assert!(
             out.contains("return _parametric_is(a, A[object], (1,))"),
             "covariant probe carries variance code 1: {out}"
+        );
+    }
+
+    #[test]
+    fn use_site_covariant_target_probes_covariantly() {
+        // `A[out int]` projects an invariant `T` covariantly for this one
+        // test, so the probe matches with code 1 — and the target renders as
+        // plain `A[int]`, the keyword having no runtime spelling
+        let out = out(indoc! {"
+            class A[in out T]:
+                def __init__(self): ...
+            def f(a: A[*]) -> bool:
+                return a is A[out int]
+        "});
+        assert!(
+            out.contains("return _parametric_is(a, A[int], (1,))"),
+            "use-site `out` probes covariantly: {out}"
+        );
+    }
+
+    #[test]
+    fn use_site_contravariant_target_probes_contravariantly() {
+        let out = out(indoc! {"
+            class S[in out T]:
+                def __init__(self): ...
+            def f(s: S[*]) -> bool:
+                return s is S[in bool]
+        "});
+        assert!(
+            out.contains("return _parametric_is(s, S[bool], (2,))"),
+            "use-site `in` probes contravariantly: {out}"
+        );
+    }
+
+    #[test]
+    fn unprojected_invariant_target_probes_invariantly() {
+        // the counterpart to the two above: without a projection an invariant
+        // `T` keeps demanding an exact match
+        let out = out(indoc! {"
+            class A[in out T]:
+                def __init__(self): ...
+            def f(a: A[*]) -> bool:
+                return a is A[int]
+        "});
+        assert!(
+            out.contains("return _parametric_is(a, A[int], (0,))"),
+            "no projection stays invariant: {out}"
+        );
+    }
+
+    #[test]
+    fn use_site_covariant_target_folds_true() {
+        // `A[bool]` is an `A[out int]` statically, so this folds rather than
+        // probing — the fold must agree with assignability, not contradict it
+        let out = out(indoc! {"
+            class A[in out T]:
+                def __init__(self): ...
+            def f(a: A[bool]) -> bool:
+                return a is A[out int]
+        "});
+        assert!(
+            out.contains("return True"),
+            "A[bool] is an A[out int]: {out}"
+        );
+    }
+
+    #[test]
+    fn use_site_variance_on_declared_covariant_target_is_a_no_op() {
+        // a declared `out T` already covers what the projection could give
+        let out = out(indoc! {"
+            class A[out T]:
+                def __init__(self): ...
+            def f(a: object) -> bool:
+                return a is A[out object]
+        "});
+        assert!(
+            out.contains("return _parametric_is(a, A[object], (1,))"),
+            "declared variance wins: {out}"
+        );
+    }
+
+    #[test]
+    fn reified_tuple_target_compares_each_cell() {
+        // a `tuple[T, U]` value unifies against the tuple target position by
+        // position — the `Tuple::Fixed` unify branch
+        let out = out(indoc! {"
+            def f[T, U](x: tuple[T, U]) -> bool:
+                return x is tuple[int, str]
+        "});
+        assert!(
+            out.contains("return (T == int and U == str)"),
+            "tuple target compares each cell: {out}"
+        );
+    }
+
+    #[test]
+    fn nested_generic_value_unifies_recursively() {
+        // `A[list[T]]` reaches `T` through two levels; the unify descends the
+        // target structure to the cell
+        let out = out(indoc! {"
+            class A[T]:
+                def __init__(self): ...
+            def f[T](x: A[list[T]]) -> bool:
+                return x is A[list[int]]
+        "});
+        assert!(
+            out.contains("return (T == int)"),
+            "nested value unifies to the inner cell: {out}"
+        );
+    }
+
+    #[test]
+    fn multi_param_probe_carries_a_variance_per_param() {
+        // two invariant parameters → a two-entry variance tuple, exercising the
+        // plural branch of the tuple spelling and the polyfill's per-arg loop
+        let out = out(indoc! {"
+            class Pair[K, V]:
+                def __init__(self, k: K, v: V):
+                    self.k: K = k
+                    self.v: V = v
+            def f(x: object) -> bool:
+                return x is Pair[int, str]
+        "});
+        assert!(
+            out.contains("return _parametric_is(x, Pair[int, str], (0, 0))"),
+            "one variance code per parameter: {out}"
+        );
+    }
+
+    #[test]
+    fn bivariant_typevar_probes_with_code_three() {
+        // a parameter unused in the class body is bivariant; the probe matches
+        // either way (code 3)
+        let out = out(indoc! {"
+            class Box[T]:
+                def __init__(self): ...
+            def f(x: object) -> bool:
+                return x is Box[int]
+        "});
+        assert!(
+            out.contains("return _parametric_is(x, Box[int], (3,))"),
+            "bivariant parameter probes with code 3: {out}"
+        );
+    }
+
+    #[test]
+    fn declared_contravariant_dynamic_probes_with_code_two() {
+        // the counterpart to `covariant_dynamic_probes_with_variance` for a
+        // declared `in T` — the probe carries variance code 2
+        let out = out(indoc! {"
+            class Sink[in T]:
+                def __init__(self): ...
+                def put(self, x: T) -> None: ...
+            def f(x: object) -> bool:
+                return x is Sink[int]
+        "});
+        assert!(
+            out.contains("return _parametric_is(x, Sink[int], (2,))"),
+            "declared contravariant probes with code 2: {out}"
+        );
+    }
+
+    #[test]
+    fn protocol_target_probe_becomes_false() {
+        // a protocol target can't be probed (its instances never carry a
+        // matching `__orig_class__`); ty reports the error and the lowering is
+        // the constant it always is, with no polyfill
+        let out = out(indoc! {"
+            from typing import Protocol
+            class P[T](Protocol):
+                def get(self) -> T: ...
+            def f(x: object) -> bool:
+                return x is P[int]
+        "});
+        assert!(out.contains("return False"), "protocol target folds: {out}");
+        assert!(!out.contains("_parametric_is"), "no probe emitted: {out}");
+    }
+
+    #[test]
+    fn implicit_alias_target_probes_like_the_specialization() {
+        // `X = A[int]` binds `X` to the specialization itself, so `y is X`
+        // resolves exactly as `y is A[int]` would — a probe here
+        let out = out(indoc! {"
+            class A[T]:
+                def __init__(self, v: T):
+                    self.v: list[T] = [v]
+            X = A[int]
+            def f(y: object) -> bool:
+                return y is X
+        "});
+        assert!(
+            out.contains("return _parametric_is(y, X, (0,))"),
+            "alias name probes through `X`: {out}"
+        );
+    }
+
+    #[test]
+    fn implicit_alias_builtin_target_is_erased() {
+        // an alias to a builtin specialization is erased just like the direct
+        // form — a constant, and ty reports the error
+        let out = out(indoc! {"
+            X = list[int]
+            def f(y: object) -> bool:
+                return y is X
+        "});
+        assert!(out.contains("return False"), "erased alias target: {out}");
+        assert!(!out.contains("_parametric_is"), "no probe: {out}");
+    }
+
+    #[test]
+    fn pep695_type_alias_target_probes_through_value() {
+        // `type W = A[int]` is a `TypeAliasType`; the probe unwraps `.__value__`
+        // at runtime, so `y is W` still resolves against `A[int]`
+        let out = out(indoc! {"
+            class A[T]:
+                def __init__(self, v: T):
+                    self.v: list[T] = [v]
+            type W = A[int]
+            def f(y: object) -> bool:
+                return y is W
+        "});
+        assert!(
+            out.contains("return _parametric_is(y, W, (0,))"),
+            "type alias probes through `W`: {out}"
+        );
+    }
+
+    #[test]
+    fn bare_class_name_still_lowers_to_isinstance() {
+        // a non-generic name target is not a specialization; it keeps the
+        // ordinary isinstance lowering that identity_swap used to own
+        let out = out(indoc! {"
+            def f(y: object) -> bool:
+                return y is int
+        "});
+        assert!(
+            out.contains("return isinstance(y, int)"),
+            "bare class → isinstance: {out}"
+        );
+    }
+
+    #[test]
+    fn union_of_plain_classes_ors_isinstance() {
+        // a union target is the disjunction of its arms — never a runtime
+        // `isinstance(a, X | Y)`, which fails on a parameterized arm and even on
+        // plain classes before python 3.10
+        let out = out(indoc! {"
+            def f(a: object) -> bool:
+                return a is int | str
+        "});
+        assert!(
+            out.contains("return (isinstance(a, int) or isinstance(a, str))"),
+            "plain union ORs isinstance per arm: {out}"
+        );
+    }
+
+    #[test]
+    fn union_mixes_probe_and_isinstance_per_arm() {
+        let out = out(indoc! {"
+            class A[T]:
+                def __init__(self, v: T):
+                    self.v: list[T] = [v]
+            def f(a: object) -> bool:
+                return a is A[int] | object
+        "});
+        assert!(
+            out.contains("return (_parametric_is(a, A[int], (0,)) or isinstance(a, object))"),
+            "each arm lowered by its own kind: {out}"
+        );
+    }
+
+    #[test]
+    fn union_negation_wraps_the_disjunction() {
+        let out = out(indoc! {"
+            def f(a: object) -> bool:
+                return a is not int | str
+        "});
+        assert!(
+            out.contains("return not (isinstance(a, int) or isinstance(a, str))"),
+            "`is not` negates the whole disjunction: {out}"
+        );
+    }
+
+    #[test]
+    fn union_three_arms() {
+        let out = out(indoc! {"
+            def f(a: object) -> bool:
+                return a is int | str | bytes
+        "});
+        assert!(
+            out.contains(
+                "return (isinstance(a, int) or isinstance(a, str) or isinstance(a, bytes))"
+            ),
+            "a flat chain of arms: {out}"
+        );
+    }
+
+    #[test]
+    fn union_none_arm_is_an_identity_check() {
+        // `X | None` (an optional) tests the `None` arm by identity — `None` is
+        // a value, so `isinstance(a, None)` would be a runtime `TypeError`
+        let out = out(indoc! {"
+            def f(a: object) -> bool:
+                return a is int | None
+        "});
+        assert!(
+            out.contains("return (isinstance(a, int) or a is None)"),
+            "None arm is an identity check: {out}"
+        );
+    }
+
+    #[test]
+    fn union_effectful_lhs_binds_once_via_lambda() {
+        // an effectful lhs must be evaluated exactly once across the arms, so it
+        // is bound to a lambda parameter rather than referenced per arm
+        let out = out(indoc! {"
+            def g() -> object:
+                return 1
+            def f() -> bool:
+                return g() is int | str
+        "});
+        assert!(
+            out.contains(
+                "return (lambda _by_is_value: isinstance(_by_is_value, int) or \
+                 isinstance(_by_is_value, str))(g())"
+            ),
+            "effectful lhs bound once: {out}"
         );
     }
 

--- a/crates/by_transforms/src/transforms/use_site_variance.rs
+++ b/crates/by_transforms/src/transforms/use_site_variance.rs
@@ -1,35 +1,91 @@
-//! Pre-source text-edit that strips use-site variance markers (`out T`,
-//! `in T`, `in out T`) from the source string before the main lowering
+//! Pre-source text-edit that blanks use-site variance markers (`out T`,
+//! `in T`, `in out T`) out of the source string before the main lowering
 //! pipeline begins.
 //!
 //! Unlike the other passes in `ast_pass`, this one does NOT mutate the AST
 //! and re-render through [`Generator`]; it scans the AST for variance
-//! markers, gathers their source ranges, and deletes them from the source
+//! markers, gathers their source ranges, and overwrites them in the source
 //! string directly. The result is a basedpython source file with no
 //! variance keywords — downstream transforms (callable arrow lowering,
 //! intersection lowering) can then copy operand source verbatim without
-//! capturing variance keywords that would later leak
+//! capturing variance keywords that would later leak, and AST passes can
+//! re-render a statement without the [`Generator`] meeting a marker node it
+//! has no spelling for
 //!
-//! Pure-deletion edits like this don't have an overlap problem with other
-//! transforms' edits, because we apply them to the source upstream of the
-//! whole text-edit pipeline. They also preserve every other byte of
-//! formatting — the only change to the source is the variance keyword
-//! (and one trailing space) being removed at each marker site.
+//! The keyword bytes are replaced with spaces rather than deleted, which is
+//! what lets the *type checker* keep reading the markers: blanking preserves
+//! every byte position, so the db can hold the original source — markers
+//! intact — while every pass reads and splices the blanked copy at exactly
+//! the same ranges. A pass that asks ty about `x is A[out int]` therefore
+//! sees the projection, and still renders `A[int]`. Deleting the bytes
+//! instead would shift every following position out of alignment and hide
+//! the projection from ty entirely
+//!
+//! The padding this leaves behind (`A[    int]`) is valid Python but ugly, so
+//! the driver also emits each blanked range as a deletion edit. Those apply
+//! wherever no wider edit claims the region, which is the common case; inside
+//! a wider *plain* text edit the padding survives, harmlessly.
 
 use ruff_python_ast::PySourceType;
 use ruff_python_ast::helpers::use_site_variance_marker;
 use ruff_python_ast::visitor::{Visitor, walk_expr, walk_stmt};
 use ruff_python_ast::{Expr, Stmt};
 use ruff_python_parser::parse_unchecked_source;
-use ruff_text_size::Ranged;
+use ruff_text_size::{Ranged, TextRange};
 
-/// Strip every use-site variance marker (`out T`, `in T`, `in out T`)
-/// from `source` and return the cleaned source. If parsing fails or no
-/// markers are present, returns `source` unchanged.
-pub(crate) fn strip(source: &str) -> std::borrow::Cow<'_, str> {
+/// A source with every use-site variance marker blanked out, plus the ranges
+/// that were blanked.
+pub(crate) struct Blanked<'a> {
+    pub(crate) source: std::borrow::Cow<'a, str>,
+    /// the blanked ranges, ascending. Positions are valid in both the
+    /// original and the blanked source — blanking is length-preserving
+    pub(crate) ranges: Vec<TextRange>,
+}
+
+/// What a blanked range should collapse to: nothing, except any newlines it
+/// spanned. Keeping those means the marker never costs a line, so output line
+/// numbers still match the input's — which the driver's identity line table
+/// relies on. A marker written on one line, the overwhelmingly common case,
+/// collapses to the empty string
+pub(crate) fn collapsed_to(source: &str, range: TextRange) -> String {
+    source[usize::from(range.start())..usize::from(range.end())]
+        .matches('\n')
+        .collect()
+}
+
+impl Blanked<'_> {
+    /// `original` with the marker keywords collapsed away, rather than blanked
+    /// to spaces. This is what the driver's edits produce for an unclaimed
+    /// range; the early-return paths, where no pass ran to emit them, use it to
+    /// get the same output directly
+    pub(crate) fn stripped<'s>(&self, original: &'s str) -> std::borrow::Cow<'s, str> {
+        if self.ranges.is_empty() {
+            return std::borrow::Cow::Borrowed(original);
+        }
+        let mut out = original.to_owned();
+        for range in self.ranges.iter().rev() {
+            out.replace_range(
+                usize::from(range.start())..usize::from(range.end()),
+                &collapsed_to(original, *range),
+            );
+        }
+        std::borrow::Cow::Owned(out)
+    }
+}
+
+/// Blank every use-site variance marker (`out T`, `in T`, `in out T`) out of
+/// `source`, replacing the keyword bytes with spaces so byte positions are
+/// preserved. Newlines are kept as-is, so line structure survives a marker
+/// that spans a line break. If parsing fails or no markers are present,
+/// returns `source` unchanged with no ranges.
+pub(crate) fn blank(source: &str) -> Blanked<'_> {
+    let unchanged = || Blanked {
+        source: std::borrow::Cow::Borrowed(source),
+        ranges: Vec::new(),
+    };
     let parsed = parse_unchecked_source(source, PySourceType::BasedPython);
     if !parsed.errors().is_empty() {
-        return std::borrow::Cow::Borrowed(source);
+        return unchanged();
     }
     let module = parsed.into_syntax();
 
@@ -38,20 +94,35 @@ pub(crate) fn strip(source: &str) -> std::borrow::Cow<'_, str> {
         collector.visit_stmt(stmt);
     }
     if collector.ranges.is_empty() {
-        return std::borrow::Cow::Borrowed(source);
+        return unchanged();
     }
     let mut ranges = collector.ranges;
-    // sort descending by start so position-based edits stay valid
-    ranges.sort_by_key(|r| std::cmp::Reverse(r.0));
+    ranges.sort_by_key(Ranged::start);
+
     let mut out = source.to_owned();
-    for (start, end) in ranges {
-        out.replace_range(start..end, "");
+    for range in &ranges {
+        let span = &source[usize::from(range.start())..usize::from(range.end())];
+        // keep newlines so the blanked copy has the same line structure; every
+        // other byte becomes a space. mapping *bytes* (not chars) is what
+        // makes this length-preserving even if the span holds a comment with
+        // multi-byte text, and the all-ASCII result is still valid UTF-8
+        let blanked: String = span
+            .bytes()
+            .map(|b| if b == b'\n' { '\n' } else { ' ' })
+            .collect();
+        out.replace_range(
+            usize::from(range.start())..usize::from(range.end()),
+            &blanked,
+        );
     }
-    std::borrow::Cow::Owned(out)
+    Blanked {
+        source: std::borrow::Cow::Owned(out),
+        ranges,
+    }
 }
 
 struct MarkerCollector {
-    ranges: Vec<(usize, usize)>,
+    ranges: Vec<TextRange>,
 }
 
 impl<'ast> Visitor<'ast> for MarkerCollector {
@@ -61,12 +132,12 @@ impl<'ast> Visitor<'ast> for MarkerCollector {
 
     fn visit_expr(&mut self, expr: &'ast Expr) {
         if let Some((_, inner)) = use_site_variance_marker(expr) {
-            // delete the variance keyword bytes between the outer marker
+            // blank the variance keyword bytes between the outer marker
             // range and the inner expression's start
-            let start = usize::from(expr.range().start());
-            let inner_start = usize::from(inner.range().start());
+            let start = expr.range().start();
+            let inner_start = inner.range().start();
             if start < inner_start {
-                self.ranges.push((start, inner_start));
+                self.ranges.push(TextRange::new(start, inner_start));
             }
         }
         walk_expr(self, expr);
@@ -178,28 +249,92 @@ mod tests {
     }
 
     #[test]
-    fn strips_use_site_variance() {
-        let out = strip("def f(x: list[out int]) -> None: ...\n");
-        assert_eq!(out, "def f(x: list[int]) -> None: ...\n");
+    fn blanks_use_site_variance() {
+        let out = blank("def f(x: list[out int]) -> None: ...\n");
+        assert_eq!(out.source, "def f(x: list[    int]) -> None: ...\n");
     }
 
     #[test]
-    fn strips_inside_callable_arrow() {
-        let out = strip("fn: (list[out int]) -> None\n");
-        assert_eq!(out, "fn: (list[int]) -> None\n");
+    fn blanks_inside_callable_arrow() {
+        let out = blank("fn: (list[out int]) -> None\n");
+        assert_eq!(out.source, "fn: (list[    int]) -> None\n");
     }
 
     #[test]
-    fn strips_inside_intersection() {
-        let out = strip("def h(x: list[out int] & list[out str]) -> None: pass\n");
-        assert_eq!(out, "def h(x: list[int] & list[str]) -> None: pass\n");
+    fn blanks_inside_intersection() {
+        let out = blank("def h(x: list[out int] & list[out str]) -> None: pass\n");
+        assert_eq!(
+            out.source,
+            "def h(x: list[    int] & list[    str]) -> None: pass\n"
+        );
+    }
+
+    /// blanking must not move a single byte: the driver relies on this to hold
+    /// the original source (markers intact) in the db while every pass reads
+    /// and splices the blanked copy at the same ranges
+    #[test]
+    fn blanking_preserves_every_byte_position() {
+        let src = "def f(x: dict[str, out int], y: list[in out str]) -> None: ...\n";
+        let out = blank(src);
+        assert_eq!(out.source.len(), src.len());
+        for range in &out.ranges {
+            assert!(
+                out.source[usize::from(range.start())..usize::from(range.end())]
+                    .bytes()
+                    .all(|b| b == b' '),
+                "blanked range should be all spaces"
+            );
+        }
+    }
+
+    /// a marker spanning a line break keeps its newline, so line numbers in
+    /// the blanked copy still match the original
+    #[test]
+    fn blanking_preserves_line_structure() {
+        let src = "x: list[out\n    int]\n";
+        let out = blank(src);
+        assert_eq!(out.source, "x: list[   \n    int]\n");
+        assert_eq!(
+            out.source.lines().count(),
+            src.lines().count(),
+            "line count must survive"
+        );
+    }
+
+    #[test]
+    fn stripped_collapses_what_blank_padded() {
+        let src = "def f(x: list[out int]) -> None: ...\n";
+        assert_eq!(
+            blank(src).stripped(src),
+            "def f(x: list[int]) -> None: ...\n"
+        );
+    }
+
+    /// a marker spanning a line break keeps its newline through the collapse
+    /// too, so output line numbers still match the input's — the driver's
+    /// identity line table depends on it. the run of indentation up to the
+    /// inner expression is part of the marker's range and goes with it
+    #[test]
+    fn collapsing_a_multiline_marker_costs_no_line() {
+        let src = "x: list[out\n    int]\ny = 1\n";
+        let stripped = blank(src).stripped(src);
+        assert_eq!(stripped, "x: list[\nint]\ny = 1\n");
+        assert_eq!(stripped.lines().count(), src.lines().count());
+    }
+
+    /// the whole point of the multi-line case: it still transpiles, and `y`
+    /// stays on the line it started on
+    #[test]
+    fn multiline_marker_transpiles_without_shifting_lines() {
+        check("x: list[out\n    int]\ny = 1\n", "x: list[\nint]\ny = 1\n");
     }
 
     #[test]
     fn no_markers_borrows_input() {
         let src = "def f(x: list[int]) -> None: ...\n";
-        let out = strip(src);
-        assert!(matches!(out, std::borrow::Cow::Borrowed(_)));
-        assert_eq!(out, src);
+        let out = blank(src);
+        assert!(matches!(out.source, std::borrow::Cow::Borrowed(_)));
+        assert!(out.ranges.is_empty());
+        assert_eq!(out.source, src);
     }
 }

--- a/crates/by_transforms/src/type_info.rs
+++ b/crates/by_transforms/src/type_info.rs
@@ -59,13 +59,14 @@ pub(crate) trait TypeInfo {
 
     /// how the keyword-form parametric type test `lhs is rhs` resolves
     /// (rust-style: statically folded, reified-cell token equality, witness
-    /// probe, or an unchecked runtime probe). `None` when `rhs` is not a
-    /// subscripted generic class — the pair is then an ordinary isinstance
-    /// lowering
+    /// probe, or an unchecked runtime probe). `rhs` may spell the target
+    /// specialization directly (`list[int]`) or through an alias (`X =
+    /// list[int]`, `type X = list[int]`). `None` when `rhs` does not resolve to
+    /// a specialization — the pair is then an ordinary isinstance lowering
     fn parametric_is_plan(
         &self,
         lhs: &Expr,
-        rhs: &ruff_python_ast::ExprSubscript,
+        rhs: &Expr,
     ) -> Option<ty_python_semantic::ParametricIsPlan>;
 
     /// whether `expr` resolves to `typing.Any` (the explicitly-annotated
@@ -210,7 +211,7 @@ impl TypeInfo for SemanticModel<'_> {
     fn parametric_is_plan(
         &self,
         lhs: &Expr,
-        rhs: &ruff_python_ast::ExprSubscript,
+        rhs: &Expr,
     ) -> Option<ty_python_semantic::ParametricIsPlan> {
         SemanticModel::parametric_is_plan(self, lhs, rhs)
     }

--- a/crates/ty_python_semantic/resources/mdtest/basedpython_parametric_is.md
+++ b/crates/ty_python_semantic/resources/mdtest/basedpython_parametric_is.md
@@ -56,6 +56,56 @@ def g(a: A[object]) -> bool:
     return a is A[int]
 ```
 
+## use-site variance is respected
+
+A target may spell its own variance (`A[out int]`), which projects an invariant `T` covariantly for
+this one test — so `A[bool]` is an `A[out int]`, exactly as it is assignable to one. The projection
+applies to the runtime probe too, not just the static fold.
+
+```by
+class A[in out T]:
+    def __init__(self): ...
+
+def f(a: A[bool]) -> bool:
+    b: A[out int] = a  # assignable, so the test below is `True`
+    return a is A[out int]
+
+def g(a: A[*]) -> bool:
+    return a is A[out int]
+
+def h(a: A[*]) -> bool:
+    return a is A[in int]
+
+# without a projection `T` stays invariant, so a wider value is not a match
+def i(a: A[bool]) -> bool:
+    return a is A[int]
+```
+
+Narrowing keeps the projection rather than discarding it to `Unknown`:
+
+```by
+class B[in out T]:
+    def __init__(self): ...
+
+def f(b: B[*]):
+    if b is B[out int]:
+        reveal_type(b)  # revealed: B[*] & B[out int]
+```
+
+A projection cannot widen a declared-variant parameter beyond what it already allows — the declared
+variance wins, so these behave exactly as the unprojected forms do:
+
+```by
+class C[out T]:
+    def __init__(self): ...
+
+def f(c: C[int]) -> bool:
+    return c is C[out object]
+
+def g(c: C[*]) -> bool:
+    return c is C[out int]
+```
+
 ## a user-generic union is discriminated by the probe
 
 `A`'s instances carry `__orig_class__`, so each arm is distinguishable at runtime (an invariant
@@ -112,6 +162,218 @@ def f(x) -> bool:
 
 def g(x: object) -> bool:
     return x is A[int]
+```
+
+## a protocol target cannot be checked at runtime
+
+A protocol's instances record their own concrete class in `__orig_class__`, never the protocol, so a
+probe could never match — and a structural `isinstance` check sees no type arguments (it raises
+outright unless the protocol is `@runtime_checkable`). So an undecidable protocol target is an
+error, exactly like a builtin.
+
+```by
+from typing import Protocol
+
+class P[T](Protocol):
+    def get(self) -> T: ...
+
+def f(x: object) -> bool:
+    return x is P[int]  # error: [erased-type-check]
+```
+
+## a decidable protocol target folds silently
+
+Only the runtime-probe case errors; a statically provable protocol target folds like any other.
+
+```by
+from typing import Protocol
+
+class P[T](Protocol):
+    def get(self) -> T: ...
+
+class C:
+    def get(self) -> int:
+        return 1
+
+def f(c: C) -> bool:
+    return c is P[int]
+```
+
+## a tuple target compares each element cell
+
+`x: tuple[T, U]` carries both parameters in reified cells, so the test unifies position by position
+against the tuple target.
+
+```by
+def f[T, U](x: tuple[T, U]) -> bool:
+    return x is tuple[int, str]
+```
+
+## a nested generic value unifies structurally
+
+`x: A[list[T]]` reaches `T` through two levels; the test descends the target structure to the cell.
+
+```by
+class A[T]:
+    def __init__(self): ...
+
+def f[T](x: A[list[T]]) -> bool:
+    return x is A[list[int]]
+```
+
+## a multi-parameter target probes each argument
+
+`Pair`'s two invariant parameters each get matched by the probe.
+
+```by
+class Pair[K, V]:
+    def __init__(self, k: K, v: V):
+        self.k: K = k
+        self.v: V = v
+
+def f(x: object) -> bool:
+    return x is Pair[int, str]
+```
+
+## a bivariant parameter matches any specialization
+
+A type parameter never used in the class body is bivariant, so every specialization is mutually
+assignable and the probe matches either way.
+
+```by
+class Box[T]:
+    def __init__(self): ...
+
+def f(x: object) -> bool:
+    return x is Box[int]
+```
+
+## a declared-contravariant target follows its variance
+
+With `in T`, `Sink[int]` is a `Sink[bool]` (because `bool <: int`), so a statically-`Sink[int]`
+value folds the test to `True`.
+
+```by
+class Sink[in T]:
+    def __init__(self): ...
+    def put(self, x: T) -> None: ...
+
+def f(s: Sink[int]) -> bool:
+    return s is Sink[bool]
+
+def g(s: Sink[bool]) -> bool:
+    return s is Sink[int]
+```
+
+## a decidable builtin target does not error
+
+The erased-target error only fires when the test would fall back to a runtime probe. A value whose
+static type settles the test — here a union disjoint from the target — folds silently even against a
+builtin.
+
+```by
+def f(x: int | str) -> bool:
+    return x is list[int]
+```
+
+## an alias name targets its specialization
+
+A name bound to a specialization (`X = A[int]`) is that specialization, so `y is X` resolves exactly
+as `y is A[int]` — a probe of a user generic here, no diagnostic.
+
+```by
+class A[T]:
+    def __init__(self, t: T):
+        self.v: list[T] = [t]
+
+X = A[int]
+
+def f(y: object) -> bool:
+    return y is X
+```
+
+## an alias to a builtin specialization is erased
+
+Just like the spelled-out form.
+
+```by
+X = list[int]
+
+def f(y: object) -> bool:
+    return y is X  # error: [erased-type-check]
+```
+
+## a PEP 695 type alias targets its value
+
+`type X = A[int]` resolves to `A[int]` the same way; the runtime probe unwraps the alias.
+
+```by
+class A[T]:
+    def __init__(self, t: T):
+        self.v: list[T] = [t]
+
+type X = A[int]
+
+def f(y: object) -> bool:
+    return y is X
+```
+
+## a PEP 695 alias to a builtin is erased
+
+```by
+type X = list[int]
+
+def f(y: object) -> bool:
+    return y is X  # error: [erased-type-check]
+```
+
+## a bare class name is an ordinary instance test
+
+A name that is not a specialization keeps plain `isinstance` semantics — never an erased-target
+error.
+
+```by
+def f(y: object) -> bool:
+    return y is int
+```
+
+## a union target tests each arm
+
+`a is T1 | T2` matches when `a` matches any arm, so it lowers to the disjunction of the per-arm
+tests — each arm resolved by its own kind (a bare class by `isinstance`, a specialization by a probe
+or fold). It never builds a runtime `isinstance(a, T1 | T2)`, which would fail on a parameterized
+arm.
+
+```by
+class A[T]:
+    def __init__(self, t: T):
+        self.v: list[T] = [t]
+
+def f(a: object) -> bool:
+    return a is A[int] | object
+
+def g(a: object) -> bool:
+    return a is int | str | bytes
+```
+
+## a `None` arm is an identity check
+
+`X | None` — an optional — tests the `None` arm by identity, not `isinstance(_, None)` (`None` is a
+value, not a class).
+
+```by
+def f(a: object) -> bool:
+    return a is int | None
+```
+
+## an erased arm of a union is rejected
+
+An arm that can't be checked at runtime (a builtin specialization) is an error, exactly like a
+standalone erased target — it may not silently fold to `False` inside the disjunction.
+
+```by
+def f(a: object) -> bool:
+    return a is list[int] | int  # error: [erased-type-check]
 ```
 
 ## positive narrowing

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -47,7 +47,7 @@ pub use types::ide_support::{
     definitions_for_unary_op, map_stub_definition, type_hierarchy_prepare, type_hierarchy_subtypes,
     type_hierarchy_supertypes,
 };
-pub use types::reified_infer::{ArgVariance, ParametricIsPlan};
+pub use types::reified_infer::{ArgVariance, ErasedTargetReason, ParametricIsPlan};
 pub use types::{DisplaySettings, TypeQualifiers};
 
 pub mod api_lockfile;

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -118,17 +118,18 @@ impl<'db> SemanticModel<'db> {
     }
 
     /// basedpython: how the parametric type test `lhs is rhs` (keyword form)
-    /// resolves, from the operands' inferred types. `None` when `rhs` does
-    /// not evaluate to a subscripted generic class — the test is then an
-    /// ordinary isinstance lowering
+    /// resolves, from the operands' inferred types. `rhs` may name the target
+    /// specialization directly (`list[int]`) or through an alias — an implicit
+    /// alias whose value is a specialization (`X = list[int]`) or a PEP 695
+    /// `type` alias. `None` when `rhs` does not resolve to a specialization —
+    /// the test is then an ordinary isinstance lowering
     pub fn parametric_is_plan(
         &self,
         lhs: &ast::Expr,
-        rhs: &ast::ExprSubscript,
+        rhs: &ast::Expr,
     ) -> Option<crate::types::reified_infer::ParametricIsPlan> {
-        let Type::GenericAlias(alias) = rhs.inferred_type(self)? else {
-            return None;
-        };
+        let alias =
+            crate::types::reified_infer::parametric_is_target(self.db, rhs.inferred_type(self)?)?;
         let lhs_ty = lhs.inferred_type(self)?;
         Some(crate::types::reified_infer::classify_parametric_is(
             self.db, lhs_ty, alias, rhs,

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1957,7 +1957,7 @@ fn specialization_variance<'db>(
 ///   (`in out`). A non-`None` projection on the *source* side without a
 ///   matching projection on the target side means the source describes a
 ///   wider set of types than the target can hold, so the relation fails.
-fn combine_use_site_projections(
+pub(crate) fn combine_use_site_projections(
     declared: TypeVarVariance,
     source: Option<ruff_python_ast::helpers::UseSiteVariance>,
     target: Option<ruff_python_ast::helpers::UseSiteVariance>,

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -96,7 +96,7 @@ use crate::types::match_pattern::{ClassPatternPositionalResult, class_pattern_po
 use crate::types::narrow::NarrowingEvaluatorExtension;
 use crate::types::narrow::pattern_success_types;
 use crate::types::newtype::NewType;
-use crate::types::reified_infer::{self, ReifiedInferenceError};
+use crate::types::reified_infer::{self, ErasedTargetReason, ReifiedInferenceError};
 use crate::types::set_theoretic::RecursivelyDefined;
 use crate::types::signatures::{CallableSignature, ReturnCallableTypeVarScope};
 use crate::types::soundness::{erases_type_arguments, runtime_check_target};
@@ -11285,46 +11285,92 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         if !matches!(op, ast::CmpOp::Is | ast::CmpOp::IsNot) || !self.is_basedpython_file() {
             return None;
         }
-        let ast::Expr::Subscript(subscript) = right else {
-            return None;
-        };
-        let Type::GenericAlias(alias) = right_ty else {
-            return None;
-        };
         let source = ruff_db::source::source_text(self.db(), self.file());
         if !crate::reified::is_keyword_comparison(source.as_str(), op, left, right) {
             return None;
         }
-        let plan = crate::types::reified_infer::classify_parametric_is(
-            self.db(),
-            left_ty,
-            alias,
-            subscript,
-        );
         let bool_ty = KnownClass::Bool.to_instance(self.db());
-        // only a probe against a runtime-erased builtin is an error; every
-        // other plan (fold, reified-cell equality, witness, or a probe of a
-        // user generic that carries `__orig_class__`) is a valid test
-        if plan != crate::types::reified_infer::ParametricIsPlan::ErasedTarget {
+
+        // a union target `a is T1 | T2` tests each arm (`type(a) <: Ti` for any
+        // arm). an erased arm can't be checked at runtime and, unlike a
+        // standalone erased target, may not fold to a constant inside the
+        // disjunction — that would be unsound — so it is rejected per arm
+        if let Some(arms) = union_target_arms(right) {
+            for arm in arms {
+                let Some(alias) = crate::types::reified_infer::parametric_is_target(
+                    self.db(),
+                    self.expression_type(arm),
+                ) else {
+                    continue;
+                };
+                if let crate::types::reified_infer::ParametricIsPlan::ErasedTarget(reason) =
+                    crate::types::reified_infer::classify_parametric_is(
+                        self.db(),
+                        left_ty,
+                        alias,
+                        arm,
+                    )
+                {
+                    self.report_erased_type_check(arm.range(), &source[arm.range()], reason);
+                }
+            }
             return Some(bool_ty);
         }
-        let range = TextRange::new(left.start(), right.end());
-        let Some(builder) = self.context.report_lint(&ERASED_TYPE_CHECK, range) else {
-            return Some(bool_ty);
-        };
-        let target = &source[subscript.range()];
-        let mut diagnostic = builder.into_diagnostic(format_args!(
-            "`is {target}` cannot be checked at runtime: builtin collections erase their type arguments"
-        ));
-        diagnostic.info(format_args!(
-            "a `list` / `dict` / `set` / `tuple` built at runtime carries no record of \
-             its type arguments, so no runtime check can confirm the specialization"
-        ));
-        diagnostic.info(format_args!(
-            "reify the type parameter (`def f[T](x: T)`), or test against a user-defined \
-             generic whose instances carry `__orig_class__`"
-        ));
+
+        let alias = crate::types::reified_infer::parametric_is_target(self.db(), right_ty)?;
+        let plan =
+            crate::types::reified_infer::classify_parametric_is(self.db(), left_ty, alias, right);
+        // only a probe against a runtime-erased target is an error; every
+        // other plan (fold, reified-cell equality, witness, or a probe of a
+        // user generic that carries `__orig_class__`) is a valid test
+        if let crate::types::reified_infer::ParametricIsPlan::ErasedTarget(reason) = plan {
+            self.report_erased_type_check(
+                TextRange::new(left.start(), right.end()),
+                &source[right.range()],
+                reason,
+            );
+        }
         Some(bool_ty)
+    }
+
+    /// report an `erased-type-check` for a parametric `is`-target (or one arm
+    /// of a union target) whose specialization cannot be probed at runtime
+    fn report_erased_type_check(
+        &self,
+        primary: TextRange,
+        target: &str,
+        reason: ErasedTargetReason,
+    ) {
+        let Some(builder) = self.context.report_lint(&ERASED_TYPE_CHECK, primary) else {
+            return;
+        };
+        let mut diagnostic = builder.into_diagnostic(format_args!(
+            "`is {target}` cannot be checked at runtime: {}",
+            match reason {
+                ErasedTargetReason::BuiltinCollection =>
+                    "builtin collections erase their type arguments",
+                ErasedTargetReason::Protocol =>
+                    "a protocol's instances don't record which specialization they satisfy",
+            }
+        ));
+        match reason {
+            ErasedTargetReason::BuiltinCollection => {
+                diagnostic.info(format_args!(
+                    "a `list` / `dict` / `set` / `tuple` built at runtime carries no record of \
+                     its type arguments, so no runtime check can confirm the specialization"
+                ));
+            }
+            ErasedTargetReason::Protocol => {
+                diagnostic.info(format_args!(
+                    "an instance's `__orig_class__` names its concrete class, never the protocol, \
+                     and a structural `isinstance` check can't see type arguments"
+                ));
+            }
+        }
+        diagnostic.info(format_args!(
+            "reify the type parameter (`def f[T](x: T)`), or test against a concrete generic \
+             class whose instances carry `__orig_class__`"
+        ));
     }
 
     fn infer_type_parameters(&mut self, type_parameters: &ast::TypeParams) {
@@ -12056,6 +12102,28 @@ fn is_collection_literal(expression: &ast::Expr) -> bool {
         expression,
         ast::Expr::List(_) | ast::Expr::Set(_) | ast::Expr::Dict(_)
     )
+}
+
+/// the flat arms of a `|` union type expression (`A | B | C` → `[A, B, C]`), or
+/// `None` when `expr` is not a union — used to test each arm of a parametric
+/// `is`-target union independently
+fn union_target_arms(expr: &ast::Expr) -> Option<Vec<&ast::Expr>> {
+    fn collect<'a>(expr: &'a ast::Expr, arms: &mut Vec<&'a ast::Expr>) {
+        if let ast::Expr::BinOp(binop) = expr
+            && binop.op == ast::Operator::BitOr
+        {
+            collect(&binop.left, arms);
+            collect(&binop.right, arms);
+        } else {
+            arms.push(expr);
+        }
+    }
+    if !matches!(expr, ast::Expr::BinOp(binop) if binop.op == ast::Operator::BitOr) {
+        return None;
+    }
+    let mut arms = Vec::new();
+    collect(expr, &mut arms);
+    Some(arms)
 }
 
 /// Returns `true` if `expression` is a link of a basedpython optional chain: a `?.` access, or a

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -18,6 +18,9 @@ use crate::types::diagnostic::{
 };
 use crate::types::generics::{GenericContext, InferableTypeVars, bind_typevar};
 use crate::types::infer::builder::annotation_expression::PEP613Policy;
+use crate::types::infer::builder::type_expression::{
+    resolve_use_site_variance_class, use_site_variance_slice_elements,
+};
 use crate::types::infer::builder::{ArgExpr, ArgumentsIter, MultiInferenceGuard};
 use crate::types::infer::{InferenceFlags, TypeExpressionFlags};
 use crate::types::special_form::AliasSpec;
@@ -274,6 +277,22 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         match value_ty {
             Type::ClassLiteral(class) => {
+                // basedpython use-site variance in *value* position — the
+                // `is` target of a parametric type test (`x is A[out int]`).
+                // Produce the same projected specialization the annotation
+                // form does, as a class object rather than an instance, so
+                // the test resolves against the projection instead of losing
+                // it to ordinary subscript inference
+                if self.is_basedpython_file()
+                    && let Some(elements) = use_site_variance_slice_elements(slice)
+                {
+                    let class_type =
+                        resolve_use_site_variance_class(db, value_ty, &elements, |elt| {
+                            self.infer_type_expression(elt)
+                        });
+                    return class_type.map_or_else(Type::unknown, Type::from);
+                }
+
                 // HACK ALERT: If we are subscripting a generic class, short-circuit the rest of the
                 // subscript inference logic and treat this as an explicit specialization.
                 // TODO: Move this logic into a custom callable, and update `find_name_in_mro` to return

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -7,6 +7,7 @@ use ruff_python_ast::{self as ast, PythonVersion};
 use ruff_text_size::Ranged;
 
 use super::{DeferredExpressionState, TypeInferenceBuilder};
+use crate::types::ClassType;
 use crate::types::call::CallArguments;
 use crate::types::diagnostic::{
     self, EXPERIMENTAL_SYNTAX, INVALID_TYPE_FORM, NOT_SUBSCRIPTABLE, UNBOUND_TYPE_VARIABLE,
@@ -3819,7 +3820,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
 /// One element of a subscript slice that may or may not carry a variance
 /// marker.
-struct VarianceSliceElement<'ast> {
+pub(super) struct VarianceSliceElement<'ast> {
     variance: Option<UseSiteVariance>,
     /// inner expression — for marker elements this is the unwrapped
     /// expression inside the marker; for non-marker elements the element
@@ -3840,7 +3841,9 @@ fn basedpython_float_constant(attr: &ast::Identifier) -> Option<f64> {
 /// If `slice` contains at least one use-site variance marker, return the
 /// flat list of slice elements with their variance and inner expression.
 /// Returns `None` if no element is variance-marked.
-fn use_site_variance_slice_elements(slice: &ast::Expr) -> Option<Vec<VarianceSliceElement<'_>>> {
+pub(super) fn use_site_variance_slice_elements(
+    slice: &ast::Expr,
+) -> Option<Vec<VarianceSliceElement<'_>>> {
     let elements: Vec<&ast::Expr> = match slice {
         ast::Expr::Tuple(t)
             if !t.parenthesized && !t.is_anon_named_tuple && !t.is_anon_named_tuple_value =>
@@ -3870,24 +3873,24 @@ fn use_site_variance_slice_elements(slice: &ast::Expr) -> Option<Vec<VarianceSli
     if any_marker { Some(mapped) } else { None }
 }
 
-/// Build an instance type for `value_ty[slice...]` where at least one slice
-/// element carries a use-site variance marker. Returns an instance of the
-/// outer class specialized with the slice's types and tagged with per-typevar
-/// projections so downstream member access can apply kotlin-style variance
-/// restrictions. Falls back to `Unknown` if the outer is not a class.
-fn resolve_use_site_variance<'db, 'ast>(
+/// Build the projected class type for `value_ty[slice...]` where at least one
+/// slice element carries a use-site variance marker. Returns the outer class
+/// specialized with the slice's types and tagged with per-typevar projections
+/// so downstream member access can apply kotlin-style variance restrictions.
+/// `None` if the outer is not a class.
+pub(super) fn resolve_use_site_variance_class<'db, 'ast>(
     db: &'db dyn crate::Db,
     value_ty: Type<'db>,
     elements: &[VarianceSliceElement<'ast>],
     mut infer_inner: impl FnMut(&'ast ast::Expr) -> Type<'db>,
-) -> Type<'db> {
+) -> Option<ClassType<'db>> {
     let Type::ClassLiteral(class_literal) = value_ty else {
         // variance keywords on a non-class outer — infer inners for
         // diagnostics and bail.
         for element in elements {
             let _ = infer_inner(element.inner);
         }
-        return Type::unknown();
+        return None;
     };
     let arg_types: Vec<Type<'db>> = elements.iter().map(|elt| infer_inner(elt.inner)).collect();
     let projections: Vec<Option<UseSiteVariance>> =
@@ -3901,5 +3904,19 @@ fn resolve_use_site_variance<'db, 'ast>(
             generic_context.specialize(db, vec![Type::unknown(); n].as_slice())
         }
     });
-    Type::instance(db, class_type)
+    Some(class_type)
+}
+
+/// The instance type a variance-marked subscript denotes in a type expression.
+/// Falls back to `Unknown` if the outer is not a class.
+fn resolve_use_site_variance<'db, 'ast>(
+    db: &'db dyn crate::Db,
+    value_ty: Type<'db>,
+    elements: &[VarianceSliceElement<'ast>],
+    infer_inner: impl FnMut(&'ast ast::Expr) -> Type<'db>,
+) -> Type<'db> {
+    match resolve_use_site_variance_class(db, value_ty, elements, infer_inner) {
+        Some(class_type) => Type::instance(db, class_type),
+        None => Type::unknown(),
+    }
 }

--- a/crates/ty_python_semantic/src/types/reified_infer.rs
+++ b/crates/ty_python_semantic/src/types/reified_infer.rs
@@ -26,9 +26,9 @@ use rustc_hash::FxHashMap;
 use crate::Db;
 use crate::place::{builtins_symbol, global_symbol};
 use crate::types::call::{Argument, CallArguments};
-use crate::types::class::{ClassLiteral, ClassType};
+use crate::types::class::{ClassLiteral, ClassType, GenericAlias};
 use crate::types::function::FunctionType;
-use crate::types::generics::Specialization;
+use crate::types::generics::{Specialization, combine_use_site_projections};
 use crate::types::tuple::Tuple;
 use crate::types::typevar::TypeVarBoundOrConstraints;
 use crate::types::variance::TypeVarVariance;
@@ -312,13 +312,27 @@ pub enum ParametricIsPlan {
     TokenEq(Vec<(Name, TextRange)>),
     /// not decidable from static types, but the target is a user-defined
     /// generic whose instances carry `__orig_class__` — probe it at runtime,
-    /// matching each argument by the target's declared variance (one entry
+    /// matching each argument by the target's effective variance (one entry
     /// per type parameter). a legitimate, unwarned runtime test
     Probe(Box<[ArgVariance]>),
-    /// not decidable from static types, and the target is a builtin
-    /// collection whose instances never carry `__orig_class__`, so no sound
-    /// runtime probe exists — the test is an error
-    ErasedTarget,
+    /// not decidable from static types, and the target's instances never carry
+    /// a usable `__orig_class__`, so no sound runtime probe exists — the test
+    /// is an error. the reason picks the diagnostic wording
+    ErasedTarget(ErasedTargetReason),
+}
+
+/// why a parametric test's target cannot be probed at runtime
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ErasedTargetReason {
+    /// a builtin collection (`list` / `dict` / `set` / `frozenset` / `tuple`)
+    /// erases its type arguments — its C-level instances reject
+    /// `__orig_class__` entirely
+    BuiltinCollection,
+    /// a protocol's instances record their own concrete class in
+    /// `__orig_class__`, never the protocol, so a probe could never match it;
+    /// and a structural `isinstance` check sees no type arguments (and raises
+    /// outright unless the protocol is `@runtime_checkable`)
+    Protocol,
 }
 
 /// how the runtime probe matches one type argument of the reified
@@ -335,12 +349,17 @@ pub enum ArgVariance {
     Bivariant,
 }
 
-/// whether specialized instances of `origin` carry `__orig_class__` at
-/// runtime. the builtin collections are C types that erase their type
-/// arguments and reject the attribute; a user-defined generic carries it
-/// (set by `types.GenericAlias.__call__` after construction)
-fn target_carries_orig_class<'db>(db: &'db dyn Db, origin: ClassLiteral<'db>) -> bool {
-    !matches!(
+/// why the target class can't back a runtime `__orig_class__` probe, or
+/// `None` when it can. the builtin collections are C types that erase their
+/// type arguments and reject the attribute; a protocol's instances record
+/// their concrete class rather than the protocol; every other user-defined
+/// generic carries a matching `__orig_class__` (set by
+/// `types.GenericAlias.__call__` after construction)
+fn erased_target_reason<'db>(
+    db: &'db dyn Db,
+    origin: ClassLiteral<'db>,
+) -> Option<ErasedTargetReason> {
+    if matches!(
         origin.known(db),
         Some(
             KnownClass::List
@@ -349,22 +368,63 @@ fn target_carries_orig_class<'db>(db: &'db dyn Db, origin: ClassLiteral<'db>) ->
                 | KnownClass::FrozenSet
                 | KnownClass::Tuple
         )
-    )
+    ) {
+        return Some(ErasedTargetReason::BuiltinCollection);
+    }
+    if origin.is_protocol(db) {
+        return Some(ErasedTargetReason::Protocol);
+    }
+    None
 }
 
-/// Classify how `lhs is rhs` (keyword form, `rhs` a subscripted generic
-/// class evaluating to `rhs_alias`) resolves, from the already-inferred
-/// static type of the lhs.
+/// The target specialization a parametric `is` test is checking against, drawn
+/// from the inferred type of the rhs. It is a `GenericAlias` when the rhs is a
+/// subscripted generic (`list[int]`) or an implicit alias bound to one
+/// (`X = list[int]`); a PEP 695 `type` alias is unwrapped to the same. `None`
+/// when the rhs is not a specialization — a bare class or value — so the caller
+/// keeps the ordinary `isinstance` lowering.
+pub(crate) fn parametric_is_target<'db>(
+    db: &'db dyn Db,
+    rhs_ty: Type<'db>,
+) -> Option<GenericAlias<'db>> {
+    match rhs_ty {
+        Type::GenericAlias(alias) => Some(alias),
+        _ => {
+            let value = rhs_ty.as_type_alias()?.value_type(db);
+            match value {
+                Type::GenericAlias(alias) => Some(alias),
+                Type::NominalInstance(instance) => match instance.class(db) {
+                    ClassType::Generic(alias) => Some(alias),
+                    ClassType::NonGeneric(_) => None,
+                },
+                _ => None,
+            }
+        }
+    }
+}
+
+/// Classify how `lhs is rhs` (keyword form) resolves, from the already-inferred
+/// static type of the lhs. `rhs` evaluates to `rhs_alias` — it may be spelled
+/// directly (`list[int]`), through an alias name whose value is that
+/// specialization (`X = list[int]; … is X`), or through a PEP 695 alias.
+///
+/// Only a directly-subscripted target exposes its type arguments as syntax, so
+/// the reified-cell token-equality path (which spells `T == <arg>`) is
+/// available for a subscript rhs but not for an alias name; an alias name falls
+/// back to the static fold or the runtime probe.
 pub(crate) fn classify_parametric_is<'db>(
     db: &'db dyn Db,
     lhs_ty: Type<'db>,
     rhs_alias: crate::types::class::GenericAlias<'db>,
-    rhs_node: &ast::ExprSubscript,
+    rhs_node: &ast::Expr,
 ) -> ParametricIsPlan {
     let target_origin = ClassLiteral::Static(rhs_alias.origin(db));
-    let target_args_ast: Vec<&ast::Expr> = match rhs_node.slice.as_ref() {
-        ast::Expr::Tuple(tuple) => tuple.elts.iter().collect(),
-        single => vec![single],
+    let target_args_ast: Vec<&ast::Expr> = match rhs_node {
+        ast::Expr::Subscript(subscript) => match subscript.slice.as_ref() {
+            ast::Expr::Tuple(tuple) => tuple.elts.iter().collect(),
+            single => vec![single],
+        },
+        _ => Vec::new(),
     };
     let plan = classify_value(
         db,
@@ -375,14 +435,15 @@ pub(crate) fn classify_parametric_is<'db>(
         rhs_node,
     );
     // a runtime `__orig_class__` probe is the last resort. it only works when
-    // the target's instances carry that attribute — a builtin collection
-    // never does, so the test cannot be checked at runtime and becomes an error
-    match plan {
-        ParametricIsPlan::Probe(_) if !target_carries_orig_class(db, target_origin) => {
-            ParametricIsPlan::ErasedTarget
-        }
-        other => other,
+    // the target's instances carry a matching attribute — a builtin collection
+    // or a protocol never does, so the test cannot be checked at runtime and
+    // becomes an error
+    if let ParametricIsPlan::Probe(_) = plan
+        && let Some(reason) = erased_target_reason(db, target_origin)
+    {
+        return ParametricIsPlan::ErasedTarget(reason);
     }
+    plan
 }
 
 fn classify_value<'db>(
@@ -391,7 +452,7 @@ fn classify_value<'db>(
     target_origin: ClassLiteral<'db>,
     rhs_alias: crate::types::class::GenericAlias<'db>,
     target_args_ast: &[&ast::Expr],
-    rhs_node: &ast::ExprSubscript,
+    rhs_node: &ast::Expr,
 ) -> ParametricIsPlan {
     // when the value's type is carried by a reified type parameter, the answer
     // lives in a runtime cell rather than the static type — extract the cell
@@ -419,7 +480,7 @@ fn classify_value<'db>(
     } else {
         // undecidable statically; `classify_parametric_is` turns this into a
         // runtime probe (user generic) or an erased-target error (builtin)
-        ParametricIsPlan::Probe(target_variances(db, target_origin))
+        ParametricIsPlan::Probe(target_variances(db, rhs_alias))
     }
 }
 
@@ -433,12 +494,23 @@ fn try_token_eq<'db>(
     target_origin: ClassLiteral<'db>,
     rhs_alias: crate::types::class::GenericAlias<'db>,
     target_args_ast: &[&ast::Expr],
-    rhs_node: &ast::ExprSubscript,
+    rhs_node: &ast::Expr,
 ) -> Option<ParametricIsPlan> {
     match value_ty {
-        Type::TypeVar(bound_typevar) if is_reified_function_typevar(db, bound_typevar) => Some(
-            ParametricIsPlan::TokenEq(vec![(bound_typevar.name(db).clone(), rhs_node.range())]),
-        ),
+        // `x: T is <target>` compares the reified `T` cell against the target
+        // *as spelled*. that is only sound when the source evaluates to the
+        // specialization itself — a direct subscript. an alias name would
+        // compare against the alias object (or, for a PEP 695 alias, a
+        // `TypeAliasType` wrapper), so it falls through to the static resolution
+        Type::TypeVar(bound_typevar)
+            if is_reified_function_typevar(db, bound_typevar)
+                && matches!(rhs_node, ast::Expr::Subscript(_)) =>
+        {
+            Some(ParametricIsPlan::TokenEq(vec![(
+                bound_typevar.name(db).clone(),
+                rhs_node.range(),
+            )]))
+        }
         Type::NominalInstance(instance) => {
             let ClassType::Generic(alias) = instance.class(db) else {
                 return None;
@@ -486,32 +558,52 @@ pub(crate) fn parametric_soundness_spelling<'db>(
         return None;
     };
     let origin = ClassLiteral::Static(alias.origin(db));
-    // builtin collections erase their type arguments at runtime, so there is
-    // nothing to probe — the base `isinstance` check is all that's sound
-    if !target_carries_orig_class(db, origin) {
+    // a target whose instances don't carry a usable `__orig_class__` — a
+    // builtin collection (erased arguments) or a protocol — has nothing to
+    // probe, so the base `isinstance` check is all that's sound
+    if erased_target_reason(db, origin).is_some() {
         return None;
     }
     let spelling = spell_class(db, file, ClassType::Generic(alias))?;
-    let variances = target_variances(db, origin);
+    let variances = target_variances(db, alias);
     if variances.is_empty() {
         return None;
     }
     Some((spelling, variances))
 }
 
-/// the declared variance of each of the target class's type parameters — how
-/// the runtime probe matches each argument
-fn target_variances<'db>(db: &'db dyn Db, origin: ClassLiteral<'db>) -> Box<[ArgVariance]> {
+/// the effective variance of each of the target's type parameters — how the
+/// runtime probe matches each argument. this is the declared variance combined
+/// with any use-site projection the target spells (`A[out int]` matches
+/// covariantly even when `A`'s `T` is declared invariant), using the same
+/// combiner that decides subtyping, so the probe agrees with `is_subtype_of`
+///
+/// the probe reads the value's `__orig_class__`, which records a concrete
+/// construction (`A[bool](…)`) and never a projected view, so the source side
+/// of the combination carries no projection
+fn target_variances<'db>(db: &'db dyn Db, alias: GenericAlias<'db>) -> Box<[ArgVariance]> {
+    let origin = ClassLiteral::Static(alias.origin(db));
     let Some(generic_context) = origin.generic_context(db) else {
         return Box::default();
     };
+    let specialization = alias.specialization(db);
     generic_context
         .variables(db)
-        .map(|bound_typevar| match bound_typevar.variance(db) {
-            TypeVarVariance::Invariant => ArgVariance::Invariant,
-            TypeVarVariance::Covariant => ArgVariance::Covariant,
-            TypeVarVariance::Contravariant => ArgVariance::Contravariant,
-            TypeVarVariance::Bivariant => ArgVariance::Bivariant,
+        .map(|bound_typevar| {
+            let declared = bound_typevar.variance(db);
+            let effective = combine_use_site_projections(
+                declared,
+                None,
+                specialization.projection_for(db, bound_typevar),
+                false,
+            )
+            .unwrap_or(declared);
+            match effective {
+                TypeVarVariance::Invariant => ArgVariance::Invariant,
+                TypeVarVariance::Covariant => ArgVariance::Covariant,
+                TypeVarVariance::Contravariant => ArgVariance::Contravariant,
+                TypeVarVariance::Bivariant => ArgVariance::Bivariant,
+            }
         })
         .collect()
 }

--- a/docs/basedpython/features/parametric-type-tests.md
+++ b/docs/basedpython/features/parametric-type-tests.md
@@ -1,9 +1,8 @@
 # parametric type tests
 
-basedpython's `is` keyword is an instance test (`x is int` lowers to
 `isinstance(x, int)`). when the right-hand side is a *parameterized* generic,
-`x is C[args]` means `type(x) <: C[args]`, so it follows `C`'s declared
-variance:
+`x is C[args]` means `type(x) <: C[args]`, so it follows `C`'s
+[variance](variance.md):
 
 ```by
 class Box[out T]:
@@ -29,6 +28,7 @@ the value's static type decides the strategy:
     ty's own subtyping, so it respects variance automatically — a covariant
     `Box[int]` is a `Box[object]`, an invariant `list[object]` is not a
     `list[int]`. side effects in the tested expression are preserved
+
 - **reified type parameter → token equality**. a value typed by a reified
     type parameter carries the specialization in that parameter's runtime cell,
     so the test compares cells: `x: T` against `C[args]` lowers to
@@ -36,12 +36,14 @@ the value's static type decides the strategy:
     `T == int`. the parameter is [reified](reified-generics.md) for this. this
     works against a builtin target too — the cell holds the alias, nothing is
     erased
+
 - **undecidable, user-generic target → `__orig_class__` probe**. when none of
     the above apply, the last resort reads the value's `__orig_class__` — which
     `A[int](…)` [stamps](type-reification.md) on user generics — and matches
     each type argument by the target's variance. it discriminates a union
     soundly (`x: A[int] | A[str]` against `A[int]`); answers `False` for values
     that carry no `__orig_class__`
+
 - **undecidable, builtin target → error**. a runtime `list` / `dict` / `set`
     / `tuple` carries no record of its type arguments, so it cannot be checked
     at runtime. this is an [`erased-type-check`](#the-erased-type-check-error)
@@ -57,6 +59,47 @@ def f(a: object):
     a is A[int]      # valid — A's instances carry __orig_class__
     a is list[int]   # error — a runtime list erases its element type
 ```
+
+## the target may be spelled through an alias
+
+The target need not be a literal subscript. A name bound to a specialization, or a PEP 695 `type`
+alias for one, resolves the same way — `x is X` behaves exactly like `x is A[int]`:
+
+```by
+class A[T]: ...
+
+X = A[int]          # implicit alias
+type Y = A[int]     # PEP 695 alias
+
+def f(a: object):
+    a is X          # same as `a is A[int]`
+    a is Y          # same as `a is A[int]`
+```
+
+A bare class name that is *not* a specialization (`a is int`) stays an ordinary instance test. One
+limitation: the [reified-cell](#how-a-test-resolves) path spells `T == <arg>` from the target's
+syntax, so it needs a literal subscript — `x: T is X` through an alias falls back to the fold or the
+probe rather than the cell comparison.
+
+## variance
+
+both the fold and the probe read the *effective* variance of each type
+argument: the declared variance combined with any [use-site
+projection](variance.md#use-site-variance) the target spells. so an invariant
+`T` can be matched covariantly for one test by asking for it:
+
+```by
+class A[in out T]:
+    def __init__(self): ...
+
+def f(a: A[*]):
+    print(a is A[out int])   # True for an A[bool] — `out` projects T covariantly
+    print(a is A[int])       # False for an A[bool] — T is invariant unprojected
+```
+
+this is the same combination that decides assignability, so a test can never
+contradict the annotation: wherever `b: A[out int] = a` is accepted,
+`a is A[out int]` is `True`.
 
 ## narrowing
 

--- a/docs/basedpython/features/variance.md
+++ b/docs/basedpython/features/variance.md
@@ -10,12 +10,15 @@ class Both[in out T]: ...
 ```
 
 `out T` declares `T` covariant, `in T` contravariant, and `in out T`
-bivariant. variance affects subtyping in the obvious way:
+invariant — read-write, which is what a bare `T` already means, so `in out`
+is only ever worth writing to say so explicitly. variance affects subtyping
+in the obvious way:
 
 - `Source[Dog]` is assignable to `Source[Animal]` (covariant — `T` is
     produced)
 - `Sink[Animal]` is assignable to `Sink[Dog]` (contravariant — `T` is
     consumed)
+- `Both[Dog]` and `Both[Animal]` are assignable to neither (invariant)
 
 ## transpilation
 
@@ -73,9 +76,23 @@ def both(data: list[in out int]):
     data[0] = 1    # ok
 ```
 
-the outer container's nominal identity is dropped on purpose — only the
-variance-restricted view that the surface form promises survives. that
-makes `list[out int]` and `set[out int]` evaluate to the same view type.
+the container keeps its nominal identity — the projection rides along as a
+per-parameter tag, so `list[out int]` and `set[out int]` stay unrelated
+types. each argument of a multi-argument subscript is tagged independently,
+and an unmarked argument is simply untagged:
 
-only single-argument subscripts are supported; multi-argument variance
-(e.g. `dict[K, out V]`) reports a transpile error.
+```by
+def f(m: dict[str, out int]):
+    m["a"]         # int
+    m["a"] = 1     # error — write rejected through the `out` view
+```
+
+a projection only ever *adds* to what the declaration allows. against a
+declared-invariant parameter, `out` relaxes the position to covariant and
+`in` to contravariant; against a parameter already declared `out T` or
+`in T`, the declared variance covers everything the projection could give
+and the projection is a no-op.
+
+the projection is part of the type, so it also decides a
+[parametric type test](parametric-type-tests.md) — `a is A[out int]` matches
+covariantly even when `A`'s `T` is invariant.


### PR DESCRIPTION
`a is A[out int]` answered False for an `A[bool]`: the use-site projection never reached the test. three gaps, each enough on its own:

- the transpiler stripped the markers before inference ran, so ty was asked about `A[int]` and the `out` had simply never existed. `strip` becomes `blank`, overwriting the keyword bytes with spaces instead of deleting them — that preserves every byte position, so the db can now hold the original source (markers intact) while passes read and splice the blanked copy at the same ranges. the driver emits each blanked range as a collapse edit, keeping any newline it spanned so line numbers don't drift, and `parametric_is` emits a template edit so its rendered target composes with that collapse rather than clobbering it
- `target_variances` read only declared variance. it now combines the declared variance with the target's projection via `combine_use_site_projections` — the same combiner subtyping uses, so a test can't contradict assignability
- ty couldn't infer a marked subscript in value position at all (`A[out int]` evaluated to `A[Unknown]`), which is where an `is` target lives

the static fold was the worst of it: `a: A[bool]` folded `a is A[out int]`
to a constant False while `b: A[out int] = a` was accepted next to it.

blanking also drops the fall-back-to-single-file-db path, so a file using use-site variance now resolves cross-module imports like any other.

docs: variance.md called `in out` bivariant (it's invariant), claimed use-site variance drops nominal identity (it doesn't — `list[out int]` and `set[out int]` stay unrelated), and claimed multi-arg variance is a transpile error (it works); all three verified against the implementation.
