### PR TITLE
implement extensions

### DIFF
--- a/crates/by_transforms/src/lib.rs
+++ b/crates/by_transforms/src/lib.rs
@@ -561,6 +561,8 @@ pub fn reverse_transpile(source: &str, config: &Config) -> Result<String, String
     let mut overload = reverse_transforms::overload::OverloadReverse::new(src);
     let mut modifiers_rev = reverse_transforms::modifiers::ModifiersReverse::new(src);
     let mut enums_rev = reverse_transforms::enums::EnumsReverse::new();
+    let mut extension_rev =
+        reverse_transforms::extension::ExtensionReverse::new(src, module.suite());
     let mut coalesce_rev = reverse_transforms::coalesce::CoalesceReverse::new(src);
     let mut generics_rev = reverse_transforms::generics::GenericsReverse::new(src);
     let mut auto_quote_rev = reverse_transforms::auto_quote::AutoQuoteReverse::new(src);
@@ -586,6 +588,7 @@ pub fn reverse_transpile(source: &str, config: &Config) -> Result<String, String
         unpack.visit_stmt(stmt);
         modifiers_rev.visit_stmt(stmt);
         enums_rev.visit_stmt(stmt);
+        extension_rev.visit_stmt(stmt);
         coalesce_rev.visit_stmt(stmt);
         auto_quote_rev.visit_stmt(stmt);
         compat_rev.visit_stmt(stmt);
@@ -636,6 +639,7 @@ pub fn reverse_transpile(source: &str, config: &Config) -> Result<String, String
     fixes.extend(overload.edits);
     fixes.extend(modifiers_rev.edits);
     fixes.extend(enums_rev.edits);
+    fixes.extend(extension_rev.edits);
     fixes.extend(coalesce_rev.edits);
     fixes.extend(generics_rev.edits);
     fixes.extend(auto_quote_rev.edits);
@@ -1125,6 +1129,38 @@ mod cross_file {
         assert!(
             out.contains("Box[int](1)"),
             "imported generic constructor must keep its type args, got:\n{out}"
+        );
+    }
+
+    /// an extension declared in an imported module resolves at call sites in
+    /// the importing module: the lowering rewrites the call to the backing
+    /// function and emits its precise import. the surface stays `import ext`
+    #[test]
+    fn imported_extension_rewrites_call_and_adds_import() {
+        let db = project_db(&[
+            (
+                "/ext.by",
+                "extension list:\n    def second(self) -> Element:\n        return self[1]\n",
+            ),
+            (
+                "/main.by",
+                "import ext\n\nxs = [1, 2, 3]\nprint(xs.second())\n",
+            ),
+        ]);
+        let out = transpile_file(&db, "/main.by", &Config::test_default());
+        assert!(
+            out.contains("from ext import __by_ext__list__second"),
+            "backing-function import should be emitted, got:\n{out}"
+        );
+        assert!(
+            out.contains("print(__by_ext__list__second(xs))"),
+            "call should be rewritten, got:\n{out}"
+        );
+        // the defining module lowers the block itself
+        let ext_out = transpile_file(&db, "/ext.by", &Config::test_default());
+        assert!(
+            ext_out.contains("def __by_ext__list__second(self):"),
+            "defining module should lower the block, got:\n{ext_out}"
         );
     }
 

--- a/crates/by_transforms/src/reverse_transforms/extension.rs
+++ b/crates/by_transforms/src/reverse_transforms/extension.rs
@@ -1,0 +1,404 @@
+//! reverse of `crate::transforms::extension`:
+//!   `def __by_ext__list__second(self): …  # basedpython: extension method list`
+//!   → `extension list:` block, and `__by_ext__list__second(xs)` → `xs.second()`
+//!
+//! the forward lowering tags each backing function's header line with a
+//! `# basedpython: extension <kind> <header>` marker — provenance carrying the
+//! member kind (method / property / static / classmethod) and the original
+//! extension header, bracket bounds included. only marked functions re-sugar;
+//! backing-shaped functions written by hand (no marker) are ordinary python.
+//! call sites re-sugar only when the backing function is defined (and marked)
+//! in the same file — a cross-module import of a backing function stays as the
+//! explicit call, conservatively
+
+use std::collections::HashMap;
+
+use ruff_diagnostics::{Edit, Fix};
+use ruff_python_ast::visitor::{Visitor, walk_stmt};
+use ruff_python_ast::{Expr, Stmt, StmtFunctionDef};
+use ruff_text_size::{Ranged, TextRange};
+use ty_python_semantic::ExtensionMemberKind;
+
+use crate::transforms::extension::{EXTENSION_MARKER, parse_kind_word};
+use crate::transforms::source_util::line_start;
+
+/// a backing function recognised by its marker, keyed for call re-sugaring
+struct BackingFn {
+    member: String,
+    kind: ExtensionMemberKind,
+    /// the extension target's name (`list` from a `list[Element: int]` header)
+    target: String,
+}
+
+pub(crate) struct ExtensionReverse<'src> {
+    source: &'src str,
+    functions: HashMap<String, BackingFn>,
+    pub(crate) edits: Vec<Fix>,
+}
+
+/// the `<kind> <header>` payload of a marker comment found inside `span`
+fn marker_payload(source: &str, span: TextRange) -> Option<(&str, &str)> {
+    let text = &source[usize::from(span.start())..usize::from(span.end())];
+    let after = text.split_once(EXTENSION_MARKER)?.1;
+    let line = after.split('\n').next().unwrap_or(after).trim();
+    line.split_once(' ')
+}
+
+/// the member name of `name` under the mangle for `target`:
+/// `__by_ext__list__second` / `__by_ext2__list__second` → `second`
+fn member_of(name: &str, target: &str) -> Option<String> {
+    let rest = name.strip_prefix("__by_ext")?;
+    let rest = rest.trim_start_matches(|c: char| c.is_ascii_digit());
+    let rest = rest.strip_prefix("__")?;
+    let rest = rest.strip_prefix(target)?;
+    let member = rest.strip_prefix("__")?;
+    (!member.is_empty()).then(|| member.to_owned())
+}
+
+impl<'src> ExtensionReverse<'src> {
+    pub(crate) fn new(source: &'src str, suite: &[Stmt]) -> Self {
+        let mut reverse = Self {
+            source,
+            functions: HashMap::new(),
+            edits: Vec::new(),
+        };
+        reverse.resugar_blocks(suite);
+        reverse
+    }
+
+    /// a top-level function's marker data, when it is a recognisable backing
+    /// function: (kind, header, target, member)
+    fn backing_marker(
+        &self,
+        func: &StmtFunctionDef,
+    ) -> Option<(ExtensionMemberKind, String, String, String)> {
+        let (kind_word, header) = marker_payload(self.source, func.range())?;
+        let kind = parse_kind_word(kind_word)?;
+        let header = header.to_owned();
+        let target = header
+            .split_once('[')
+            .map_or(header.as_str(), |(target, _)| target)
+            .trim()
+            .to_owned();
+        let member = member_of(func.name.as_str(), &target)?;
+        Some((kind, header, target, member))
+    }
+
+    /// group consecutive top-level backing functions with the same header into
+    /// one `extension <header>:` block, and register every backing function
+    /// for the call-site re-sugar
+    fn resugar_blocks(&mut self, suite: &[Stmt]) {
+        let mut index = 0;
+        while index < suite.len() {
+            let Stmt::FunctionDef(func) = &suite[index] else {
+                index += 1;
+                continue;
+            };
+            let Some((kind, header, target, member)) = self.backing_marker(func) else {
+                index += 1;
+                continue;
+            };
+
+            let mut group = vec![(func, kind, member.clone())];
+            self.functions.insert(
+                func.name.to_string(),
+                BackingFn {
+                    member,
+                    kind,
+                    target: target.clone(),
+                },
+            );
+            let mut end = index + 1;
+            while let Some(Stmt::FunctionDef(next)) = suite.get(end) {
+                let Some((next_kind, next_header, next_target, next_member)) =
+                    self.backing_marker(next)
+                else {
+                    break;
+                };
+                if next_header != header {
+                    break;
+                }
+                self.functions.insert(
+                    next.name.to_string(),
+                    BackingFn {
+                        member: next_member.clone(),
+                        kind: next_kind,
+                        target: next_target,
+                    },
+                );
+                group.push((next, next_kind, next_member));
+                end += 1;
+            }
+
+            let start = line_start(
+                self.source,
+                group[0]
+                    .0
+                    .decorator_list
+                    .first()
+                    .map_or(group[0].0.range().start(), |dec| dec.range().start()),
+            );
+            let span = TextRange::new(start, group[end - index - 1].0.range().end());
+            let mut replacement = format!("extension {header}:\n");
+            for (position, (func, kind, member)) in group.iter().enumerate() {
+                if position > 0 {
+                    replacement.push('\n');
+                }
+                replacement.push_str(&self.resugar_member(func, *kind, member));
+            }
+            self.edits
+                .push(Fix::safe_edit(Edit::range_replacement(replacement, span)));
+            index = end;
+        }
+    }
+
+    /// one member of the block: the backing function's own source, marker
+    /// stripped, renamed to the surface member name, indented one level, and
+    /// re-spelled by kind (`@property`, `static def`, `class def`)
+    fn resugar_member(
+        &self,
+        func: &StmtFunctionDef,
+        kind: ExtensionMemberKind,
+        member: &str,
+    ) -> String {
+        let start = line_start(
+            self.source,
+            func.decorator_list
+                .first()
+                .map_or(func.range().start(), |dec| dec.range().start()),
+        );
+        let text = &self.source[usize::from(start)..usize::from(func.range().end())];
+
+        let mut result = String::new();
+        for (position, line) in text.split('\n').enumerate() {
+            if position > 0 {
+                result.push('\n');
+            }
+            // strip the marker comment (and the spacing before it)
+            let line = line
+                .split_once(EXTENSION_MARKER)
+                .map_or(line, |(before, _)| before.trim_end());
+            if line.is_empty() {
+                continue;
+            }
+            result.push_str("    ");
+            result.push_str(line);
+        }
+
+        // rename the mangled def to the surface member name
+        let result = result.replacen(
+            &format!("def {}", func.name.as_str()),
+            &format!("def {member}"),
+            1,
+        );
+
+        match kind {
+            ExtensionMemberKind::Method => result,
+            ExtensionMemberKind::Property => format!("    @property\n{result}"),
+            ExtensionMemberKind::StaticMethod => result.replacen("    def ", "    static def ", 1),
+            ExtensionMemberKind::ClassMethod => result.replacen("    def ", "    class def ", 1),
+        }
+    }
+
+    /// receivers re-sugared from an argument keep working as a postfix base;
+    /// anything lower-precedence gets wrapped
+    fn receiver_source(&self, receiver: &Expr) -> String {
+        let text = self.source
+            [usize::from(receiver.range().start())..usize::from(receiver.range().end())]
+            .to_owned();
+        if matches!(
+            receiver,
+            Expr::Name(_)
+                | Expr::Attribute(_)
+                | Expr::Subscript(_)
+                | Expr::Call(_)
+                | Expr::StringLiteral(_)
+                | Expr::List(_)
+                | Expr::Dict(_)
+                | Expr::Set(_)
+                | Expr::Tuple(_)
+        ) {
+            text
+        } else {
+            format!("({text})")
+        }
+    }
+
+    fn resugar_call(&mut self, call: &ruff_python_ast::ExprCall) {
+        // `functools.partial(__by_ext__list__second, xs)` → `xs.second`
+        if let Expr::Attribute(attr) = call.func.as_ref()
+            && attr.attr.as_str() == "partial"
+            && matches!(attr.value.as_ref(), Expr::Name(n) if n.id.as_str() == "functools")
+            && let [Expr::Name(backing), receiver] = call.arguments.args.as_ref()
+            && call.arguments.keywords.is_empty()
+            && let Some(function) = self.functions.get(backing.id.as_str())
+            && matches!(
+                function.kind,
+                ExtensionMemberKind::Method | ExtensionMemberKind::ClassMethod
+            )
+        {
+            let replacement = format!("{}.{}", self.receiver_source(receiver), function.member);
+            self.edits.push(Fix::safe_edit(Edit::range_replacement(
+                replacement,
+                call.range(),
+            )));
+            return;
+        }
+
+        let Expr::Name(name) = call.func.as_ref() else {
+            return;
+        };
+        let Some(function) = self.functions.get(name.id.as_str()) else {
+            return;
+        };
+        let rest = |args: &[Expr]| -> String {
+            let spans: Vec<&str> = args
+                .iter()
+                .map(|arg| {
+                    &self.source[usize::from(arg.range().start())..usize::from(arg.range().end())]
+                })
+                .chain(call.arguments.keywords.iter().map(|kw| {
+                    &self.source[usize::from(kw.range().start())..usize::from(kw.range().end())]
+                }))
+                .collect();
+            spans.join(", ")
+        };
+        let replacement = match function.kind {
+            ExtensionMemberKind::Property => {
+                let [receiver] = call.arguments.args.as_ref() else {
+                    return;
+                };
+                if !call.arguments.keywords.is_empty() {
+                    return;
+                }
+                format!("{}.{}", self.receiver_source(receiver), function.member)
+            }
+            ExtensionMemberKind::Method | ExtensionMemberKind::ClassMethod => {
+                let Some((receiver, rest_args)) = call.arguments.args.split_first() else {
+                    return;
+                };
+                format!(
+                    "{}.{}({})",
+                    self.receiver_source(receiver),
+                    function.member,
+                    rest(rest_args)
+                )
+            }
+            ExtensionMemberKind::StaticMethod => {
+                format!(
+                    "{}.{}({})",
+                    function.target,
+                    function.member,
+                    rest(&call.arguments.args)
+                )
+            }
+        };
+        self.edits.push(Fix::safe_edit(Edit::range_replacement(
+            replacement,
+            call.range(),
+        )));
+    }
+}
+
+impl<'ast> Visitor<'ast> for ExtensionReverse<'_> {
+    fn visit_stmt(&mut self, stmt: &'ast Stmt) {
+        walk_stmt(self, stmt);
+    }
+
+    fn visit_expr(&mut self, expr: &'ast Expr) {
+        if let Expr::Call(call) = expr {
+            self.resugar_call(call);
+        }
+        ruff_python_ast::visitor::walk_expr(self, expr);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Config, reverse_transpile, transpile};
+
+    fn rev(source: &str) -> String {
+        reverse_transpile(source, &Config::test_default()).unwrap()
+    }
+
+    #[test]
+    fn backing_functions_resugar_to_an_extension_block() {
+        let src = "def __by_ext__list__second(self):  # basedpython: extension method list\n    return self[1]\n\nxs = [1, 2]\nprint(__by_ext__list__second(xs))\n";
+        let out = rev(src);
+        assert!(out.contains("extension list:"), "got:\n{out}");
+        assert!(out.contains("    def second(self):"), "got:\n{out}");
+        assert!(out.contains("print(xs.second())"), "got:\n{out}");
+        assert!(!out.contains("__by_ext__"), "got:\n{out}");
+    }
+
+    #[test]
+    fn consecutive_members_share_one_block() {
+        let src = "def __by_ext__list__second(self):  # basedpython: extension method list\n    return self[1]\n\ndef __by_ext__list__third(self):  # basedpython: extension method list\n    return self[2]\n";
+        let out = rev(src);
+        assert_eq!(out.matches("extension list:").count(), 1, "got:\n{out}");
+        assert!(out.contains("    def second(self):"), "got:\n{out}");
+        assert!(out.contains("    def third(self):"), "got:\n{out}");
+    }
+
+    #[test]
+    fn property_resugars_with_decorator_and_bare_access() {
+        let src = "def __by_ext__str__shouty(self):  # basedpython: extension property str\n    return self.upper()\n\nname = \"hi\"\nprint(__by_ext__str__shouty(name))\n";
+        let out = rev(src);
+        assert!(out.contains("extension str:"), "got:\n{out}");
+        assert!(
+            out.contains("    @property\n    def shouty(self):"),
+            "got:\n{out}"
+        );
+        assert!(out.contains("print(name.shouty)"), "got:\n{out}");
+    }
+
+    #[test]
+    fn bounds_come_back_from_the_marker() {
+        let src = "def __by_ext__list__total(self):  # basedpython: extension method list[Element: int]\n    return sum(self)\n";
+        let out = rev(src);
+        assert!(out.contains("extension list[Element: int]:"), "got:\n{out}");
+    }
+
+    #[test]
+    fn partial_reference_resugars_to_bare_attribute() {
+        let src = "import functools\n\ndef __by_ext__list__second(self):  # basedpython: extension method list\n    return self[1]\n\nxs = [1, 2]\nf = functools.partial(__by_ext__list__second, xs)\n";
+        let out = rev(src);
+        assert!(out.contains("f = xs.second"), "got:\n{out}");
+    }
+
+    #[test]
+    fn unmarked_backing_shaped_function_is_ordinary_python() {
+        let src = "def __by_ext__list__second(self):\n    return self[1]\n\nprint(__by_ext__list__second([1, 2]))\n";
+        let out = rev(src);
+        assert!(!out.contains("extension"), "got:\n{out}");
+        assert!(
+            out.contains("print(__by_ext__list__second([1, 2]))"),
+            "got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn round_trip_reproduces_the_lowering() {
+        // reverse then forward reproduces the same *AST* (the documented
+        // round-trip contract) — indentation inside re-sugared bodies may
+        // legitimately differ
+        let by = "extension list:\n    def second(self) -> Element:\n        return self[1]\n\nxs = [1, 2, 3]\nprint(xs.second())\n";
+        let lowered = transpile(by, &Config::test_default()).unwrap();
+        let resugared = rev(&lowered);
+        let relowered = transpile(&resugared, &Config::test_default()).unwrap();
+        let parse = |source: &str| {
+            ruff_python_parser::parse_module(source)
+                .expect("round-trip output should parse")
+                .into_syntax()
+        };
+        assert_eq!(
+            ruff_python_ast::comparable::ComparableMod::from(&ruff_python_ast::Mod::Module(parse(
+                &lowered
+            ))),
+            ruff_python_ast::comparable::ComparableMod::from(&ruff_python_ast::Mod::Module(parse(
+                &relowered
+            ))),
+            "lowered:\n{lowered}\nrelowered:\n{relowered}"
+        );
+    }
+}

--- a/crates/by_transforms/src/reverse_transforms/mod.rs
+++ b/crates/by_transforms/src/reverse_transforms/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod dedent_string;
 pub(crate) mod dynamic_keyword;
 pub(crate) mod empty_declarations;
 pub(crate) mod enums;
+pub(crate) mod extension;
 pub(crate) mod generics;
 pub(crate) mod identity_swap;
 pub(crate) mod intersection;

--- a/crates/by_transforms/src/transforms/ast_driver.rs
+++ b/crates/by_transforms/src/transforms/ast_driver.rs
@@ -36,11 +36,11 @@ use ruff_text_size::{Ranged, TextRange};
 use super::{
     annotation, anon_named_tuple, auto_quote, callable, checked_cast, coalesce, coalesce_chain,
     compat, context_params, decl_site_variance, decorator_keyword, dedent_string, dynamic_keyword,
-    empty_declarations, float_const, force_unwrap, generic_call, generics, identity_swap,
-    implicit_typing, init_method, just_float, kw_subscript, literal_types, main_function,
-    modifiers, mutable_defaults, none_chain, optional_type, overload, parametric_is, postfix_await,
-    propagate, reified_generic, repeated_underscore, sentinel, some_ctor, soundness, string_tag,
-    super_keyword, symbolic_type_op, top_star, trailing_lambda, tuple_index, type_is,
+    empty_declarations, extension, float_const, force_unwrap, generic_call, generics,
+    identity_swap, implicit_typing, init_method, just_float, kw_subscript, literal_types,
+    main_function, modifiers, mutable_defaults, none_chain, optional_type, overload, parametric_is,
+    postfix_await, propagate, reified_generic, repeated_underscore, sentinel, some_ctor, soundness,
+    string_tag, super_keyword, symbolic_type_op, top_star, trailing_lambda, tuple_index, type_is,
     type_reification, typed_dict_literal, typed_lambda, typeof_keyword, unpack, use_site_variance,
 };
 use crate::Config;
@@ -480,6 +480,8 @@ pub(crate) fn run_against_source<'a>(
     let checked_cast_pass = checked_cast::CheckedCastPass::new(config.checked_cast);
     let trailing_lambda_pass = trailing_lambda::TrailingLambdaPass::new(source_ref);
     let context_params_pass = context_params::ContextParamsPass::new(source_ref);
+    let extension_block_pass = extension::ExtensionBlockPass::new(source_ref);
+    let extension_call_pass = extension::ExtensionCallPass;
     let variance_pass = decl_site_variance::VarianceStripPass::new();
     let anon_named_tuple_pass =
         anon_named_tuple::AnonNamedTuplePass::new(source_ref, config.clone());
@@ -556,6 +558,13 @@ pub(crate) fn run_against_source<'a>(
         // call's closing paren. single insertions, so they compose inside any
         // wrapping template's `Src` spans (including the trailing-lambda one)
         &context_params_pass,
+        // `extension` blocks lower to module-level backing functions; member
+        // bodies pass through as `Src` spans so lowerings inside them (and
+        // the call rewrites below) still compose
+        &extension_block_pass,
+        // type-directed rewrite of attribute accesses ty resolved to
+        // extension members (`xs.second()` → `__by_ext__list__second(xs)`)
+        &extension_call_pass,
         &dynamic_keyword_pass,
         &just_float_pass,
         &float_const_pass,
@@ -960,6 +969,11 @@ pub(crate) fn run_against_source<'a>(
     if needs_trailing_nl && !out.ends_with('\n') {
         out.push('\n');
     }
+    // extension backing functions are lowered in place (so their bodies keep
+    // their source ranges for sibling-pass composition); hoist them to the
+    // module top now that lowering is done, so a member called before its
+    // block's position still resolves
+    let (out, table) = extension::hoist_backing_functions(out, table);
     (Cow::Owned(out), ctx.errors, table)
 }
 

--- a/crates/by_transforms/src/transforms/coalesce.rs
+++ b/crates/by_transforms/src/transforms/coalesce.rs
@@ -26,9 +26,11 @@ impl<'src> NoneCoalesce<'src> {
     }
 }
 
-fn expand_none_chain(expr: &Expr, source: &str, types: &dyn TypeInfo) -> Option<String> {
-    let (form, guards) = super::none_chain::expand_chain(expr, source, types)?;
-    Some(super::none_chain::build_expansion(&guards, &form, "_t"))
+fn expand_none_chain(expr: &Expr, source: &str, types: &dyn TypeInfo) -> Option<Vec<Fragment>> {
+    let (form, guards, base) = super::none_chain::expand_chain(expr, source, types)?;
+    Some(super::none_chain::build_expansion(
+        &guards, &form, "_t", base,
+    ))
 }
 
 impl<'ast> Visitor<'ast> for NoneCoalesce<'_> {
@@ -79,11 +81,9 @@ impl NoneCoalesce<'_> {
         };
         match expand_none_chain(&b.left, self.source, self.types) {
             Some(expanded) => {
-                let mut t = vec![
-                    Fragment::Lit(format!("_t{unwrap} if (_t := ")),
-                    Fragment::Lit(expanded),
-                    Fragment::Lit(") is not None else ".to_owned()),
-                ];
+                let mut t = vec![Fragment::Lit(format!("_t{unwrap} if (_t := "))];
+                t.extend(expanded);
+                t.push(Fragment::Lit(") is not None else ".to_owned()));
                 t.extend(rhs);
                 t
             }
@@ -120,7 +120,7 @@ impl NoneCoalesce<'_> {
             return self.expand_coalesce(expr);
         }
         if let Some(expanded) = expand_none_chain(expr, self.source, self.types) {
-            return vec![Fragment::Lit(expanded)];
+            return expanded;
         }
         vec![Fragment::Src(expr.range())]
     }

--- a/crates/by_transforms/src/transforms/extension.rs
+++ b/crates/by_transforms/src/transforms/extension.rs
@@ -1,0 +1,767 @@
+//! Lowering for `extension` declarations and their call sites.
+//!
+//! An `extension list:` block parses to a `ClassDef` carrying a synthetic
+//! `extension_def` marker. Python has no extension methods and builtin C types
+//! cannot be monkey-patched, so extensions are resolved entirely at transpile
+//! time:
+//!
+//! - each member lowers to a module-level backing function
+//!   (`def second(self)` inside `extension list:` → `def
+//!   __by_ext__list__second(self)`), tagged with a `# basedpython: extension
+//!   <kind> <header>` marker comment carrying the member kind and the original
+//!   header (including any bracket bounds) for the reverse transform
+//! - call sites are rewritten by type: ty resolves `xs.second()` to the
+//!   extension member, and the call lowers to `__by_ext__list__second(xs)`.
+//!   a computed property drops the parentheses (`name.shouty` →
+//!   `__by_ext__str__shouty(name)`); an unapplied method reference becomes a
+//!   `functools.partial`
+//! - when the extension lives in another module, the precise import of the
+//!   backing function is emitted (`from textwrap import
+//!   __by_ext__str__dedented`), so `import textwrap` on the surface carries
+//!   the extensions with no runtime cost
+//!
+//! backing functions are plain and unannotated: their annotations reference
+//! the extended type's type parameters (`Element` on `list`), which have no
+//! runtime binding at module level. member bodies pass through as
+//! [`Fragment::Src`] spans, so lowerings inside them still compose. when a
+//! module declares more than one extension of the same target, later ones
+//! mangle with an ordinal (`__by_ext2__list__…`) so their members don't
+//! collide — the same rule ty uses when resolving call sites
+
+use std::collections::{BTreeSet, HashMap};
+
+use ruff_python_ast::visitor::{Visitor, walk_expr, walk_stmt};
+use ruff_python_ast::{self as ast, Expr, PySourceType, Stmt};
+use ruff_python_parser::parse_unchecked_source;
+use ruff_text_size::{Ranged, TextRange};
+use ty_python_semantic::ExtensionMemberKind;
+
+use super::ast_driver::{Fragment, PassContext, TypeAwarePass};
+use super::source_util::{is_synthetic_decorator, line_start};
+use crate::type_info::TypeInfo;
+
+/// the marker-comment prefix that ties a backing function to its extension
+pub(crate) const EXTENSION_MARKER: &str = "# basedpython: extension";
+
+/// the mangled module-level name of an extension member's backing function.
+/// `ordinal` is the extension's occurrence index among same-target extensions
+/// in its module — mirrored by ty's `backing_function_name`
+pub(crate) fn backing_name(target: &str, ordinal: usize, member: &str) -> String {
+    if ordinal == 0 {
+        format!("__by_ext__{target}__{member}")
+    } else {
+        format!("__by_ext{}__{target}__{member}", ordinal + 1)
+    }
+}
+
+/// the spelled member kind, syntactically: a real `@property` decorator or a
+/// synthetic `static` / `classmethod` modifier marker
+fn member_kind(func: &ast::StmtFunctionDef, source: &str) -> ExtensionMemberKind {
+    for decorator in &func.decorator_list {
+        let Expr::Name(name) = &decorator.expression else {
+            continue;
+        };
+        if is_synthetic_decorator(source, decorator) {
+            match name.id.as_str() {
+                "static" => return ExtensionMemberKind::StaticMethod,
+                "classmethod" => return ExtensionMemberKind::ClassMethod,
+                _ => {}
+            }
+        } else if name.id.as_str() == "property" {
+            return ExtensionMemberKind::Property;
+        }
+    }
+    ExtensionMemberKind::Method
+}
+
+fn kind_word(kind: ExtensionMemberKind) -> &'static str {
+    match kind {
+        ExtensionMemberKind::Method => "method",
+        ExtensionMemberKind::Property => "property",
+        ExtensionMemberKind::StaticMethod => "static",
+        ExtensionMemberKind::ClassMethod => "classmethod",
+    }
+}
+
+pub(crate) fn parse_kind_word(word: &str) -> Option<ExtensionMemberKind> {
+    match word {
+        "method" => Some(ExtensionMemberKind::Method),
+        "property" => Some(ExtensionMemberKind::Property),
+        "static" => Some(ExtensionMemberKind::StaticMethod),
+        "classmethod" => Some(ExtensionMemberKind::ClassMethod),
+        _ => None,
+    }
+}
+
+/// render a member's parameter list without annotations (they reference type
+/// parameters with no runtime binding). defaults pass through as source spans
+/// so lowerings inside them compose
+fn parameter_fragments(parameters: &ast::Parameters, fragments: &mut Vec<Fragment>) {
+    let mut first = true;
+    let mut separate = |fragments: &mut Vec<Fragment>| {
+        if !first {
+            fragments.push(Fragment::Lit(", ".to_owned()));
+        }
+        first = false;
+    };
+    for param in &parameters.posonlyargs {
+        separate(fragments);
+        fragments.push(Fragment::Lit(param.parameter.name.to_string()));
+        if let Some(default) = &param.default {
+            fragments.push(Fragment::Lit("=".to_owned()));
+            fragments.push(Fragment::Src(default.range()));
+        }
+    }
+    if !parameters.posonlyargs.is_empty() {
+        separate(&mut *fragments);
+        fragments.push(Fragment::Lit("/".to_owned()));
+    }
+    for param in &parameters.args {
+        separate(fragments);
+        fragments.push(Fragment::Lit(param.parameter.name.to_string()));
+        if let Some(default) = &param.default {
+            fragments.push(Fragment::Lit("=".to_owned()));
+            fragments.push(Fragment::Src(default.range()));
+        }
+    }
+    if let Some(vararg) = &parameters.vararg {
+        separate(&mut *fragments);
+        fragments.push(Fragment::Lit(format!("*{}", vararg.name)));
+    } else if !parameters.kwonlyargs.is_empty() {
+        separate(&mut *fragments);
+        fragments.push(Fragment::Lit("*".to_owned()));
+    }
+    for param in &parameters.kwonlyargs {
+        separate(fragments);
+        fragments.push(Fragment::Lit(param.parameter.name.to_string()));
+        if let Some(default) = &param.default {
+            fragments.push(Fragment::Lit("=".to_owned()));
+            fragments.push(Fragment::Src(default.range()));
+        }
+    }
+    if let Some(kwarg) = &parameters.kwarg {
+        separate(&mut *fragments);
+        fragments.push(Fragment::Lit(format!("**{}", kwarg.name)));
+    }
+}
+
+/// lowers `extension` blocks to module-level backing functions
+pub(crate) struct ExtensionBlockPass<'a> {
+    source: &'a str,
+}
+
+impl<'a> ExtensionBlockPass<'a> {
+    pub(crate) fn new(source: &'a str) -> Self {
+        Self { source }
+    }
+
+    /// lower one extension block to its backing functions, in place. the block
+    /// is replaced where it stands so the method bodies keep their original
+    /// source ranges — that lets the sibling passes (extension-call rewrite,
+    /// coalesce, cast, …) compose their edits inside the `Src` body spans. the
+    /// finished `def`s are later hoisted to the module top by
+    /// [`hoist_backing_functions`], because a member may be called before the
+    /// block's source position
+    fn lower_block(&self, class: &ast::StmtClassDef, ordinal: usize, ctx: &mut PassContext) {
+        let source = self.source;
+        let target = class.name.as_str();
+        // the header spelling between `extension ` and `:`, bounds included —
+        // carried on each backing function so the reverse transform can
+        // re-sugar the block (and its bounds) faithfully
+        let header_end = class
+            .type_params
+            .as_deref()
+            .map_or(class.name.range().end(), |params| params.range.end());
+        let header = &source[usize::from(class.name.range().start())..usize::from(header_end)];
+
+        let mut fragments: Vec<Fragment> = Vec::new();
+        let mut first_member = true;
+        for stmt in &class.body {
+            let func = match stmt {
+                Stmt::FunctionDef(func) => func,
+                // a docstring, `...`, or `pass` adds nothing to the lowering
+                Stmt::Expr(expr)
+                    if matches!(
+                        &*expr.value,
+                        Expr::StringLiteral(_) | Expr::EllipsisLiteral(_)
+                    ) =>
+                {
+                    continue;
+                }
+                Stmt::Pass(_) => continue,
+                other => {
+                    ctx.errors.push(format!(
+                        "extension `{target}` may only contain methods and computed \
+                        properties (line with offset {})",
+                        u32::from(other.range().start()),
+                    ));
+                    continue;
+                }
+            };
+
+            if !first_member {
+                fragments.push(Fragment::Lit("\n\n".to_owned()));
+            }
+            first_member = false;
+
+            let kind = member_kind(func, source);
+            // real decorators other than `property` are kept (dedented to the
+            // module level); `property` and the synthetic modifier markers are
+            // consumed by the lowering itself
+            for decorator in &func.decorator_list {
+                if is_synthetic_decorator(source, decorator) {
+                    continue;
+                }
+                if matches!(&decorator.expression, Expr::Name(name) if name.id.as_str() == "property")
+                {
+                    continue;
+                }
+                fragments.push(Fragment::Lit("@".to_owned()));
+                fragments.push(Fragment::Src(decorator.expression.range()));
+                fragments.push(Fragment::Lit("\n".to_owned()));
+            }
+
+            fragments.push(Fragment::Lit(format!(
+                "def {}(",
+                backing_name(target, ordinal, func.name.as_str())
+            )));
+            parameter_fragments(&func.parameters, &mut fragments);
+            fragments.push(Fragment::Lit(")".to_owned()));
+
+            let marker = format!("{EXTENSION_MARKER} {} {header}", kind_word(kind));
+            let (Some(first_stmt), Some(last_stmt)) = (func.body.first(), func.body.last()) else {
+                fragments.push(Fragment::Lit(format!(": ...  {marker}")));
+                continue;
+            };
+            let body_line_start = line_start(source, first_stmt.range().start());
+            let inline = source
+                [usize::from(body_line_start)..usize::from(first_stmt.range().start())]
+                .contains(|c: char| !c.is_whitespace());
+            if inline {
+                fragments.push(Fragment::Lit(": ".to_owned()));
+                fragments.push(Fragment::Src(TextRange::new(
+                    first_stmt.range().start(),
+                    last_stmt.range().end(),
+                )));
+                fragments.push(Fragment::Lit(format!("  {marker}")));
+            } else {
+                fragments.push(Fragment::Lit(format!(":  {marker}\n")));
+                fragments.push(Fragment::Src(TextRange::new(
+                    body_line_start,
+                    last_stmt.range().end(),
+                )));
+            }
+        }
+
+        ctx.template_edits.push((class.range, fragments));
+    }
+}
+
+impl TypeAwarePass for ExtensionBlockPass<'_> {
+    fn run(&self, stmts: &[Stmt], _types: &dyn TypeInfo, ctx: &mut PassContext) {
+        // occurrence index per target name, module-wide — the mangle
+        // discriminator shared with ty's `backing_function_name`
+        let mut ordinals: HashMap<&str, usize> = HashMap::new();
+        for stmt in stmts {
+            let Stmt::ClassDef(class) = stmt else {
+                continue;
+            };
+            if !class.is_extension() {
+                continue;
+            }
+            let ordinal = *ordinals
+                .entry(class.name.as_str())
+                .and_modify(|n| *n += 1)
+                .or_insert(0);
+            self.lower_block(class, ordinal, ctx);
+        }
+    }
+}
+
+/// move the extension backing functions to the module top.
+///
+/// the block lowering re-emits each backing `def` where its `extension` block
+/// stood, so the method bodies keep their source ranges and the sibling passes
+/// compose their edits inside them. but a member may be *called* before that
+/// position — a plain top-level call resolves left-to-right, so the `def` must
+/// precede every use. this runs on the finished output text: it re-parses,
+/// finds the top-level `__by_ext…` functions, and moves their line blocks to
+/// just after the leading imports, permuting the line table identically so
+/// source maps stay aligned
+pub(crate) fn hoist_backing_functions(
+    out: String,
+    table: Vec<Option<u32>>,
+) -> (String, Vec<Option<u32>>) {
+    // cheap early-out: no backing functions were emitted
+    if !out.contains(EXTENSION_MARKER) {
+        return (out, table);
+    }
+
+    let parsed = parse_unchecked_source(&out, PySourceType::Python);
+    if !parsed.errors().is_empty() {
+        // the output isn't clean python yet (a later phase may still fix it);
+        // don't risk a move against a shape we can't trust
+        return (out, table);
+    }
+    let module = parsed.suite();
+
+    // the byte offset after the leading run of imports (and a module docstring)
+    // — where the backing functions belong, before any other statement
+    let mut insert_offset = 0usize;
+    for (index, stmt) in module.iter().enumerate() {
+        let is_docstring =
+            index == 0 && matches!(stmt, Stmt::Expr(expr) if expr.value.is_string_literal_expr());
+        if matches!(stmt, Stmt::Import(_) | Stmt::ImportFrom(_)) || is_docstring {
+            insert_offset = usize::from(stmt.range().end());
+        } else {
+            break;
+        }
+    }
+
+    // byte ranges of the top-level backing functions (decorators included)
+    let mut backing: Vec<(usize, usize)> = Vec::new();
+    for stmt in module {
+        if let Stmt::FunctionDef(func) = stmt
+            && func.name.starts_with("__by_ext")
+        {
+            let start = func
+                .decorator_list
+                .first()
+                .map_or(func.range().start(), |dec| dec.range().start());
+            backing.push((usize::from(start), usize::from(func.range().end())));
+        }
+    }
+    if backing.is_empty() {
+        return (out, table);
+    }
+
+    // line-block move. the table has one entry per output line, so permuting
+    // whole lines keeps it aligned
+    let had_trailing_newline = out.ends_with('\n');
+    let body = out.strip_suffix('\n').unwrap_or(&out);
+    let lines: Vec<&str> = body.split('\n').collect();
+    if table.len() != lines.len() {
+        // can't map lines to table entries one-to-one; leave order untouched
+        // rather than emit a misaligned table
+        return (out, table);
+    }
+
+    let line_starts: Vec<usize> = std::iter::once(0)
+        .chain(body.match_indices('\n').map(|(i, _)| i + 1))
+        .collect();
+    let line_of = |offset: usize| match line_starts.binary_search(&offset) {
+        Ok(line) => line,
+        Err(next) => next - 1,
+    };
+
+    let insert_line = if insert_offset == 0 {
+        0
+    } else {
+        line_of(insert_offset.min(body.len())) + 1
+    };
+
+    let mut moved: Vec<usize> = Vec::new();
+    for (start, end) in &backing {
+        let first = line_of(*start);
+        let last = line_of(end.saturating_sub(1));
+        moved.extend(first..=last);
+    }
+    let moved_set: BTreeSet<usize> = moved.iter().copied().collect();
+
+    // head (before the insertion point) + the moved defs + the tail, each with
+    // the moved lines removed — a permutation of every original line index
+    let mut order: Vec<usize> = Vec::with_capacity(lines.len());
+    order.extend((0..insert_line).filter(|i| !moved_set.contains(i)));
+    order.extend(moved.iter().copied());
+    order.extend((insert_line..lines.len()).filter(|i| !moved_set.contains(i)));
+
+    let new_lines: Vec<&str> = order.iter().map(|&i| lines[i]).collect();
+    let new_table: Vec<Option<u32>> = order.iter().map(|&i| table[i]).collect();
+
+    let mut result = new_lines.join("\n");
+    if had_trailing_newline {
+        result.push('\n');
+    }
+    (result, new_table)
+}
+
+/// does the postfix spine of `expr` contain an optional (`?.`) segment? the
+/// receiver of an extension rewrite must not, because the rewrite hoists the
+/// member access out of the chain's short-circuit
+fn spine_has_optional(expr: &Expr) -> bool {
+    match expr {
+        Expr::Attribute(attr) => attr.optional || spine_has_optional(&attr.value),
+        Expr::Subscript(subscript) => spine_has_optional(&subscript.value),
+        Expr::Call(call) => spine_has_optional(&call.func),
+        _ => false,
+    }
+}
+
+/// the source span of a call's arguments (positional and keyword), without
+/// the parentheses. `None` when the call has no arguments
+fn arguments_span(arguments: &ast::Arguments) -> Option<TextRange> {
+    let starts = arguments
+        .args
+        .iter()
+        .map(|arg| arg.range().start())
+        .chain(arguments.keywords.iter().map(|kw| kw.range().start()));
+    let ends = arguments
+        .args
+        .iter()
+        .map(|arg| arg.range().end())
+        .chain(arguments.keywords.iter().map(|kw| kw.range().end()));
+    Some(TextRange::new(starts.min()?, ends.max()?))
+}
+
+/// rewrites attribute accesses that ty resolved to extension members
+struct ExtensionCallLower<'a> {
+    types: &'a dyn TypeInfo,
+    edits: Vec<(TextRange, Vec<Fragment>)>,
+    imports: BTreeSet<String>,
+    needs_functools: bool,
+    errors: Vec<String>,
+    /// attribute nodes consumed by a whole-call rewrite, so the attribute
+    /// visit doesn't rewrite them a second time
+    handled: Vec<TextRange>,
+}
+
+impl<'a> ExtensionCallLower<'a> {
+    fn new(types: &'a dyn TypeInfo) -> Self {
+        Self {
+            types,
+            edits: Vec::new(),
+            imports: BTreeSet::new(),
+            needs_functools: false,
+            errors: Vec::new(),
+            handled: Vec::new(),
+        }
+    }
+
+    fn note_import(&mut self, info: &ty_python_semantic::ExtensionAttributeInfo) {
+        if let Some(module) = &info.import_from {
+            self.imports
+                .insert(format!("from {module} import {}", info.function));
+        }
+    }
+
+    /// the receiver a backing function is handed: the receiver itself for
+    /// methods, the class object for a `class def` (via `type(…)` when the
+    /// access went through an instance)
+    fn receiver_fragments(
+        info: &ty_python_semantic::ExtensionAttributeInfo,
+        receiver: &Expr,
+        fragments: &mut Vec<Fragment>,
+    ) {
+        if info.kind == ExtensionMemberKind::ClassMethod && !info.receiver_is_class {
+            fragments.push(Fragment::Lit("type(".to_owned()));
+            fragments.push(Fragment::Src(receiver.range()));
+            fragments.push(Fragment::Lit(")".to_owned()));
+        } else {
+            fragments.push(Fragment::Src(receiver.range()));
+        }
+    }
+}
+
+impl<'ast> Visitor<'ast> for ExtensionCallLower<'_> {
+    fn visit_stmt(&mut self, stmt: &'ast Stmt) {
+        walk_stmt(self, stmt);
+    }
+
+    fn visit_expr(&mut self, expr: &'ast Expr) {
+        match expr {
+            Expr::Call(call) => {
+                if let Expr::Attribute(attr) = call.func.as_ref()
+                    && attr.ctx.is_load()
+                    && let Some(info) = self.types.extension_attribute_info(attr)
+                    && info.kind != ExtensionMemberKind::Property
+                {
+                    if attr.optional || spine_has_optional(&attr.value) {
+                        self.errors.push(format!(
+                            "extension member `{}` cannot be called through an \
+                            optional chain yet",
+                            attr.attr,
+                        ));
+                    } else {
+                        self.handled.push(attr.range());
+                        self.note_import(&info);
+                        let mut fragments = vec![Fragment::Lit(format!("{}(", info.function))];
+                        let receiver_counts = info.kind != ExtensionMemberKind::StaticMethod;
+                        if receiver_counts {
+                            Self::receiver_fragments(&info, &attr.value, &mut fragments);
+                        }
+                        if let Some(span) = arguments_span(&call.arguments) {
+                            if receiver_counts {
+                                fragments.push(Fragment::Lit(", ".to_owned()));
+                            }
+                            fragments.push(Fragment::Src(span));
+                        }
+                        fragments.push(Fragment::Lit(")".to_owned()));
+                        self.edits.push((call.range(), fragments));
+                    }
+                }
+            }
+            Expr::Attribute(attr) => {
+                if attr.ctx.is_load()
+                    && !self.handled.contains(&attr.range())
+                    && let Some(info) = self.types.extension_attribute_info(attr)
+                {
+                    if attr.optional || spine_has_optional(&attr.value) {
+                        self.errors.push(format!(
+                            "extension member `{}` cannot be accessed through an \
+                            optional chain yet",
+                            attr.attr,
+                        ));
+                    } else {
+                        self.note_import(&info);
+                        let mut fragments = Vec::new();
+                        match info.kind {
+                            ExtensionMemberKind::Property => {
+                                fragments.push(Fragment::Lit(format!("{}(", info.function)));
+                                fragments.push(Fragment::Src(attr.value.range()));
+                                fragments.push(Fragment::Lit(")".to_owned()));
+                            }
+                            ExtensionMemberKind::StaticMethod => {
+                                fragments.push(Fragment::Lit(info.function.clone()));
+                            }
+                            ExtensionMemberKind::Method | ExtensionMemberKind::ClassMethod => {
+                                // an unapplied member reference: bind the
+                                // receiver the way the bound method would have
+                                self.needs_functools = true;
+                                fragments.push(Fragment::Lit(format!(
+                                    "functools.partial({}, ",
+                                    info.function
+                                )));
+                                Self::receiver_fragments(&info, &attr.value, &mut fragments);
+                                fragments.push(Fragment::Lit(")".to_owned()));
+                            }
+                        }
+                        self.edits.push((attr.range(), fragments));
+                    }
+                }
+            }
+            _ => {}
+        }
+        walk_expr(self, expr);
+    }
+}
+
+pub(crate) struct ExtensionCallPass;
+
+impl TypeAwarePass for ExtensionCallPass {
+    fn run(&self, stmts: &[Stmt], types: &dyn TypeInfo, ctx: &mut PassContext) {
+        let mut inner = ExtensionCallLower::new(types);
+        for stmt in stmts {
+            inner.visit_stmt(stmt);
+        }
+        ctx.errors.extend(inner.errors);
+        if inner.edits.is_empty() {
+            return;
+        }
+        if inner.needs_functools {
+            ctx.required_imports.push("import functools".to_owned());
+        }
+        ctx.required_imports.extend(inner.imports);
+        ctx.template_edits.extend(inner.edits);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Config, transpile};
+
+    fn check(input: &str) -> String {
+        transpile(input, &Config::test_default()).unwrap()
+    }
+
+    #[test]
+    fn method_lowers_to_backing_function() {
+        let out = check(
+            "extension list:\n    def second(self) -> Element:\n        return self[1]\n\nxs = [1, 2, 3]\nprint(xs.second())\n",
+        );
+        assert!(
+            out.contains("def __by_ext__list__second(self):  # basedpython: extension method list"),
+            "got:\n{out}"
+        );
+        assert!(out.contains("return self[1]"), "got:\n{out}");
+        assert!(
+            out.contains("print(__by_ext__list__second(xs))"),
+            "got:\n{out}"
+        );
+        assert!(!out.contains("extension list"), "got:\n{out}");
+    }
+
+    #[test]
+    fn backing_function_is_hoisted_above_an_earlier_call() {
+        // a member called before the block's source position must still resolve
+        // — the backing `def` is hoisted to the module top
+        let out =
+            check("\"asdf\".foo()\n\nextension str:\n    def foo(self):\n        print(\"hi\")\n");
+        let def_at = out
+            .find("def __by_ext__str__foo")
+            .expect("backing def present");
+        let call_at = out
+            .find("__by_ext__str__foo(\"asdf\")")
+            .expect("call rewritten");
+        assert!(
+            def_at < call_at,
+            "backing def must precede its call, got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn call_arguments_follow_the_receiver() {
+        let out = check(
+            "extension list:\n    def first_or(self, default: Element) -> Element:\n        return self[0] if self else default\n\nxs = [1]\nprint(xs.first_or(9))\n",
+        );
+        assert!(
+            out.contains("print(__by_ext__list__first_or(xs, 9))"),
+            "got:\n{out}"
+        );
+        // annotations are dropped from the backing function — its parameters
+        // reference type variables with no runtime binding
+        assert!(
+            out.contains("def __by_ext__list__first_or(self, default):"),
+            "got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn property_access_drops_the_parentheses() {
+        let out = check(
+            "extension str:\n    @property\n    def shouty(self) -> str:\n        return self.upper()\n\nname = \"hi\"\nprint(name.shouty)\n",
+        );
+        assert!(
+            out.contains("def __by_ext__str__shouty(self):  # basedpython: extension property str"),
+            "got:\n{out}"
+        );
+        assert!(!out.contains("@property"), "got:\n{out}");
+        assert!(
+            out.contains("print(__by_ext__str__shouty(name))"),
+            "got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn conditional_extension_keeps_bounds_in_marker() {
+        let out = check(
+            "extension list[Element: int]:\n    def total(self) -> int:\n        return sum(self)\n\nxs = [1, 2]\nprint(xs.total())\n",
+        );
+        assert!(
+            out.contains(
+                "def __by_ext__list__total(self):  # basedpython: extension method list[Element: int]"
+            ),
+            "got:\n{out}"
+        );
+        assert!(
+            out.contains("print(__by_ext__list__total(xs))"),
+            "got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn same_target_extensions_get_ordinals() {
+        let out = check(
+            "extension list[Element: int]:\n    def total(self) -> int:\n        return sum(self)\n\nextension list[Element: str]:\n    def total(self) -> str:\n        return \"\".join(self)\n\nints = [1, 2]\nwords = [\"a\"]\nprint(ints.total())\nprint(words.total())\n",
+        );
+        assert!(
+            out.contains("def __by_ext__list__total(self):"),
+            "got:\n{out}"
+        );
+        assert!(
+            out.contains("def __by_ext2__list__total(self):"),
+            "got:\n{out}"
+        );
+        assert!(
+            out.contains("print(__by_ext__list__total(ints))"),
+            "got:\n{out}"
+        );
+        assert!(
+            out.contains("print(__by_ext2__list__total(words))"),
+            "got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn unapplied_method_reference_becomes_partial() {
+        let out = check(
+            "extension list:\n    def second(self) -> Element:\n        return self[1]\n\nxs = [1, 2]\nf = xs.second\nprint(f())\n",
+        );
+        assert!(
+            out.contains("f = functools.partial(__by_ext__list__second, xs)"),
+            "got:\n{out}"
+        );
+        assert!(out.contains("import functools"), "got:\n{out}");
+    }
+
+    #[test]
+    fn nested_lowerings_compose_inside_member_bodies() {
+        // the member body's own basedpython constructs still lower: the body
+        // passes through as a source span with nested edits applied
+        let out = check(
+            "extension list:\n    def head(self) -> Element?:\n        return self[0] if self else None\n\nxs = [1]\nprint(xs.head())\n",
+        );
+        assert!(
+            out.contains("def __by_ext__list__head(self):"),
+            "got:\n{out}"
+        );
+        assert!(
+            out.contains("print(__by_ext__list__head(xs))"),
+            "got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn extension_method_calling_another_extension_member() {
+        let out = check(
+            "extension list:\n    def second(self) -> Element:\n        return self[1]\n    def second_twice(self) -> Element:\n        return self.second()\n\nxs = [1, 2]\nprint(xs.second_twice())\n",
+        );
+        assert!(
+            out.contains("return __by_ext__list__second(self)"),
+            "got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn real_attributes_win_over_extensions() {
+        let out = check(
+            "class Widget:\n    def label(self) -> str:\n        return \"real\"\n\nextension Widget:\n    def label(self) -> int:\n        return 0\n\nw = Widget()\nprint(w.label())\n",
+        );
+        assert!(out.contains("print(w.label())"), "got:\n{out}");
+    }
+
+    #[test]
+    fn static_and_class_members_bind_the_class_object() {
+        let out = check(
+            "extension str:\n    static def joined(parts: list[str]) -> str:\n        return \"-\".join(parts)\n    class def empty(cls) -> str:\n        return cls()\n\nprint(str.joined([\"a\", \"b\"]))\nprint(str.empty())\n",
+        );
+        assert!(
+            out.contains("def __by_ext__str__joined(parts):  # basedpython: extension static str"),
+            "got:\n{out}"
+        );
+        assert!(
+            out.contains(
+                "def __by_ext__str__empty(cls):  # basedpython: extension classmethod str"
+            ),
+            "got:\n{out}"
+        );
+        // a static member drops the receiver; a classmethod receives the class
+        assert!(
+            out.contains("print(__by_ext__str__joined([\"a\", \"b\"]))"),
+            "got:\n{out}"
+        );
+        assert!(
+            out.contains("print(__by_ext__str__empty(str))"),
+            "got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn optional_chain_receiver_is_rejected() {
+        let err = transpile(
+            "extension list:\n    def second(self) -> Element:\n        return self[1]\n\nxs: list[int]? = [1, 2]\nprint(xs?.second())\n",
+            &Config::test_default(),
+        )
+        .unwrap_err();
+        assert!(err.contains("optional chain"), "got:\n{err}");
+    }
+}

--- a/crates/by_transforms/src/transforms/mod.rs
+++ b/crates/by_transforms/src/transforms/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod dedent_string;
 pub(crate) mod dynamic_keyword;
 pub(crate) mod empty_declarations;
 pub(crate) mod enums;
+pub(crate) mod extension;
 pub(crate) mod float_const;
 pub(crate) mod force_unwrap;
 pub(crate) mod generic_call;

--- a/crates/by_transforms/src/transforms/none_chain.rs
+++ b/crates/by_transforms/src/transforms/none_chain.rs
@@ -36,10 +36,11 @@ fn pick_temp_var(types: &dyn TypeInfo, anchor: &Expr) -> &'static str {
     "_t9"
 }
 
-/// walks an attribute-access chain and returns `Some((python_form, guards))` when
-/// any `?.` is present, where `python_form` has all `?.` replaced by `.` and
+/// walks an attribute-access chain and returns `Some((python_form, guards, base))`
+/// when any `?.` is present, where `python_form` has all `?.` replaced by `.`,
 /// `guards` is the ordered list of accumulated sub-expressions that must be
-/// non-None before each subsequent optional access is safe.
+/// non-None before each subsequent optional access is safe, and `base` is the
+/// source range of the first `?.`'s receiver — everything before the first `?`
 ///
 /// a `?.` whose base is a *wrapped* optional (`int??`, a generic `T?`)
 /// reaches its present value through the runtime wrapper: the guard still
@@ -48,7 +49,7 @@ pub(super) fn expand_chain(
     expr: &Expr,
     source: &str,
     types: &dyn TypeInfo,
-) -> Option<(String, Vec<String>)> {
+) -> Option<(String, Vec<String>, TextRange)> {
     let Expr::Attribute(attr) = expr else {
         return None;
     };
@@ -59,11 +60,11 @@ pub(super) fn expand_chain(
         ""
     };
     match expand_chain(&attr.value, source, types) {
-        Some((v_form, mut guards)) => {
+        Some((v_form, mut guards, base)) => {
             if attr.optional {
                 guards.push(v_form.clone());
             }
-            Some((format!("{v_form}{unwrap}.{field}"), guards))
+            Some((format!("{v_form}{unwrap}.{field}"), guards, base))
         }
         None => {
             if !attr.optional {
@@ -72,19 +73,37 @@ pub(super) fn expand_chain(
             let start = usize::from(attr.value.range().start());
             let end = usize::from(attr.value.range().end());
             let v_form = source[start..end].to_owned();
-            Some((format!("{v_form}{unwrap}.{field}"), vec![v_form]))
+            Some((
+                format!("{v_form}{unwrap}.{field}"),
+                vec![v_form],
+                attr.value.range(),
+            ))
         }
     }
 }
 
 /// builds a `None if ... is None else ...` chain from guards and final result,
-/// using walrus assignment to avoid evaluating compound intermediate expressions twice
-pub(super) fn build_expansion(guards: &[String], result: &str, temp: &str) -> String {
+/// using walrus assignment to avoid evaluating compound intermediate
+/// expressions twice.
+///
+/// returns fragments rather than text: a compound chain base is walrus-bound
+/// exactly once, and passing it through as a [`Fragment::Src`] span lets
+/// sibling lowerings inside it (an extension call, a cast, …) materialize
+/// instead of being clobbered. only the first guard can carry the raw base —
+/// every later guard is an incremental `temp.suffix` — and a name-only base
+/// has no interior for an edit to target, so the `Src` is needed exactly there
+pub(super) fn build_expansion(
+    guards: &[String],
+    result: &str,
+    temp: &str,
+    base: TextRange,
+) -> Vec<Fragment> {
+    let mut fragments: Vec<Fragment> = Vec::new();
     let mut s = String::new();
     let mut use_t = false;
     let mut prev_guard: Option<&str> = None;
 
-    for guard in guards {
+    for (position, guard) in guards.iter().enumerate() {
         let guard_expr = if let Some(prev) = prev_guard.filter(|_| use_t) {
             let incremental = &guard[prev.len() + 1..];
             format!("{temp}.{incremental}")
@@ -95,7 +114,14 @@ pub(super) fn build_expansion(guards: &[String], result: &str, temp: &str) -> St
         if guard_expr.chars().all(|c| c.is_alphanumeric() || c == '_') {
             let _ = write!(s, "None if {guard_expr} is None else ");
         } else {
-            let _ = write!(s, "None if ({temp} := {guard_expr}) is None else ");
+            if position == 0 {
+                let _ = write!(s, "None if ({temp} := ");
+                fragments.push(Fragment::Lit(std::mem::take(&mut s)));
+                fragments.push(Fragment::Src(base));
+                let _ = write!(s, ") is None else ");
+            } else {
+                let _ = write!(s, "None if ({temp} := {guard_expr}) is None else ");
+            }
             use_t = true;
         }
         prev_guard = Some(guard.as_str());
@@ -107,8 +133,11 @@ pub(super) fn build_expansion(guards: &[String], result: &str, temp: &str) -> St
     } else {
         s.push_str(result);
     }
+    if !s.is_empty() {
+        fragments.push(Fragment::Lit(s));
+    }
 
-    s
+    fragments
 }
 
 /// the `?.` attribute chain at the base of `expr`, with its expansion, when `expr` is a
@@ -120,9 +149,9 @@ fn chain_head<'a>(
     expr: &'a Expr,
     source: &str,
     types: &dyn TypeInfo,
-) -> Option<(&'a Expr, String, Vec<String>)> {
-    if let Some((form, guards)) = expand_chain(expr, source, types) {
-        return Some((expr, form, guards));
+) -> Option<(&'a Expr, String, Vec<String>, TextRange)> {
+    if let Some((form, guards, base)) = expand_chain(expr, source, types) {
+        return Some((expr, form, guards, base));
     }
     match expr {
         Expr::Attribute(attribute) => chain_head(&attribute.value, source, types),
@@ -192,18 +221,14 @@ impl<'ast> Visitor<'ast> for NoneChain<'_> {
         // followed into its `else` branch — `not a?.b` would yield `a.b`, and
         // `[i for i in a?.b]` would not even parse. the parentheses keep the emitted tree
         // the one that was parsed
-        if let Some((head, form, guards)) = chain_head(expr, self.source, self.types) {
+        if let Some((head, form, guards, base)) = chain_head(expr, self.source, self.types) {
             let temp = pick_temp_var(self.types, expr);
-            let expansion = build_expansion(&guards, &form, temp);
             let trailers = TextRange::new(head.range().end(), expr.range().end());
-            self.template_edits.push((
-                expr.range(),
-                vec![
-                    Fragment::Lit(format!("({expansion}")),
-                    Fragment::Src(trailers),
-                    Fragment::Lit(")".to_owned()),
-                ],
-            ));
+            let mut fragments = vec![Fragment::Lit("(".to_owned())];
+            fragments.extend(build_expansion(&guards, &form, temp, base));
+            fragments.push(Fragment::Src(trailers));
+            fragments.push(Fragment::Lit(")".to_owned()));
+            self.template_edits.push((expr.range(), fragments));
             self.visit_trailers(expr, head);
             return;
         }

--- a/crates/by_transforms/src/type_info.rs
+++ b/crates/by_transforms/src/type_info.rs
@@ -77,6 +77,15 @@ pub(crate) trait TypeInfo {
     /// reject as its classinfo argument at runtime
     fn is_keeps_identity(&self, expr: &Expr) -> bool;
 
+    /// when `attribute` resolves to a basedpython `extension` member, the
+    /// backing-function rewrite to apply (`xs.second()` →
+    /// `__by_ext__list__second(xs)`). `None` for ordinary attributes —
+    /// extensions never shadow declared members
+    fn extension_attribute_info(
+        &self,
+        attribute: &ruff_python_ast::ExprAttribute,
+    ) -> Option<ty_python_semantic::ExtensionAttributeInfo>;
+
     /// whether `expr` resolves to `typing.Any` (the explicitly-annotated
     /// dynamic type). distinguishes the special form from a shadowing binding
     /// or the `Unknown` that an unresolved / invalid type expression yields,
@@ -241,6 +250,13 @@ impl TypeInfo for SemanticModel<'_> {
         expr.inferred_type(self).is_some_and(|ty| {
             ty_python_semantic::types::basedpython_is_keeps_identity(self.db(), ty)
         })
+    }
+
+    fn extension_attribute_info(
+        &self,
+        attribute: &ruff_python_ast::ExprAttribute,
+    ) -> Option<ty_python_semantic::ExtensionAttributeInfo> {
+        SemanticModel::extension_attribute_info(self, attribute)
     }
 
     fn is_any(&self, expr: &Expr) -> bool {

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -83,6 +83,14 @@ impl StmtClassDef {
         self.has_synthetic_marker("enum_def")
     }
 
+    /// True for an extension declaration (`extension list:`) — methods and
+    /// computed properties added to an existing type. the class name is the
+    /// *extended* type, a reference to an existing declaration, so an
+    /// extension def never introduces a binding for it.
+    pub fn is_extension(&self) -> bool {
+        self.has_synthetic_marker("extension_def")
+    }
+
     /// True for a based-enum variant (`Circle(radius: float)`, `Empty`) — the
     /// nested class defs inside a based enum.
     pub fn is_enum_variant(&self) -> bool {

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/extension.by
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/extension.by
@@ -1,0 +1,34 @@
+# basedpython `extension` blocks — the synthetic `extension_def` marker renders
+# as the `extension` keyword and suppresses the `class` keyword, while the body
+# formats as ordinary class-body statements
+
+extension list:
+    def second(self) -> Element:
+        return self[1]
+
+
+# reused-parameter bound in the bracket header
+extension list[Element: int]:
+    def total(self) -> int:
+        return sum(self)
+
+
+# computed property
+extension str:
+    @property
+    def shouty(self) -> str:
+        return self.upper()
+
+
+# `static def` / `class def` members
+extension str:
+    static def joined(parts: list[str]) -> str:
+        return "-".join(parts)
+    class def empty(cls) -> str:
+        return cls()
+
+
+# a method introducing its own fresh parameters
+extension dict:
+    def get_or[R](self, key: Key, default: R) -> Value | R:
+        return self[key] if key in self else default

--- a/crates/ruff_python_formatter/src/statement/stmt_class_def.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_class_def.rs
@@ -82,14 +82,19 @@ impl FormatNodeRule<StmtClassDef> for FormatStmtClassDef {
         // are more than two, then `leading_comments` will preserve the correct number of newlines.
         empty_lines_after_leading_comments(comments.leading(item)).fmt(f)?;
 
-        // basedpython: `protocol Foo:` introduces a class without the `class`
-        // keyword. the parser still synthesizes a `ClassDef` but tags it with a
-        // synthetic `protocol_class` decorator so the round-trip emits the
-        // keyword form instead of `protocol class Foo:`
+        // basedpython: `protocol Foo:` and `extension Foo:` introduce a class
+        // without the `class` keyword. the parser still synthesizes a `ClassDef`
+        // but tags it with a synthetic `protocol_class` / `extension_def`
+        // decorator (rendered verbatim as its keyword text). suppress the `class`
+        // keyword so the round-trip emits `protocol Foo:` / `extension Foo:`
+        // rather than `protocol class Foo:`. the body is ordinary class-body
+        // statements, so it formats normally (unlike `enum`, whose `case`
+        // variants have no printer and force verbatim)
         let suppress_class_keyword = f.options().is_basedpython()
-            && decorator_list.iter().any(
-                |d| matches!(&d.expression, Expr::Name(n) if n.id.as_str() == "protocol_class"),
-            );
+            && decorator_list.iter().any(|d| {
+                matches!(&d.expression, Expr::Name(n)
+                    if matches!(n.id.as_str(), "protocol_class" | "extension_def"))
+            });
 
         let format_header = format_with(|f| {
             if !suppress_class_keyword {

--- a/crates/ruff_python_formatter/tests/snapshots/format@extension.by.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@extension.by.snap
@@ -1,0 +1,81 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/extension.by
+---
+## Input
+```bython
+# basedpython `extension` blocks — the synthetic `extension_def` marker renders
+# as the `extension` keyword and suppresses the `class` keyword, while the body
+# formats as ordinary class-body statements
+
+extension list:
+    def second(self) -> Element:
+        return self[1]
+
+
+# reused-parameter bound in the bracket header
+extension list[Element: int]:
+    def total(self) -> int:
+        return sum(self)
+
+
+# computed property
+extension str:
+    @property
+    def shouty(self) -> str:
+        return self.upper()
+
+
+# `static def` / `class def` members
+extension str:
+    static def joined(parts: list[str]) -> str:
+        return "-".join(parts)
+    class def empty(cls) -> str:
+        return cls()
+
+
+# a method introducing its own fresh parameters
+extension dict:
+    def get_or[R](self, key: Key, default: R) -> Value | R:
+        return self[key] if key in self else default
+```
+
+## Output
+```bython
+# basedpython `extension` blocks — the synthetic `extension_def` marker renders
+# as the `extension` keyword and suppresses the `class` keyword, while the body
+# formats as ordinary class-body statements
+
+
+extension list:
+    def second(self) -> Element:
+        return self[1]
+
+
+# reused-parameter bound in the bracket header
+extension list[Element: int]:
+    def total(self) -> int:
+        return sum(self)
+
+
+# computed property
+extension str:
+    @property
+    def shouty(self) -> str:
+        return self.upper()
+
+
+# `static def` / `class def` members
+extension str:
+    static def joined(parts: list[str]) -> str:
+        return "-".join(parts)
+
+    class def empty(cls) -> str:
+        return cls()
+
+
+# a method introducing its own fresh parameters
+extension dict:
+    def get_or[R](self, key: Key, default: R) -> Value | R:
+        return self[key] if key in self else default
+```

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -249,6 +249,12 @@ impl<'src> Parser<'src> {
             );
             return Some(self.parse_protocol_def(start, DecoratorList::new()));
         }
+        if kw == "extension" && self.peek() == TokenKind::Name {
+            self.error_if_not_basedpython(
+                "`extension` declarations are not valid in .py files".to_string(),
+            );
+            return Some(self.parse_extension_def(start));
+        }
         // `enum class E:` / `enum class E[T]:` — a "based enum" (an algebraic
         // sum type when its body has payload variants, an idiomatic `Enum` when
         // its variants are all unit). the `class` keyword is part of the
@@ -1089,6 +1095,70 @@ impl<'src> Parser<'src> {
             name,
             type_params: type_params.map(Box::new),
             arguments,
+            body,
+            node_index: AtomicNodeIndex::NONE,
+        })
+    }
+
+    /// Parses an `extension Name[bounds]:` declaration — methods and computed
+    /// properties added to an existing type without subclassing it.
+    ///
+    /// Produces a [`ClassDef`] carrying a synthetic `extension_def` marker
+    /// decorator. the class name is the *extended* type (it references an
+    /// existing declaration rather than introducing a new one), and any
+    /// bracketed type params are constraints on that type's own parameters
+    /// (`extension list[Element: int]:`), not fresh declarations
+    ///
+    /// [`ClassDef`]: ast::StmtClassDef
+    fn parse_extension_def(&mut self, start: TextSize) -> Stmt {
+        let extension_start = self.current_token_range().start();
+        self.bump(TokenKind::Name); // consume "extension"
+        let name_start = self.current_token_range().start();
+        let decorator_range = TextRange::new(extension_start, name_start);
+
+        let mut decorators = DecoratorList::new();
+        decorators.push(ast::Decorator {
+            expression: Expr::Name(ast::ExprName {
+                id: Name::new_static("extension_def"),
+                ctx: ExprContext::Invalid,
+                range: decorator_range,
+                node_index: AtomicNodeIndex::NONE,
+            }),
+            range: decorator_range,
+            node_index: AtomicNodeIndex::NONE,
+        });
+
+        let name = self.parse_identifier();
+        let type_params = self.try_parse_type_params();
+
+        // an extension adds behaviour to the named type; it has no bases
+        if self.at(TokenKind::Lpar) {
+            self.add_error(
+                ParseErrorType::OtherError(
+                    "`extension` declarations cannot have base classes".to_string(),
+                ),
+                self.current_token_range(),
+            );
+        }
+
+        let body = if self.eat(TokenKind::Colon) {
+            self.parse_body(Clause::Class)
+        } else {
+            self.add_error(
+                ParseErrorType::OtherError(
+                    "Expected `:` after `extension` declaration".to_string(),
+                ),
+                self.current_token_range(),
+            );
+            Suite::new()
+        };
+
+        Stmt::ClassDef(ast::StmtClassDef {
+            range: self.node_range(start),
+            decorator_list: decorators,
+            name,
+            type_params: type_params.map(Box::new),
+            arguments: None,
             body,
             node_index: AtomicNodeIndex::NONE,
         })

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -163,6 +163,100 @@ fn basedpython_paramspec_arrow_params_parse() {
 }
 
 #[test]
+fn basedpython_extension_parses_to_marked_class() {
+    let parsed = parse_basedpython_module(
+        "extension list:\n    def second(self) -> Element:\n        return self[1]\n",
+    );
+    let [Stmt::ClassDef(class)] = parsed.syntax().body.as_slice() else {
+        panic!("expected a single ClassDef");
+    };
+    assert_eq!(class.name.as_str(), "list");
+    assert!(class.type_params.is_none());
+    assert!(class.arguments.is_none());
+    let names: Vec<&str> = class
+        .decorator_list
+        .iter()
+        .filter_map(|d| d.expression.as_name_expr().map(|n| n.id.as_str()))
+        .collect();
+    assert_eq!(names, ["extension_def"]);
+    assert!(matches!(class.body.as_slice(), [Stmt::FunctionDef(f)] if f.name.as_str() == "second"));
+}
+
+#[test]
+fn basedpython_extension_with_bounds_parses_type_params() {
+    let parsed = parse_basedpython_module(
+        "extension list[Element: int]:\n    def total(self) -> int:\n        return sum(self)\n",
+    );
+    let [Stmt::ClassDef(class)] = parsed.syntax().body.as_slice() else {
+        panic!("expected a single ClassDef");
+    };
+    let type_params = class.type_params.as_ref().expect("expected type params");
+    assert_eq!(type_params.type_params.len(), 1);
+    let param = type_params.type_params[0]
+        .as_type_var()
+        .expect("expected a plain TypeVar param");
+    assert_eq!(param.name.as_str(), "Element");
+    assert!(param.bound.is_some());
+}
+
+#[test]
+fn basedpython_extension_rejects_base_classes() {
+    let parsed = crate::Parser::new(
+        "extension list(Sequence):\n    def second(self): ...\n",
+        ParseOptions::from(Mode::Module).with_basedpython(true),
+    )
+    .parse()
+    .try_into_module()
+    .unwrap();
+    assert!(
+        parsed
+            .errors()
+            .iter()
+            .any(|e| e.to_string().contains("cannot have base classes")),
+        "expected a base-class error, got: {:?}",
+        parsed.errors()
+    );
+}
+
+#[test]
+fn basedpython_extension_soft_keyword_stays_a_name() {
+    // `extension` only introduces a declaration when followed by a name.
+    // every other shape must remain an ordinary identifier
+    for source in [
+        "extension = 1",
+        "extension(x)",
+        "extension[0]",
+        "print(extension)",
+        "extension.field = 2",
+        "extension: int = 3",
+    ] {
+        let parsed = parse_basedpython_module(source);
+        assert!(
+            parsed.errors().is_empty(),
+            "unexpected parse errors in {source:?}: {:?}",
+            parsed.errors()
+        );
+        assert!(
+            !matches!(parsed.syntax().body.as_slice(), [Stmt::ClassDef(_)]),
+            "{source:?} must not parse as an extension declaration"
+        );
+    }
+}
+
+#[test]
+fn extension_rejected_in_py_file() {
+    // the `extension` introducer is basedpython-only
+    let has_error = match parse(
+        "extension list:\n    def second(self): ...\n",
+        ParseOptions::from(Mode::Module),
+    ) {
+        Ok(parsed) => !parsed.errors().is_empty(),
+        Err(_) => true,
+    };
+    assert!(has_error, "`extension` must be rejected in a .py file");
+}
+
+#[test]
 fn final_annotation_rejected_in_py_file() {
     // `final x: T` is basedpython-only; a plain `.py` parse must report the gate
     let has_error = match parse("final x: int\n", ParseOptions::from(Mode::Module)) {

--- a/crates/ty/docs/rules.md
+++ b/crates/ty/docs/rules.md
@@ -8,7 +8,7 @@
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.13">0.0.13</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22abstract-method-in-final-class%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1234" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1292" target="_blank">View source</a>
 </small>
 
 
@@ -54,7 +54,7 @@ class Derived(Base):  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.61">0.0.61</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22ambiguous-context-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1022" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1080" target="_blank">View source</a>
 </small>
 
 
@@ -81,13 +81,48 @@ f(1)          # error: `s1` and `s2` both match
 f(1, b=s1)    # ok — explicit
 ```
 
+## `ambiguous-extension-member`
+
+<small>
+Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
+Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.3">0.0.1-alpha.3</a> ·
+<a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22ambiguous-extension-member%22" target="_blank">Related issues</a> ·
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L968" target="_blank">View source</a>
+</small>
+
+
+**What it does**
+
+Checks for attribute accesses that resolve to a member supplied by more
+than one applicable basedpython extension.
+
+**Why is this bad?**
+
+When two extensions in scope both add the same member to the receiver's
+type, the access is ambiguous — which implementation runs would depend
+on arbitrary ordering. Constrain one of the extensions (or drop the
+import that brings the second into scope) so exactly one applies.
+
+**Example**
+
+
+```by
+extension list:
+    def second(self) -> Element: ...
+
+extension list:
+    def second(self) -> Element: ...
+
+[1, 2].second()  # error: ambiguous extension member
+```
+
 ## `ambiguous-protocol-member`
 
 <small>
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.20">0.0.1-alpha.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22ambiguous-protocol-member%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L344" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L346" target="_blank">View source</a>
 </small>
 
 
@@ -151,7 +186,7 @@ class SubProto(BaseProto, Protocol):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22assert-type-unspellable-subtype%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1279" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1337" target="_blank">View source</a>
 </small>
 
 
@@ -234,7 +269,7 @@ value = unknown  # ty: ignore[unresolved-reference]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.16">0.0.16</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22call-abstract-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1243" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1301" target="_blank">View source</a>
 </small>
 
 
@@ -289,7 +324,7 @@ Foo.method()  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22call-non-callable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L198" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L200" target="_blank">View source</a>
 </small>
 
 
@@ -317,7 +352,7 @@ Calling a non-callable object will raise a `TypeError` at runtime.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.7">0.0.7</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22call-top-callable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L207" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L209" target="_blank">View source</a>
 </small>
 
 
@@ -352,7 +387,7 @@ def f(x: object):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22conflicting-declarations%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L225" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L227" target="_blank">View source</a>
 </small>
 
 
@@ -386,7 +421,7 @@ a = 1  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22conflicting-metaclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L234" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L236" target="_blank">View source</a>
 </small>
 
 
@@ -421,7 +456,7 @@ class C(A, B): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22cyclic-class-definition%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L243" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L245" target="_blank">View source</a>
 </small>
 
 
@@ -457,7 +492,7 @@ class B(A): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.29">0.0.1-alpha.29</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22cyclic-type-alias-definition%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L252" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L254" target="_blank">View source</a>
 </small>
 
 
@@ -493,7 +528,7 @@ type B = A  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22dataclass-field-order%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L297" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L299" target="_blank">View source</a>
 </small>
 
 
@@ -530,7 +565,7 @@ class Example:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.16">0.0.1-alpha.16</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22deprecated%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L270" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L272" target="_blank">View source</a>
 </small>
 
 
@@ -569,7 +604,7 @@ old_func()  # error: [deprecated]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22division-by-zero%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L261" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L263" target="_blank">View source</a>
 </small>
 
 
@@ -602,7 +637,7 @@ false positives it can produce.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22duplicate-base%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L279" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L281" target="_blank">View source</a>
 </small>
 
 
@@ -633,7 +668,7 @@ class B(A, A): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.12">0.0.1-alpha.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22duplicate-kw-only%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L288" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L290" target="_blank">View source</a>
 </small>
 
 
@@ -676,7 +711,7 @@ class A:  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22empty-body%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L444" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L446" target="_blank">View source</a>
 </small>
 
 
@@ -726,7 +761,7 @@ def bar() -> str:  # error: [empty-body]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.61">0.0.61</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22erased-cast-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L939" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L997" target="_blank">View source</a>
 </small>
 
 
@@ -767,7 +802,7 @@ def g(x: object):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.3">0.0.1-alpha.3</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22erased-type-check%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1112" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1170" target="_blank">View source</a>
 </small>
 
 
@@ -839,7 +874,7 @@ def foo() -> "intt\b": ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.50">0.0.50</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22experimental-syntax%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L189" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L191" target="_blank">View source</a>
 </small>
 
 
@@ -879,7 +914,7 @@ def g(value: ~A) -> None: ...  # error: [experimental-syntax]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22final-on-non-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1187" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1245" target="_blank">View source</a>
 </small>
 
 
@@ -914,7 +949,7 @@ def my_function() -> int:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.40">0.0.40</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22final-on-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1196" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1254" target="_blank">View source</a>
 </small>
 
 
@@ -949,7 +984,7 @@ let a = 1
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22final-without-value%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1225" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1283" target="_blank">View source</a>
 </small>
 
 
@@ -1065,7 +1100,7 @@ def test() -> "Literal[5]":
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22inconsistent-mro%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L371" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L373" target="_blank">View source</a>
 </small>
 
 
@@ -1101,7 +1136,7 @@ class C(A, B): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22index-out-of-bounds%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L380" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L382" target="_blank">View source</a>
 </small>
 
 
@@ -1131,7 +1166,7 @@ t[3]  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.33">0.0.1-alpha.33</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22ineffective-final%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1178" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1236" target="_blank">View source</a>
 </small>
 
 
@@ -1168,7 +1203,7 @@ class MyClass: ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.12">0.0.1-alpha.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22instance-layout-conflict%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L325" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L327" target="_blank">View source</a>
 </small>
 
 
@@ -1269,7 +1304,7 @@ an atypical memory layout.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-argument-type%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L417" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L419" target="_blank">View source</a>
 </small>
 
 
@@ -1301,7 +1336,7 @@ func("foo")  # error: [invalid-argument-type]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-assignment%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L453" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L455" target="_blank">View source</a>
 </small>
 
 
@@ -1332,7 +1367,7 @@ a: int = ""  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-attribute-access%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1405" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1463" target="_blank">View source</a>
 </small>
 
 
@@ -1390,7 +1425,7 @@ C.instance_only_var = 56  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.33">0.0.33</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-attribute-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1486" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1544" target="_blank">View source</a>
 </small>
 
 
@@ -1436,7 +1471,7 @@ class Sub(Base):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.19">0.0.1-alpha.19</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-await%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L462" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L464" target="_blank">View source</a>
 </small>
 
 
@@ -1478,7 +1513,7 @@ asyncio.run(main())
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-base%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L471" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L473" target="_blank">View source</a>
 </small>
 
 
@@ -1505,7 +1540,7 @@ class A(42): ...  # error: [invalid-base]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-context-manager%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L498" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L500" target="_blank">View source</a>
 </small>
 
 
@@ -1535,7 +1570,7 @@ with 1:  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.12">0.0.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-dataclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L315" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L317" target="_blank">View source</a>
 </small>
 
 
@@ -1588,7 +1623,7 @@ See: <https://docs.python.org/3/library/dataclasses.html#dataclasses.dataclass>
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.13">0.0.13</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-dataclass-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L306" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L308" target="_blank">View source</a>
 </small>
 
 
@@ -1624,7 +1659,7 @@ class A:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-declaration%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L507" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L509" target="_blank">View source</a>
 </small>
 
 
@@ -1656,7 +1691,7 @@ a: str  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-enum-member-annotation%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L525" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L527" target="_blank">View source</a>
 </small>
 
 
@@ -1713,7 +1748,7 @@ class Pet(Enum):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-exception-caught%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L516" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L518" target="_blank">View source</a>
 </small>
 
 
@@ -1777,7 +1812,7 @@ This rule corresponds to Ruff's [`except-with-non-exception-classes` (`B030`)](h
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.28">0.0.1-alpha.28</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-explicit-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1252" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1310" target="_blank">View source</a>
 </small>
 
 
@@ -1824,13 +1859,46 @@ class D(A):
     def foo(self): ...  # fine: overrides `A.foo`
 ```
 
+## `invalid-extension`
+
+<small>
+Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
+Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.3">0.0.1-alpha.3</a> ·
+<a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-extension%22" target="_blank">Related issues</a> ·
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L941" target="_blank">View source</a>
+</small>
+
+
+**What it does**
+
+Checks for invalid basedpython `extension` declarations: an extended
+name that does not resolve to a class, a bracket type parameter the
+extended type does not declare, or a member that would add stored state.
+
+**Why is this bad?**
+
+An extension adds behaviour to an existing type. Its name must reference
+a class declaration, its bracket parameters reuse (and constrain) that
+class's own type parameters by name, and its members are resolved at
+transpile time with nowhere to store new fields on already-constructed
+instances.
+
+**Example**
+
+
+```by
+extension list[T: int]:  # error: `list` declares no type parameter `T`
+    def total(self) -> int:
+        return sum(self)
+```
+
 ## `invalid-frozen-dataclass-subclass`
 
 <small>
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.35">0.0.1-alpha.35</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-frozen-dataclass-subclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1505" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1563" target="_blank">View source</a>
 </small>
 
 
@@ -1881,7 +1949,7 @@ class NonFrozenChild(FrozenBase):  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-generic-class%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L543" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L545" target="_blank">View source</a>
 </small>
 
 
@@ -1930,7 +1998,7 @@ class D(Generic[U, T]): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.12">0.0.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-generic-enum%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L534" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L536" target="_blank">View source</a>
 </small>
 
 
@@ -2026,7 +2094,7 @@ a = 20 / 0  # type: ignore
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.17">0.0.1-alpha.17</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-key%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L390" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L392" target="_blank">View source</a>
 </small>
 
 
@@ -2074,7 +2142,7 @@ carol = Person(name="Carol", aeg=25)  # typo!
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-legacy-positional-parameter%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1523" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1581" target="_blank">View source</a>
 </small>
 
 
@@ -2136,7 +2204,7 @@ def f(x, y, /):  # Python 3.8+ syntax
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-legacy-type-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L561" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L563" target="_blank">View source</a>
 </small>
 
 
@@ -2176,7 +2244,7 @@ def f(t: TypeVar("U")): ...  # ty: ignore[invalid-type-form]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.18">0.0.18</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-match-pattern%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L678" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L680" target="_blank">View source</a>
 </small>
 
 
@@ -2226,7 +2294,7 @@ match object():
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-metaclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L606" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L608" target="_blank">View source</a>
 </small>
 
 
@@ -2261,7 +2329,7 @@ class B(metaclass=42): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.20">0.0.1-alpha.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-method-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1495" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1553" target="_blank">View source</a>
 </small>
 
 
@@ -2379,7 +2447,7 @@ Correct use of `@override` is enforced by ty's [`invalid-explicit-override`](#in
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.19">0.0.1-alpha.19</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-named-tuple%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L353" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L355" target="_blank">View source</a>
 </small>
 
 
@@ -2436,7 +2504,7 @@ AttributeError: Cannot overwrite NamedTuple attribute _asdict
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.31">0.0.31</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-named-tuple-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L362" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L364" target="_blank">View source</a>
 </small>
 
 
@@ -2484,7 +2552,7 @@ admin[0]  # "Alice"
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.27">0.0.1-alpha.27</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-newtype%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L588" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L590" target="_blank">View source</a>
 </small>
 
 
@@ -2522,7 +2590,7 @@ Baz = NewType("Baz", int | str)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-overload%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L615" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L617" target="_blank">View source</a>
 </small>
 
 
@@ -2579,7 +2647,7 @@ def foo(x: int) -> int: ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-parameter-default%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L633" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L635" target="_blank">View source</a>
 </small>
 
 
@@ -2608,7 +2676,7 @@ def f(a: int = ""): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-paramspec%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L570" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L572" target="_blank">View source</a>
 </small>
 
 
@@ -2644,7 +2712,7 @@ P2 = ParamSpec()  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-protocol%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L334" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L336" target="_blank">View source</a>
 </small>
 
 
@@ -2680,7 +2748,7 @@ TypeError: Protocols can only inherit from other protocols, got <class 'int'>
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-raise%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L642" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L644" target="_blank">View source</a>
 </small>
 
 
@@ -2751,7 +2819,7 @@ def g():
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-return-type%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L426" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L428" target="_blank">View source</a>
 </small>
 
 
@@ -2783,7 +2851,7 @@ def func() -> int:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-super-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L651" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L653" target="_blank">View source</a>
 </small>
 
 
@@ -2894,7 +2962,7 @@ class C: ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.10">0.0.10</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-total-ordering%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1514" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1572" target="_blank">View source</a>
 </small>
 
 
@@ -2945,7 +3013,7 @@ class MyClass:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.6">0.0.1-alpha.6</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-alias-type%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L579" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L581" target="_blank">View source</a>
 </small>
 
 
@@ -2986,7 +3054,7 @@ NewAlias = TypeAliasType(get_name(), int)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.29">0.0.1-alpha.29</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-arguments%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L832" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L834" target="_blank">View source</a>
 </small>
 
 
@@ -3053,7 +3121,7 @@ Bar[int]  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-checking-constant%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L660" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L662" target="_blank">View source</a>
 </small>
 
 
@@ -3086,7 +3154,7 @@ TYPE_CHECKING = ""  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-form%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L669" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L671" target="_blank">View source</a>
 </small>
 
 
@@ -3122,7 +3190,7 @@ b: Annotated[int]  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.11">0.0.1-alpha.11</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-guard-call%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L696" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L698" target="_blank">View source</a>
 </small>
 
 
@@ -3169,7 +3237,7 @@ is_int(value=1)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.11">0.0.1-alpha.11</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-guard-definition%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L687" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L689" target="_blank">View source</a>
 </small>
 
 
@@ -3226,7 +3294,7 @@ class C:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-variable-bound%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L714" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L716" target="_blank">View source</a>
 </small>
 
 
@@ -3270,7 +3338,7 @@ def g[U, T: U](): ...  # error: [invalid-type-variable-bound]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-variable-constraints%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L705" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L707" target="_blank">View source</a>
 </small>
 
 
@@ -3327,7 +3395,7 @@ V = TypeVar("V", list[int], int)  # valid constrained Type
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.16">0.0.16</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-variable-default%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L723" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L725" target="_blank">View source</a>
 </small>
 
 
@@ -3369,7 +3437,7 @@ U = TypeVar("U", int, str, default=bytes)  # error: [invalid-type-variable-defau
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.28">0.0.28</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-typed-dict-field%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1468" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1526" target="_blank">View source</a>
 </small>
 
 
@@ -3405,7 +3473,7 @@ class Child(Base):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-typed-dict-header%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1477" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1535" target="_blank">View source</a>
 </small>
 
 
@@ -3448,7 +3516,7 @@ def f(options: dict[str, object]):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.9">0.0.9</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-typed-dict-statement%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1459" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1517" target="_blank">View source</a>
 </small>
 
 
@@ -3483,7 +3551,7 @@ class Foo(TypedDict):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.25">0.0.25</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-yield%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L435" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L437" target="_blank">View source</a>
 </small>
 
 
@@ -3518,7 +3586,7 @@ def gen() -> Iterator[int]:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22isinstance-against-protocol%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L399" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L401" target="_blank">View source</a>
 </small>
 
 
@@ -3585,7 +3653,7 @@ def h(arg2: type):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22isinstance-against-typed-dict%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L408" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L410" target="_blank">View source</a>
 </small>
 
 
@@ -3635,7 +3703,7 @@ def g(arg: object):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.30">0.0.30</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22mismatched-type-name%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L597" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L599" target="_blank">View source</a>
 </small>
 
 
@@ -3678,7 +3746,7 @@ Movie = TypedDict("Film", {"title": str})  # error: [mismatched-type-name]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22missing-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L741" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L743" target="_blank">View source</a>
 </small>
 
 
@@ -3709,7 +3777,7 @@ func()  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.61">0.0.61</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22missing-context-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L997" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1055" target="_blank">View source</a>
 </small>
 
 
@@ -3740,7 +3808,7 @@ f(1)                  # ok — `s` is passed implicitly
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.41">0.0.41</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22missing-override-decorator%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1261" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1319" target="_blank">View source</a>
 </small>
 
 
@@ -3799,7 +3867,7 @@ class ExplicitChild(Parent):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.45">0.0.45</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22missing-type-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L750" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L752" target="_blank">View source</a>
 </small>
 
 
@@ -3838,7 +3906,7 @@ def handle(m: re.Match[str]) -> str:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.20">0.0.1-alpha.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22missing-typed-dict-key%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1450" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1508" target="_blank">View source</a>
 </small>
 
 
@@ -3877,7 +3945,7 @@ alice["age"]  # KeyError
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22no-matching-overload%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L814" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L816" target="_blank">View source</a>
 </small>
 
 
@@ -3915,7 +3983,7 @@ func("string")  # error: [no-matching-overload]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.30">0.0.30</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22non-callable-init-subclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L552" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L554" target="_blank">View source</a>
 </small>
 
 
@@ -3953,7 +4021,7 @@ class Sub(Super): ...  # error: [non-callable-init-subclass]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.61">0.0.61</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22non-overlapping-cast%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L974" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1032" target="_blank">View source</a>
 </small>
 
 
@@ -3982,7 +4050,7 @@ def f(a: object):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22not-iterable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L841" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L843" target="_blank">View source</a>
 </small>
 
 
@@ -4011,7 +4079,7 @@ for i in 34:  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22not-subscriptable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L823" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L825" target="_blank">View source</a>
 </small>
 
 
@@ -4039,7 +4107,7 @@ Subscripting an object that does not support it will raise a `TypeError` at runt
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.29">0.0.1-alpha.29</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22override-of-final-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1160" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1218" target="_blank">View source</a>
 </small>
 
 
@@ -4076,7 +4144,7 @@ class B(A):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.16">0.0.16</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22override-of-final-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1169" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1227" target="_blank">View source</a>
 </small>
 
 
@@ -4113,7 +4181,7 @@ class B(A):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22parameter-already-assigned%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L859" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L861" target="_blank">View source</a>
 </small>
 
 
@@ -4144,7 +4212,7 @@ f(1, x=2)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22positional-only-parameter-as-kwarg%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1333" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1391" target="_blank">View source</a>
 </small>
 
 
@@ -4175,7 +4243,7 @@ f(x=1)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-missing-attribute%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L868" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L870" target="_blank">View source</a>
 </small>
 
 
@@ -4214,7 +4282,7 @@ A.c  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-missing-implicit-call%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L216" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L218" target="_blank">View source</a>
 </small>
 
 
@@ -4253,7 +4321,7 @@ A()[0]  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-missing-import%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L886" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L888" target="_blank">View source</a>
 </small>
 
 
@@ -4299,7 +4367,7 @@ from module import a  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.23">0.0.23</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-missing-submodule%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L877" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L879" target="_blank">View source</a>
 </small>
 
 
@@ -4331,7 +4399,7 @@ html.parser  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-unresolved-reference%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L895" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L897" target="_blank">View source</a>
 </small>
 
 
@@ -4403,7 +4471,7 @@ def test() -> "int":
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22redundant-cast%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1414" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1472" target="_blank">View source</a>
 </small>
 
 
@@ -4438,7 +4506,7 @@ cast(int, f())  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.18">0.0.18</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22redundant-final-classvar%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1423" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1481" target="_blank">View source</a>
 </small>
 
 
@@ -4476,7 +4544,7 @@ class C:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.3">0.0.1-alpha.3</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22reified-classmethod%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1085" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1143" target="_blank">View source</a>
 </small>
 
 
@@ -4509,7 +4577,7 @@ class C:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22shadowed-type-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1432" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1490" target="_blank">View source</a>
 </small>
 
 
@@ -4553,7 +4621,7 @@ class Outer[T]:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22static-assert-error%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1396" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1454" target="_blank">View source</a>
 </small>
 
 
@@ -4588,7 +4656,7 @@ static_assert(int(2.0 * 3.0) == 6)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.39">0.0.39</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22subclass-of-dataclass-with-order%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1151" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1209" target="_blank">View source</a>
 </small>
 
 
@@ -4639,7 +4707,7 @@ Consider using [`functools.total_ordering`][total_ordering] instead, which does 
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22subclass-of-final-class%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L904" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L906" target="_blank">View source</a>
 </small>
 
 
@@ -4673,7 +4741,7 @@ class B(A): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22subclass-of-sealed-class%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L913" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L915" target="_blank">View source</a>
 </small>
 
 
@@ -4705,7 +4773,7 @@ class Circle(Shape): ...  # error: `Shape` is sealed in another workspace
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.30">0.0.1-alpha.30</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22super-call-in-named-tuple-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1306" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1364" target="_blank">View source</a>
 </small>
 
 
@@ -4745,7 +4813,7 @@ class F(NamedTuple):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22too-many-positional-arguments%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1288" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1346" target="_blank">View source</a>
 </small>
 
 
@@ -4775,7 +4843,7 @@ f("foo")  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22type-assertion-failure%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1270" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1328" target="_blank">View source</a>
 </small>
 
 
@@ -4814,7 +4882,7 @@ def _(x: int):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unavailable-implicit-super-arguments%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1297" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1355" target="_blank">View source</a>
 </small>
 
 
@@ -4872,7 +4940,7 @@ class A:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unbound-type-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L732" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L734" target="_blank">View source</a>
 </small>
 
 
@@ -4916,7 +4984,7 @@ class C(Generic[T]):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22undefined-reveal%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1315" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1373" target="_blank">View source</a>
 </small>
 
 
@@ -4945,7 +5013,7 @@ reveal_type(1)  # revealed: Literal[1]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unknown-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1324" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1382" target="_blank">View source</a>
 </small>
 
 
@@ -4976,7 +5044,7 @@ f(x=1, y=2)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-attribute%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1342" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1400" target="_blank">View source</a>
 </small>
 
 
@@ -5009,7 +5077,7 @@ A().foo  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.15">0.0.1-alpha.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-global%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1441" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1499" target="_blank">View source</a>
 </small>
 
 
@@ -5084,7 +5152,7 @@ def g():
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-import%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1351" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1409" target="_blank">View source</a>
 </small>
 
 
@@ -5113,7 +5181,7 @@ import foo  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-reference%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1360" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1418" target="_blank">View source</a>
 </small>
 
 
@@ -5141,7 +5209,7 @@ print(x)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.3">0.0.1-alpha.3</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unspecialized-reified-generic%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1049" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1107" target="_blank">View source</a>
 </small>
 
 
@@ -5183,7 +5251,7 @@ g(1)       # ok — transpiles to g[int](1)
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.7">0.0.1-alpha.7</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsupported-base%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L480" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L482" target="_blank">View source</a>
 </small>
 
 
@@ -5230,7 +5298,7 @@ class D(C): ...  # error: [unsupported-base]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsupported-bool-conversion%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L850" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L852" target="_blank">View source</a>
 </small>
 
 
@@ -5279,7 +5347,7 @@ b1 < b2 < b1  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.12">0.0.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsupported-dynamic-base%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L489" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L491" target="_blank">View source</a>
 </small>
 
 
@@ -5326,7 +5394,7 @@ def factory(base: type[Base]) -> type:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsupported-operator%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1369" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1427" target="_blank">View source</a>
 </small>
 
 
@@ -5359,7 +5427,7 @@ A() + A()  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.21">0.0.21</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unused-awaitable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1378" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1436" target="_blank">View source</a>
 </small>
 
 
@@ -5479,7 +5547,7 @@ to `false`.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22useless-overload-body%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L624" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L626" target="_blank">View source</a>
 </small>
 
 
@@ -5558,7 +5626,7 @@ def foo(x: int | str) -> int | str:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22zero-stepsize-in-slice%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1387" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1445" target="_blank">View source</a>
 </small>
 
 

--- a/crates/ty/tests/by_e2e.rs
+++ b/crates/ty/tests/by_e2e.rs
@@ -244,6 +244,115 @@ print(shout(\"moon\", greeting=\"good night\"))
 }
 
 #[test]
+fn extension_methods_run_and_track_element_types() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fs::write(
+        dir.path().join("main.by"),
+        "\
+extension list:
+    def second(self) -> Element:
+        return self[1]
+
+extension str:
+    @property
+    def shouty(self) -> str:
+        return self.upper()
+
+xs = [1, 2, 3]
+print(xs.second())
+print(\"quiet\".shouty)
+",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_by"))
+        .args(["run", "main"])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to spawn by");
+
+    assert!(
+        output.status.success(),
+        "by run failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout)
+            .replace("\r\n", "\n")
+            .trim(),
+        "2\nQUIET"
+    );
+}
+
+#[test]
+fn extension_member_called_before_its_block_runs() {
+    // the backing function is hoisted above the call, so a member used before
+    // the `extension` block's source position resolves at runtime
+    let dir = tempfile::tempdir().expect("tempdir");
+    fs::write(
+        dir.path().join("main.by"),
+        "\
+print(\"asdf\".shout())
+
+extension str:
+    def shout(self) -> str:
+        return self.upper() + \"!\"
+",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_by"))
+        .args(["run", "main"])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to spawn by");
+
+    assert!(
+        output.status.success(),
+        "by run failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "ASDF!");
+}
+
+#[test]
+fn imported_extension_runs_across_modules() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fs::write(
+        dir.path().join("ext.by"),
+        "\
+extension list:
+    def second(self) -> Element:
+        return self[1]
+",
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("main.by"),
+        "\
+import ext
+
+xs = [\"a\", \"b\", \"c\"]
+print(xs.second())
+",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_by"))
+        .args(["run", "main"])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to spawn by");
+
+    assert!(
+        output.status.success(),
+        "by run failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "b");
+}
+
+#[test]
 fn enum_lowers_to_sealed_dataclass_hierarchy() {
     let out = transpile(
         "\

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -2851,7 +2851,20 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 self.synthesize_nested_binding_definitions(nested_bindings);
 
                 // In Python runtime semantics, a class is registered after its scope is evaluated.
-                let symbol = self.add_symbol(class.name.id.clone());
+                // an `extension list:` block references the extended type rather than
+                // declaring it, so it binds a mangled, per-statement symbol — invisible
+                // to name resolution (`<` cannot appear in an identifier) but still
+                // enumerable, so `extensions_in_module` can find every extension
+                let symbol_name = if class.is_extension() {
+                    Name::new(format!(
+                        "<extension:{}:{}>",
+                        class.name.id,
+                        class.range.start().to_u32()
+                    ))
+                } else {
+                    class.name.id.clone()
+                };
+                let symbol = self.add_symbol(symbol_name);
                 self.add_definition(symbol.into(), class);
             }
             ast::Stmt::TypeAlias(type_alias) => {

--- a/crates/ty_python_semantic/resources/mdtest/basedpython_extensions.md
+++ b/crates/ty_python_semantic/resources/mdtest/basedpython_extensions.md
@@ -1,0 +1,192 @@
+# extensions
+
+an extension adds methods and computed properties to an existing type without subclassing it. the
+extended type's own type parameters are in scope under the names its declaration bound (`Element` on
+`list`)
+
+## a method on a builtin reuses its type parameter
+
+```by
+extension list:
+    def second(self) -> Element:
+        return self[1]
+
+xs = [1, 2, 3]
+reveal_type(xs.second())  # revealed: int
+
+names = ["a", "b"]
+reveal_type(names.second())  # revealed: str
+```
+
+## `self` in the body is the extended type
+
+```by
+extension list:
+    def first_or(self, default: Element) -> Element:
+        reveal_type(self)  # revealed: list[Element@list]
+        if len(self) > 0:
+            return self[0]
+        return default
+```
+
+## a method may declare its own fresh type parameters
+
+```by
+extension list:
+    def pair[R](self, other: R) -> tuple[Element, R]:
+        return (self[0], other)
+
+xs = [1, 2]
+reveal_type(xs.pair("a"))  # revealed: (int, "a")
+```
+
+## extensions on a first-party class
+
+```by
+class Stack[T]:
+    def __init__(self, items: list[T]) -> None:
+        self._items = items
+
+extension Stack:
+    def peek(self) -> T:
+        return self._items[-1]
+
+s = Stack([1, 2, 3])
+reveal_type(s.peek())  # revealed: int
+```
+
+## conditional extensions constrain the receiver
+
+a bound on a reused parameter narrows where the extension applies
+
+```by
+extension list[Element: int]:
+    def total(self) -> int:
+        return sum(self)
+
+ints = [1, 2, 3]
+reveal_type(ints.total())  # revealed: int
+
+flags = [True, False]
+reveal_type(flags.total())  # revealed: int
+
+words = ["a", "b"]
+words.total()  # error: [unresolved-attribute]
+```
+
+## computed properties
+
+```by
+extension str:
+    @property
+    def shouty(self) -> str:
+        return self.upper()
+
+greeting = "hello"
+reveal_type(greeting.shouty)  # revealed: str
+```
+
+## `static def` and `class def` members resolve on the class object
+
+```by
+extension str:
+    static def joined(parts: list[str]) -> str:
+        return "-".join(parts)
+
+    class def empty(cls) -> str:
+        return cls()
+
+reveal_type(str.joined(["a", "b"]))  # revealed: str
+reveal_type(str.empty())  # revealed: str
+```
+
+## extensions never shadow declared members
+
+```by
+class Widget:
+    def label(self) -> str:
+        return "real"
+
+extension Widget:
+    def label(self) -> int:
+        return 0
+
+w = Widget()
+reveal_type(w.label())  # revealed: str
+```
+
+## importing a module makes its extensions applicable
+
+`ext.by`:
+
+```by
+extension list:
+    def second(self) -> Element:
+        return self[1]
+```
+
+`main.by`:
+
+```by
+import ext
+
+xs = [1, 2, 3]
+reveal_type(xs.second())  # revealed: int
+```
+
+## without the import, the extension does not apply
+
+`ext.by`:
+
+```by
+extension list:
+    def second(self) -> Element:
+        return self[1]
+```
+
+`main.by`:
+
+```by
+xs = [1, 2, 3]
+xs.second()  # error: [unresolved-attribute]
+```
+
+## an ambiguous member is an error
+
+```by
+extension list:
+    def twice(self) -> Element:
+        return self[0]
+
+extension list:
+    def twice(self) -> Element:
+        return self[1]
+
+xs = [1, 2]
+xs.twice()  # error: [ambiguous-extension-member]
+```
+
+## invalid declarations
+
+the extended name must resolve to a class
+
+```by
+extension missing:  # error: [invalid-extension]
+    def m(self) -> int:
+        return 0
+```
+
+bracket parameters must reuse names the extended type declares
+
+```by
+extension list[T: int]:  # error: [invalid-extension]
+    def total(self) -> int:
+        return 0
+```
+
+an extension adds behaviour, not state
+
+```by
+extension list:
+    count = 0  # error: [invalid-extension]
+```

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -41,6 +41,7 @@ pub use ty_site_packages::{
     PythonEnvironment, PythonVersionFileSource, PythonVersionSource, PythonVersionWithSource,
     SitePackagesPaths, SysPrefixPathOrigin,
 };
+pub use types::extensions::{ExtensionAttributeInfo, ExtensionMemberKind};
 pub use types::ide_support::{
     ImportAliasResolution, ResolvedDefinition, TypeHierarchyClass, definitions_for_attribute,
     definitions_for_bin_op, definitions_for_imported_symbol, definitions_for_name,

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -99,6 +99,52 @@ impl<'db> SemanticModel<'db> {
         )
     }
 
+    /// basedpython: when an attribute access resolves to an `extension`
+    /// member (this module's, or one from a module imported with a plain
+    /// `import mod`), the backing-function rewrite the transpiler applies.
+    /// `None` for ordinary attributes — extensions never shadow declared
+    /// members, so this only answers when normal member lookup finds nothing
+    pub fn extension_attribute_info(
+        &self,
+        attribute: &ast::ExprAttribute,
+    ) -> Option<crate::types::extensions::ExtensionAttributeInfo> {
+        let db = self.db;
+        let receiver_ty = attribute.value.inferred_type(self)?;
+        if !receiver_ty
+            .member(db, attribute.attr.as_str())
+            .place
+            .is_undefined()
+        {
+            return None;
+        }
+        let resolution = crate::types::extensions::resolve_extension_member(
+            db,
+            self.file,
+            receiver_ty,
+            attribute.attr.as_str(),
+        )?;
+        let extension_file = resolution.extension.file(db);
+        let import_from = if extension_file == self.file {
+            None
+        } else {
+            Some(
+                ty_module_resolver::file_to_module(db, extension_file)?
+                    .name(db)
+                    .to_string(),
+            )
+        };
+        Some(crate::types::extensions::ExtensionAttributeInfo {
+            function: crate::types::extensions::backing_function_name(
+                db,
+                resolution.extension,
+                attribute.attr.as_str(),
+            ),
+            kind: resolution.kind,
+            import_from,
+            receiver_is_class: receiver_ty.nominal_class(db).is_none(),
+        })
+    }
+
     /// basedpython: the bracketed type-argument spelling the transpiler
     /// injects at a bare constructor call of a generic class (`A(1)` →
     /// `"int"`), read from the inferred type of the constructed instance.

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -137,6 +137,7 @@ mod diagnostic;
 pub(crate) mod display;
 pub(crate) mod enums;
 mod equality;
+pub(crate) mod extensions;
 pub(crate) mod function;
 mod generics;
 pub mod ide_support;

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -123,6 +123,11 @@ bitflags::bitflags! {
         /// enclosing enum's generic context despite having no type params of
         /// their own, so fast paths keyed on `HAS_TYPE_PARAMS` must not skip them.
         const IS_ENUM_VARIANT = 1 << 5;
+        /// basedpython: whether this "class" is an `extension` declaration
+        /// (`extension list:`). its name references the extended type rather
+        /// than declaring a class, its members resolve on receivers of that
+        /// type, and it binds only a mangled module symbol.
+        const IS_EXTENSION = 1 << 6;
     }
 }
 
@@ -153,6 +158,10 @@ impl<'db> StaticClassLiteral<'db> {
 
     pub(crate) fn is_enum_variant(self, db: &'db dyn Db) -> bool {
         self.flags(db).contains(ClassLiteralFlags::IS_ENUM_VARIANT)
+    }
+
+    pub(crate) fn is_extension(self, db: &'db dyn Db) -> bool {
+        self.flags(db).contains(ClassLiteralFlags::IS_EXTENSION)
     }
 }
 

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -130,6 +130,8 @@ pub(crate) fn register_lints(registry: &mut LintRegistryBuilder) {
     registry.register_lint(&SHADOWED_TYPE_VARIABLE);
     registry.register_lint(&SUBCLASS_OF_FINAL_CLASS);
     registry.register_lint(&SUBCLASS_OF_SEALED_CLASS);
+    registry.register_lint(&INVALID_EXTENSION);
+    registry.register_lint(&AMBIGUOUS_EXTENSION_MEMBER);
     registry.register_lint(&ERASED_CAST_ARGUMENT);
     registry.register_lint(&NON_OVERLAPPING_CAST);
     registry.register_lint(&MISSING_CONTEXT_ARGUMENT);
@@ -932,6 +934,62 @@ declare_lint! {
     pub(crate) static SUBCLASS_OF_SEALED_CLASS = {
         summary: "detects subclasses of sealed classes from outside their workspace",
         status: LintStatus::stable("0.0.1-alpha.1"),
+        default_level: Level::Error,
+    }
+}
+
+declare_lint! {
+    /// ## What it does
+    /// Checks for invalid basedpython `extension` declarations: an extended
+    /// name that does not resolve to a class, a bracket type parameter the
+    /// extended type does not declare, or a member that would add stored state.
+    ///
+    /// ## Why is this bad?
+    /// An extension adds behaviour to an existing type. Its name must reference
+    /// a class declaration, its bracket parameters reuse (and constrain) that
+    /// class's own type parameters by name, and its members are resolved at
+    /// transpile time with nowhere to store new fields on already-constructed
+    /// instances.
+    ///
+    /// ## Example
+    ///
+    /// ```by
+    /// extension list[T: int]:  # error: `list` declares no type parameter `T`
+    ///     def total(self) -> int:
+    ///         return sum(self)
+    /// ```
+    pub(crate) static INVALID_EXTENSION = {
+        summary: "detects invalid basedpython extension declarations",
+        status: LintStatus::stable("0.0.1-alpha.3"),
+        default_level: Level::Error,
+    }
+}
+
+declare_lint! {
+    /// ## What it does
+    /// Checks for attribute accesses that resolve to a member supplied by more
+    /// than one applicable basedpython extension.
+    ///
+    /// ## Why is this bad?
+    /// When two extensions in scope both add the same member to the receiver's
+    /// type, the access is ambiguous — which implementation runs would depend
+    /// on arbitrary ordering. Constrain one of the extensions (or drop the
+    /// import that brings the second into scope) so exactly one applies.
+    ///
+    /// ## Example
+    ///
+    /// ```by
+    /// extension list:
+    ///     def second(self) -> Element: ...
+    ///
+    /// extension list:
+    ///     def second(self) -> Element: ...
+    ///
+    /// [1, 2].second()  # error: ambiguous extension member
+    /// ```
+    pub(crate) static AMBIGUOUS_EXTENSION_MEMBER = {
+        summary: "detects attribute accesses supplied by more than one extension",
+        status: LintStatus::stable("0.0.1-alpha.3"),
         default_level: Level::Error,
     }
 }

--- a/crates/ty_python_semantic/src/types/extensions.rs
+++ b/crates/ty_python_semantic/src/types/extensions.rs
@@ -1,0 +1,432 @@
+//! basedpython extension declarations (`extension list:`)
+//!
+//! an extension adds methods and computed properties to an existing type
+//! without subclassing it. the parser lowers the block to a [`ClassDef`]
+//! carrying a synthetic `extension_def` marker; the semantic index binds it
+//! under a mangled `<extension:…>` symbol so the extended type's name is never
+//! shadowed. this module answers the two questions the checker and the
+//! transpiler share:
+//!
+//! - which extensions are applicable in a file (its own plus those of every
+//!   module it imports with a plain `import mod`)
+//! - what an attribute access on a receiver resolves to when normal member
+//!   lookup finds nothing (`xs.second()` on `list[int]` → the extension
+//!   method, specialized by the receiver)
+//!
+//! the extended type's own type parameters are reused by name inside an
+//! extension body (`Element` on `list`), so a member signature is written in
+//! terms of the extended class's typevars — applying the receiver's
+//! specialization is then the ordinary generic-member substitution. a
+//! bracketed bound (`extension list[Element: int]`) re-declares that name as a
+//! *constrained* typevar for the body and narrows where the extension applies;
+//! it never introduces a parameter the extended type does not declare
+//!
+//! [`ClassDef`]: ruff_python_ast::StmtClassDef
+
+use ruff_db::files::File;
+use ruff_python_ast as ast;
+use ty_module_resolver::resolve_module;
+use ty_python_core::{global_scope, place_table, semantic_index};
+
+use crate::Db;
+use crate::place::{builtins_symbol, global_symbol};
+use crate::types::Type;
+use crate::types::class::{ClassLiteral, ClassType, StaticClassLiteral};
+use crate::types::class_base::ClassBase;
+use crate::types::context::InferContext;
+use crate::types::diagnostic::INVALID_EXTENSION;
+use crate::types::member::class_member;
+use crate::types::typevar::{BoundTypeVarInstance, TypeVarBoundOrConstraints};
+
+/// the symbol-name prefix the semantic index gives extension declarations
+pub(crate) const EXTENSION_SYMBOL_PREFIX: &str = "<extension:";
+
+/// all extension declarations in a module, in source order
+#[salsa::tracked(returns(deref), heap_size = ruff_memory_usage::heap_size)]
+pub(crate) fn extensions_in_module(db: &dyn Db, file: File) -> Box<[StaticClassLiteral<'_>]> {
+    // only basedpython files declare extensions. a `.py` file containing an
+    // `extension` block already has a parse error; don't serve its members
+    if !file.source_type(db).is_basedpython() {
+        return Box::default();
+    }
+    let global = global_scope(db, file);
+    let mut extensions = Vec::new();
+    for symbol in place_table(db, global).symbols() {
+        if !symbol.name().starts_with(EXTENSION_SYMBOL_PREFIX) {
+            continue;
+        }
+        let Some(Type::ClassLiteral(ClassLiteral::Static(candidate))) =
+            class_member(db, global, symbol.name()).ignore_possibly_undefined()
+        else {
+            continue;
+        };
+        if candidate.is_extension(db) {
+            extensions.push(candidate);
+        }
+    }
+    extensions.into_boxed_slice()
+}
+
+/// the extensions applicable in `file`: its own, then those of every module it
+/// imports with a plain `import mod` (in that order — a same-module extension
+/// wins over an imported one when both apply)
+#[salsa::tracked(returns(deref), heap_size = ruff_memory_usage::heap_size)]
+pub(crate) fn applicable_extensions(db: &dyn Db, file: File) -> Box<[StaticClassLiteral<'_>]> {
+    if !file.source_type(db).is_basedpython() {
+        return Box::default();
+    }
+    let mut extensions: Vec<StaticClassLiteral<'_>> = extensions_in_module(db, file).to_vec();
+    for module_name in semantic_index(db, file).imported_modules() {
+        let Some(module) = resolve_module(db, file, module_name) else {
+            continue;
+        };
+        let Some(module_file) = module.file(db) else {
+            continue;
+        };
+        if module_file == file {
+            continue;
+        }
+        extensions.extend_from_slice(extensions_in_module(db, module_file));
+    }
+    extensions.into_boxed_slice()
+}
+
+/// the class an extension declaration extends: its name resolved in the
+/// declaring module's globals, else builtins. `None` when the name does not
+/// resolve to a class (reported at the declaration)
+#[salsa::tracked]
+pub(crate) fn extended_class<'db>(
+    db: &'db dyn Db,
+    extension: StaticClassLiteral<'db>,
+) -> Option<ClassLiteral<'db>> {
+    let name = extension.name(db);
+    let file = extension.file(db);
+    let resolved = global_symbol(db, file, name)
+        .place
+        .ignore_possibly_undefined()
+        .or_else(|| builtins_symbol(db, name).place.ignore_possibly_undefined())?;
+    let literal = resolved.as_class_literal()?;
+    // an extension of an extension makes no sense; the mangled binding makes
+    // this unreachable in practice, but be explicit
+    if let ClassLiteral::Static(static_literal) = literal
+        && static_literal.is_extension(db)
+    {
+        return None;
+    }
+    Some(literal)
+}
+
+/// the extension body's view of the extended class: specialized at the
+/// bracket-declared (bounded) typevar where one is spelled, else at the
+/// extended class's own typevar. this is the implicit type of `self` in the
+/// extension's methods
+pub(crate) fn body_view_class<'db>(
+    db: &'db dyn Db,
+    extension: StaticClassLiteral<'db>,
+) -> Option<ClassType<'db>> {
+    let target = extended_class(db, extension)?;
+    let Some(target_context) = target.generic_context(db) else {
+        return Some(ClassType::NonGeneric(target));
+    };
+    let extension_context = extension.generic_context(db);
+    let types: Vec<Type<'db>> = target_context
+        .variables(db)
+        .map(|target_var| {
+            let spelled = extension_context.and_then(|context| {
+                context.binds_named_typevar(db, target_var.typevar(db).name(db))
+            });
+            Type::TypeVar(spelled.unwrap_or(target_var))
+        })
+        .collect();
+    Some(target.apply_specialization(db, |context| context.specialize(db, types)))
+}
+
+/// resolve `name` inside an extension body to the extended class's own typevar
+/// of that name. bracket-spelled typevars resolve normally through the
+/// type-param scope before this fallback is consulted, so this only serves the
+/// unconstrained remainder
+pub(crate) fn extension_body_typevar<'db>(
+    db: &'db dyn Db,
+    extension: StaticClassLiteral<'db>,
+    name: &str,
+) -> Option<BoundTypeVarInstance<'db>> {
+    let target = extended_class(db, extension)?;
+    target
+        .generic_context(db)?
+        .variables(db)
+        .find(|variable| variable.typevar(db).name(db).as_str() == name)
+}
+
+/// what kind of member an extension attribute resolved to. drives the
+/// transpiler's call-site rewrite (a property call drops the parentheses; a
+/// classmethod receives the class object)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExtensionMemberKind {
+    Method,
+    Property,
+    StaticMethod,
+    ClassMethod,
+}
+
+/// how the transpiler rewrites an attribute access that resolved to an
+/// extension member
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExtensionAttributeInfo {
+    /// the module-level backing function the member lowers to
+    pub function: String,
+    pub kind: ExtensionMemberKind,
+    /// the module to import the backing function from, when the extension is
+    /// declared in a module other than the one being transpiled
+    pub import_from: Option<String>,
+    /// whether the receiver is the class object itself (`str.parse(…)`) rather
+    /// than an instance — decides what a `class def` member receives
+    pub receiver_is_class: bool,
+}
+
+/// the backing-function name an extension member lowers to:
+/// `__by_ext__list__second`. when a module declares more than one extension
+/// of the same target name, later ones carry an ordinal (`__by_ext2__…`) so
+/// their members do not collide. the transpiler's block lowering computes the
+/// same name from the extension file's AST alone
+pub(crate) fn backing_function_name<'db>(
+    db: &'db dyn Db,
+    extension: StaticClassLiteral<'db>,
+    member: &str,
+) -> String {
+    let target = extension.name(db);
+    let ordinal = extensions_in_module(db, extension.file(db))
+        .iter()
+        .filter(|candidate| candidate.name(db) == target)
+        .position(|candidate| *candidate == extension)
+        .unwrap_or(0);
+    if ordinal == 0 {
+        format!("__by_ext__{target}__{member}")
+    } else {
+        format!("__by_ext{}__{target}__{member}", ordinal + 1)
+    }
+}
+
+/// a successful extension-member resolution
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ExtensionMemberResolution<'db> {
+    /// the extension declaration that supplied the member
+    pub(crate) extension: StaticClassLiteral<'db>,
+    /// the type of the attribute expression: the member bound against the
+    /// receiver (a bound method, a property's value, …)
+    pub(crate) ty: Type<'db>,
+    pub(crate) kind: ExtensionMemberKind,
+    /// another applicable extension that also supplies the member — an
+    /// ambiguity the checker reports at the access site
+    pub(crate) ambiguous_with: Option<StaticClassLiteral<'db>>,
+}
+
+/// resolve an attribute access that found no regular member: consult the
+/// extensions applicable in `file` for one that extends the receiver's class
+/// (or a class in its MRO), whose bracket bounds the receiver's specialization
+/// satisfies, and that declares `name`. extensions never shadow declared
+/// members — the caller only asks after normal lookup came up undefined
+pub(crate) fn resolve_extension_member<'db>(
+    db: &'db dyn Db,
+    file: File,
+    receiver: Type<'db>,
+    name: &str,
+) -> Option<ExtensionMemberResolution<'db>> {
+    let candidates = applicable_extensions(db, file);
+    if candidates.is_empty() {
+        return None;
+    }
+
+    // an instance receiver serves every member kind; a class-object receiver
+    // serves only `static def` / `class def` members
+    let (receiver_class, instance) = if let Some(class) = receiver.nominal_class(db) {
+        (class, Some(receiver))
+    } else if let Some(class) = receiver.to_class_type(db) {
+        (class, None)
+    } else {
+        return None;
+    };
+
+    let mut resolved: Option<ExtensionMemberResolution<'db>> = None;
+    for &extension in candidates {
+        let Some(member) = applicable_member(db, extension, receiver_class, name) else {
+            continue;
+        };
+        let kind = classify_member(db, member);
+        if instance.is_none()
+            && !matches!(
+                kind,
+                ExtensionMemberKind::StaticMethod | ExtensionMemberKind::ClassMethod
+            )
+        {
+            continue;
+        }
+        match &mut resolved {
+            None => {
+                let owner = match instance {
+                    Some(instance_ty) => instance_ty.to_meta_type(db),
+                    None => receiver,
+                };
+                let bound = member
+                    .try_call_dunder_get(db, instance, owner)
+                    .map(|(ty, _)| ty)
+                    .unwrap_or(member);
+                resolved = Some(ExtensionMemberResolution {
+                    extension,
+                    ty: bound,
+                    kind,
+                    ambiguous_with: None,
+                });
+            }
+            Some(resolution) => {
+                if resolution.ambiguous_with.is_none() {
+                    resolution.ambiguous_with = Some(extension);
+                }
+            }
+        }
+    }
+    resolved
+}
+
+/// if `extension` extends `receiver_class` (or a class in its MRO), its bounds
+/// hold for the receiver's specialization, and it declares `name`, return the
+/// member's type with the receiver's type arguments substituted in
+fn applicable_member<'db>(
+    db: &'db dyn Db,
+    extension: StaticClassLiteral<'db>,
+    receiver_class: ClassType<'db>,
+    name: &str,
+) -> Option<Type<'db>> {
+    let target = extended_class(db, extension)?;
+
+    // find the extended class in the receiver's MRO, with the specialization
+    // the receiver gives it — extension methods are inherited like any others
+    let target_class = receiver_class.iter_mro(db).find_map(|base| match base {
+        ClassBase::Class(class) if class.class_literal(db) == target => Some(class),
+        _ => None,
+    })?;
+    let receiver_specialization = match target_class {
+        ClassType::Generic(alias) => Some(alias.specialization(db)),
+        ClassType::NonGeneric(_) => None,
+    };
+
+    // bracket bounds constrain the receiver: every spelled typevar must name a
+    // parameter the extended class declares, and the receiver's argument for
+    // it must satisfy the bound
+    let extension_context = extension.generic_context(db);
+    let mut extension_substitution: Vec<Type<'db>> = Vec::new();
+    if let Some(extension_context) = extension_context {
+        let target_context = target.generic_context(db)?;
+        for extension_var in extension_context.variables(db) {
+            let target_var =
+                target_context.binds_named_typevar(db, extension_var.typevar(db).name(db))?;
+            let receiver_argument = receiver_specialization
+                .and_then(|specialization| specialization.get(db, target_var))
+                .unwrap_or_else(Type::unknown);
+            if !satisfies_bound(db, receiver_argument, extension_var) {
+                return None;
+            }
+            extension_substitution.push(receiver_argument);
+        }
+    }
+
+    let member = class_member(db, extension.body_scope(db), name).ignore_possibly_undefined()?;
+
+    // substitute the receiver's type arguments: first for the extension's own
+    // bracket typevars (matched to the target's parameters by name), then for
+    // the extended class's typevars reused directly by the member's signature
+    let mut member = member;
+    if let Some(extension_context) = extension_context {
+        member = member
+            .apply_specialization(db, extension_context.specialize(db, extension_substitution));
+    }
+    member = member.apply_optional_specialization(db, receiver_specialization);
+    Some(member)
+}
+
+/// does the receiver's type argument satisfy a bracket typevar's bound?
+fn satisfies_bound<'db>(
+    db: &'db dyn Db,
+    argument: Type<'db>,
+    extension_var: BoundTypeVarInstance<'db>,
+) -> bool {
+    match extension_var.typevar(db).bound_or_constraints(db) {
+        None => true,
+        Some(TypeVarBoundOrConstraints::UpperBound(bound)) => argument.is_assignable_to(db, bound),
+        Some(TypeVarBoundOrConstraints::Constraints(constraints)) => constraints
+            .elements(db)
+            .iter()
+            .any(|constraint| argument.is_assignable_to(db, *constraint)),
+    }
+}
+
+/// declaration-site validation, run from the post-inference static-class
+/// checks: the extended name must resolve to a class, bracket params must
+/// reuse (and only constrain) parameters the extended type declares, and the
+/// body must add behaviour, not state
+pub(crate) fn validate_extension_declaration<'db>(
+    context: &InferContext<'db, '_>,
+    extension: StaticClassLiteral<'db>,
+    class_node: &ast::StmtClassDef,
+) {
+    let db = context.db();
+
+    let Some(target) = extended_class(db, extension) else {
+        if let Some(builder) = context.report_lint(&INVALID_EXTENSION, &class_node.name) {
+            builder.into_diagnostic(format_args!(
+                "`{}` is not a class; an extension must name an existing class",
+                class_node.name,
+            ));
+        }
+        return;
+    };
+
+    if let Some(type_params) = class_node.type_params.as_deref() {
+        let target_context = target.generic_context(db);
+        for param in &type_params.type_params {
+            let name = param.name();
+            let declared = matches!(param, ast::TypeParam::TypeVar(_))
+                && target_context.is_some_and(|target_context| {
+                    target_context
+                        .variables(db)
+                        .any(|variable| variable.typevar(db).name(db).as_str() == name.as_str())
+                });
+            if !declared && let Some(builder) = context.report_lint(&INVALID_EXTENSION, param) {
+                builder.into_diagnostic(format_args!(
+                    "`{}` declares no type parameter `{name}`; an extension \
+                    reuses the extended type's own parameters by name",
+                    target.name(db),
+                ));
+            }
+        }
+    }
+
+    for stmt in &class_node.body {
+        let invalid = match stmt {
+            ast::Stmt::Assign(_) | ast::Stmt::AnnAssign(_) | ast::Stmt::AugAssign(_) => {
+                Some("stored fields")
+            }
+            ast::Stmt::ClassDef(_) => Some("nested classes"),
+            _ => None,
+        };
+        if let Some(what) = invalid
+            && let Some(builder) = context.report_lint(&INVALID_EXTENSION, stmt)
+        {
+            builder.into_diagnostic(format_args!(
+                "an extension adds methods and computed properties; {what} are not allowed",
+            ));
+        }
+    }
+}
+
+fn classify_member<'db>(db: &'db dyn Db, member: Type<'db>) -> ExtensionMemberKind {
+    match member {
+        Type::FunctionLiteral(function) if function.is_staticmethod(db) => {
+            ExtensionMemberKind::StaticMethod
+        }
+        Type::FunctionLiteral(function) if function.is_classmethod(db) => {
+            ExtensionMemberKind::ClassMethod
+        }
+        Type::PropertyInstance(_) => ExtensionMemberKind::Property,
+        _ => ExtensionMemberKind::Method,
+    }
+}

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -760,6 +760,22 @@ impl<'db> OverloadLiteral<'db> {
             let class_node = class_scope.node().as_class()?;
             let class_def = index.expect_single_definition(class_node);
             let class_literal = original_class_type(db, class_def)?;
+
+            // basedpython: an extension method's `self` is the *extended* type,
+            // specialized at the extension's view of its type parameters. the
+            // receiver's own type arguments are substituted in when the member
+            // is resolved on a receiver, exactly like ordinary generic members
+            if let ClassLiteral::Static(static_literal) = class_literal
+                && static_literal.is_extension(db)
+            {
+                let body_view = crate::types::extensions::body_view_class(db, static_literal)?;
+                return Some(if self.is_classmethod(db) {
+                    SubclassOfType::from(db, SubclassOfInner::Class(body_view))
+                } else {
+                    Type::instance(db, body_view)
+                });
+            }
+
             let class_is_generic = class_literal.generic_context(db).is_some();
             let class_is_fallback = class_literal
                 .known(db)

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -146,6 +146,24 @@ pub(crate) fn bind_typevar<'db>(
         {
             return Some(bound);
         }
+        // basedpython: an `extension` body reuses the extended class's type
+        // parameters by name, so the extended class's generic context binds
+        // them here even though the extension is not lexically inside it
+        if (!is_class_scope || !crossed_class_scope)
+            && let Some(class_ref) = ancestor_scope.node().as_class()
+        {
+            let definition = index.expect_single_definition(class_ref);
+            let module = parsed_module(db, definition.file(db)).load(db);
+            if class_ref.node(&module).is_extension()
+                && let Some(ClassLiteral::Static(extension)) =
+                    crate::types::infer::original_class_type(db, definition)
+                && let Some(target) = crate::types::extensions::extended_class(db, extension)
+                && let Some(target_context) = target.generic_context(db)
+                && let Some(bound) = target_context.binds_typevar(db, typevar)
+            {
+                return Some(bound);
+            }
+        }
         // a based-enum variant is conceptually generic in its enum's type
         // parameters (`Tree[T]`'s `Node` variant carries `T`), so it is allowed
         // to reach through to the enclosing enum's type params even though it is
@@ -190,10 +208,18 @@ pub(crate) fn typing_self<'db>(
     // for a based payload enum, `Self` ranges over the closed set of variant
     // types rather than the (abstract) enum instance, so `match self` in a
     // method is exhaustive over the variants — the same closed domain that a
-    // bare `Expr` annotation denotes
+    // bare `Expr` annotation denotes. for an `extension`, `Self` ranges over
+    // the *extended* type — the synthetic extension class never has instances
     let self_bound = class
         .as_static()
-        .and_then(|static_class| crate::types::class::based_enum_variant_union(db, static_class))
+        .and_then(|static_class| {
+            if static_class.is_extension(db) {
+                crate::types::extensions::body_view_class(db, static_class)
+                    .map(|body_view| Type::instance(db, body_view))
+            } else {
+                crate::types::class::based_enum_variant_union(db, static_class)
+            }
+        })
         .unwrap_or_else(|| Type::instance(db, class.identity_specialization(db)));
     let bounds = TypeVarBoundOrConstraints::UpperBound(self_bound);
     let typevar = TypeVarInstance::new(

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -53,17 +53,17 @@ use crate::types::class::{
 use crate::types::constraints::{ConstraintSetBuilder, PathBounds, Solutions};
 use crate::types::context::InferContext;
 use crate::types::diagnostic::{
-    self, CALL_NON_CALLABLE, CONFLICTING_DECLARATIONS, CYCLIC_TYPE_ALIAS_DEFINITION,
-    ERASED_CAST_ARGUMENT, ERASED_TYPE_CHECK, FINAL_ON_VARIABLE, GeneratorMismatchKind,
-    INEFFECTIVE_FINAL, INVALID_ARGUMENT_TYPE, INVALID_ASSIGNMENT, INVALID_DECLARATION,
-    INVALID_ENUM_MEMBER_ANNOTATION, INVALID_LEGACY_TYPE_VARIABLE, INVALID_NEWTYPE,
-    INVALID_PARAMSPEC, INVALID_TYPE_ALIAS_TYPE, INVALID_TYPE_FORM, INVALID_TYPE_GUARD_CALL,
-    INVALID_TYPE_VARIABLE_BOUND, INVALID_TYPE_VARIABLE_CONSTRAINTS, NON_OVERLAPPING_CAST,
-    POSSIBLY_MISSING_IMPLICIT_CALL, POSSIBLY_MISSING_SUBMODULE, UNDEFINED_REVEAL,
-    UNRESOLVED_ATTRIBUTE, UNRESOLVED_GLOBAL, UNRESOLVED_REFERENCE, UNSPECIALIZED_REIFIED_GENERIC,
-    UNSUPPORTED_OPERATOR, UNUSED_AWAITABLE, hint_if_stdlib_attribute_exists_on_other_versions,
-    report_attempted_protocol_instantiation, report_bad_dunder_delattr_call,
-    report_bad_dunder_delete_call, report_call_to_abstract_method,
+    self, AMBIGUOUS_EXTENSION_MEMBER, CALL_NON_CALLABLE, CONFLICTING_DECLARATIONS,
+    CYCLIC_TYPE_ALIAS_DEFINITION, ERASED_CAST_ARGUMENT, ERASED_TYPE_CHECK, FINAL_ON_VARIABLE,
+    GeneratorMismatchKind, INEFFECTIVE_FINAL, INVALID_ARGUMENT_TYPE, INVALID_ASSIGNMENT,
+    INVALID_DECLARATION, INVALID_ENUM_MEMBER_ANNOTATION, INVALID_LEGACY_TYPE_VARIABLE,
+    INVALID_NEWTYPE, INVALID_PARAMSPEC, INVALID_TYPE_ALIAS_TYPE, INVALID_TYPE_FORM,
+    INVALID_TYPE_GUARD_CALL, INVALID_TYPE_VARIABLE_BOUND, INVALID_TYPE_VARIABLE_CONSTRAINTS,
+    NON_OVERLAPPING_CAST, POSSIBLY_MISSING_IMPLICIT_CALL, POSSIBLY_MISSING_SUBMODULE,
+    UNDEFINED_REVEAL, UNRESOLVED_ATTRIBUTE, UNRESOLVED_GLOBAL, UNRESOLVED_REFERENCE,
+    UNSPECIALIZED_REIFIED_GENERIC, UNSUPPORTED_OPERATOR, UNUSED_AWAITABLE,
+    hint_if_stdlib_attribute_exists_on_other_versions, report_attempted_protocol_instantiation,
+    report_bad_dunder_delattr_call, report_bad_dunder_delete_call, report_call_to_abstract_method,
     report_cannot_pop_required_field_on_typed_dict, report_invalid_assignment,
     report_invalid_class_match_pattern, report_invalid_exception_caught,
     report_invalid_exception_cause, report_invalid_exception_raised,
@@ -77,6 +77,7 @@ use crate::types::diagnostic::{
     report_unsupported_comparison,
 };
 use crate::types::enums::{enum_ignored_names, is_enum_class_by_inheritance};
+use crate::types::extensions;
 use crate::types::function::{
     FunctionDecorators, FunctionType, KnownFunction, report_revealed_type,
     same_module_uncached_raw_signature,
@@ -9085,7 +9086,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 );
                 let collection_generic_context = collection_literal.generic_context(self.db());
 
+                // the identity-receiver probe is speculative: suppress its
+                // diagnostics (a basedpython extension member with a bracket
+                // bound legitimately fails to resolve on the identity
+                // specialization, and that must not surface as an error)
                 let mut identity_bindings = self
+                    .speculate_without_diagnostics()
                     .infer_attribute_load_impl(attribute, identity_instance)
                     .bindings(self.db())
                     .match_parameters(self.db(), &call_arguments)
@@ -9778,6 +9784,28 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         ))),
                     );
                     Place::bound(Type::single_callable(db, signature)).into()
+                } else {
+                    Place::Undefined.into()
+                }
+            })
+            // basedpython only: inside an `extension` body, the extended
+            // type's own type parameters are in scope under the names its
+            // declaration bound (`Element` on `list`). bracket-spelled
+            // (constrained) params resolve normally through the type-param
+            // scope before this fallback is reached. the name resolves to the
+            // typevar *object* — `bind_typevar` recognises extension bodies as
+            // binding the extended class's parameters, exactly as a class body
+            // binds its own
+            .or_fall_back_to(db, || {
+                if self.is_basedpython_file()
+                    && let Some(extension) = self.enclosing_extension()
+                    && let Some(typevar) =
+                        extensions::extension_body_typevar(db, extension, symbol_name)
+                {
+                    Place::bound(Type::KnownInstance(KnownInstanceType::TypeVar(
+                        typevar.typevar(db),
+                    )))
+                    .into()
                 } else {
                     Place::Undefined.into()
                 }
@@ -10612,9 +10640,33 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 assigned_type = Some(ty);
             }
         }
-        let fallback_place = value_type.member(db, &attr.id).map_type(|ty| {
+        let mut fallback_place = value_type.member(db, &attr.id).map_type(|ty| {
             self.narrow_expr_with_applicable_constraints(attribute, ty, &constraint_keys)
         });
+
+        // basedpython: an attribute that resolves to no declared member may be
+        // supplied by an `extension` in scope (this module's, or one from any
+        // module imported with a plain `import mod`). extensions never shadow
+        // declared members — this only runs after normal lookup came up empty
+        if self.is_basedpython_file() && fallback_place.place.is_undefined() {
+            if let Some(resolution) =
+                extensions::resolve_extension_member(db, self.file(), value_type, &attr.id)
+            {
+                if let Some(other) = resolution.ambiguous_with
+                    && let Some(builder) = self
+                        .context
+                        .report_lint(&AMBIGUOUS_EXTENSION_MEMBER, attribute)
+                {
+                    builder.into_diagnostic(format_args!(
+                        "Attribute `{}` is supplied by more than one applicable \
+                        extension of `{}`",
+                        attr.id,
+                        other.name(db),
+                    ));
+                }
+                fallback_place = Place::bound(resolution.ty).into();
+            }
+        }
 
         let attr_name = &attr.id;
         let resolved_type =

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -119,6 +119,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         | "protocol_class"
                         | "sealed"
                         | "enum_def"
+                        | "extension_def"
                         | "variant_unit"
                         | "variant_tuple"
                         | "private"
@@ -194,6 +195,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             ClassLiteralFlags::IS_ENUM_VARIANT,
             class_node.is_enum_variant(),
         );
+        class_flags.set(ClassLiteralFlags::IS_EXTENSION, class_node.is_extension());
         class_flags.set(
             ClassLiteralFlags::HAS_EXPLICIT_METACLASS,
             has_explicit_metaclass,

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -4,6 +4,7 @@ use crate::{
     types::{
         KnownClass, KnownInstanceType, ParamSpecAttrKind, SubclassOfInner, SubclassOfType, Type,
         TypeContext, TypeVarKind, UnionType,
+        class::ClassLiteral,
         diagnostic::{
             FINAL_ON_NON_METHOD, INVALID_PARAMETER_DEFAULT, INVALID_PARAMSPEC, INVALID_TYPE_FORM,
             REIFIED_CLASSMETHOD, USELESS_OVERLOAD_BODY, add_type_expression_reference_link,
@@ -11,6 +12,7 @@ use crate::{
             report_invalid_generator_function_return_type, report_invalid_return_type,
             report_shadowed_type_variable,
         },
+        extensions,
         function::{
             FunctionBodyKind, FunctionDecorators, FunctionLiteral, FunctionType, KnownFunction,
             OverloadLiteral, function_body_kind, is_implicit_classmethod,
@@ -1179,6 +1181,21 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let class_definition = self.index.expect_single_definition(class);
         let class_literal = original_class_type(db, class_definition)?;
+
+        // basedpython: an extension method's `self` is the *extended* type,
+        // specialized at the extension's view of its type parameters — not a
+        // `Self` typevar of the synthetic extension class (whose own body holds
+        // only the extension members)
+        if let ClassLiteral::Static(static_literal) = class_literal
+            && static_literal.is_extension(db)
+        {
+            let body_view = extensions::body_view_class(db, static_literal)?;
+            return Some(if is_classmethod || function_name == "__new__" {
+                SubclassOfType::from(db, SubclassOfInner::Class(body_view))
+            } else {
+                Type::instance(db, body_view)
+            });
+        }
 
         let typing_self = typing_self(db, self.scope(), Some(method_definition), class_literal);
         if is_classmethod || function_name == "__new__" {

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -42,6 +42,7 @@ use crate::{
             report_subclass_of_class_with_non_callable_init_subclass, report_unsupported_base,
         },
         enums::is_enum_class_by_inheritance,
+        extensions,
         function::KnownFunction,
         generics::enclosing_generic_contexts,
         infer::builder::post_inference::typed_dict::validate_typed_dict_class,
@@ -86,6 +87,14 @@ pub(crate) fn check_static_class_definitions<'db>(
     let Type::ClassLiteral(ClassLiteral::Static(class)) = ty else {
         return;
     };
+
+    // basedpython: an `extension` declaration is not a class — it references
+    // one. it gets its own validation, and none of the inheritance-based
+    // checks below apply (it has no bases by construction)
+    if class.is_extension(db) {
+        extensions::validate_extension_declaration(context, class, class_node);
+        return;
+    }
 
     // Check that the class does not have a cyclic definition
     if let Some(inheritance_cycle) = class.inheritance_cycle(db) {

--- a/crates/ty_python_semantic/src/types/infer/builder/typevar.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typevar.rs
@@ -4,6 +4,7 @@ use crate::{
     types::{
         BindingContext, KnownClass, KnownInstanceType, LintDiagnosticGuard, Truthiness, Type,
         TypeContext, TypeVarBoundOrConstraints, TypeVarKind, TypeVarVariance,
+        class::{ClassLiteral, StaticClassLiteral},
         context::InferContext,
         diagnostic::{
             INVALID_LEGACY_TYPE_VARIABLE, INVALID_PARAMSPEC, INVALID_TYPE_VARIABLE_BOUND,
@@ -13,6 +14,7 @@ use crate::{
         infer::{
             InferenceFlags, TypeInferenceBuilder,
             builder::{BoundOrConstraintsNodes, DeclaredAndInferredType, DeferredExpressionState},
+            original_class_type,
         },
         todo_type,
         typevar::{
@@ -36,6 +38,27 @@ use ty_python_core::{
 impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     pub(super) fn is_basedpython_file(&self) -> bool {
         self.file().source_type(self.db()).is_basedpython()
+    }
+
+    /// basedpython: the innermost `extension` declaration enclosing the
+    /// current scope, when inference is inside an extension body
+    pub(super) fn enclosing_extension(&self) -> Option<StaticClassLiteral<'db>> {
+        let db = self.db();
+        for (_, scope) in self.index.ancestor_scopes(self.scope().file_scope_id(db)) {
+            let Some(class) = scope.node().as_class() else {
+                continue;
+            };
+            if !class.node(self.module()).is_extension() {
+                continue;
+            }
+            let definition = self.index.expect_single_definition(class);
+            if let Some(ClassLiteral::Static(literal)) = original_class_type(db, definition)
+                && literal.is_extension(db)
+            {
+                return Some(literal);
+            }
+        }
+        None
     }
 
     pub(super) fn infer_typevar_definition(

--- a/docs/basedpython/features/extensions.md
+++ b/docs/basedpython/features/extensions.md
@@ -1,61 +1,29 @@
 # extensions
 
-> planned for `0.0.1a4` — not yet implemented
-
 an extension adds methods and computed properties to an existing type without
 subclassing it or touching its definition:
 
 ```by
 extension list:
-    def second(self) -> _T:
+    def second(self) -> Element:
         return self[1]
 ```
 
 `xs.second()` is then available on any `list`, including the builtin one. the
-extension reuses `list`'s own type parameter `_T` — it does not declare a new
-one — so the return type tracks the element type with no extra ceremony
+extension reuses `list`'s own type parameter `Element` — it does not declare a
+new one — so the return type tracks the element type with no extra ceremony
 
-## why swift-style
-
-three languages solve "where do the extended type's parameters come from"
-differently. the choice matters because of one failure mode: a parameter that
-is used before it is bound
-
-kotlin re-declares the parameters on the receiver and again on the method:
-
-```by
-# kotlin-style, rejected
-def list[T].foo[T: int](self) -> T: ...
-```
-
-`T` appears in `list[T]` before the `[T: int]` that declares it, and the two
-`T`s are different parameters that happen to share a spelling. imports are
-explicit — every extension must be named to be used
-
-dart declares two separate parameter lists and binds one to the other:
-
-```by
-# dart-style, rejected
-extension[T] on list[T]:
-    def foo[R](self, r: R) -> T | R: ...
-```
-
-this is unambiguous but verbose, and the binding `[T] on list[T]` restates a
-fact the declaration of `list` already records
-
-swift reuses the extended type's parameters directly, by the names its
-declaration gave them:
+a method may reuse the extended type's parameters directly, by the names its
+declaration gave them, and may also introduce its own fresh parameters:
 
 ```by
 extension list:
-    def foo[R](self, r: R) -> _T | R: ...
+    def foo[R](self, r: R) -> Element | R: ...
 ```
 
-`_T` is not a new parameter and not a sigil — it is the name `list`'s
-declaration bound (`class list[_T]` in typeshed). because it refers to an
-existing declaration, it can never be used before it is defined. a method may
-still introduce its own fresh parameters (`[R]` here), declared normally on the
-method. basedpython takes the swift model
+`Element` is not a new parameter and not a sigil — it is the name `list`'s
+declaration bound (`class list[in out Element]` in basedpython's typeshed).
+`[R]` is a fresh parameter the method declares normally
 
 ## reusing declared parameters
 
@@ -71,11 +39,12 @@ extension Stack:
         return self._items[-1]
 ```
 
-for a typeshed type the names follow typeshed convention (`_T`, `_KT`, `_VT`):
+for a typeshed type the names follow basedpython's typeshed, which spells the
+core containers `list[Element]`, `dict[Key, Value]`, `set[Element]`:
 
 ```by
 extension dict:
-    def invert(self) -> dict[_VT, _KT]: ...
+    def invert(self) -> dict[Value, Key]: ...
 ```
 
 referencing a name the extended type did not declare is an error — there is no
@@ -88,15 +57,15 @@ a bound on a reused parameter narrows where the extension applies. it does not
 re-declare the parameter — it constrains the receiver:
 
 ```by
-extension list[_T: int]:
+extension list[Element: int]:
     def total(self) -> int:
         return sum(self)
 ```
 
-`total` is visible on `list[int]` and `list[bool]`, not on `list[str]`. this is
-swift's `where _T: int`, spelled with basedpython's existing bracket-bound
-syntax so it reads like every other bound in the language. parameters left out
-of the bracket stay reused, unconstrained
+`total` is visible on `list[int]` and `list[bool]`, not on `list[str]`. the
+bound is spelled with basedpython's existing bracket-bound syntax so it reads
+like every other bound in the language. parameters left out of the bracket stay
+reused, unconstrained
 
 constraint applicability is resolved by the type checker per call site, so an
 extension can overlap a builtin or another extension and only apply to the
@@ -107,8 +76,8 @@ arm that satisfies its bound
 extensions add behaviour, not state — methods, `class def`/`static def`
 methods, and computed [properties](properties.md). they may not add stored
 fields, because there is nowhere to store them on an already-constructed
-instance of a builtin. this is the same boundary swift draws, and it keeps the
-feature implementable without touching object layout
+instance of a builtin, and it keeps the feature implementable without touching
+object layout
 
 ```by
 extension str:
@@ -141,20 +110,27 @@ at runtime, so extensions are resolved entirely at transpile time — no runtime
 machinery, the same approach the rest of basedpython takes
 
 each extension member lowers to a module-level free function whose first
-parameter is the receiver:
+parameter is the receiver. annotations are dropped from the backing function
+— they reference type parameters with no runtime binding at module level —
+and a marker comment carries the member kind and the original header
+(bounds included) as provenance for the reverse transpiler:
 
 ```by
 extension list:
-    def second(self) -> _T:
+    def second(self) -> Element:
         return self[1]
 ```
 
 →
 
 ```python
-def __by_ext__list__second(self):
+def __by_ext__list__second(self):  # basedpython: extension method list
     return self[1]
 ```
+
+when a module declares more than one extension of the same target, later
+ones mangle with an ordinal (`__by_ext2__list__…`) so their members don't
+collide — conditional extensions of the same method name coexist this way
 
 call sites are rewritten by the type checker. ty already knows the receiver's
 type and which extensions are in scope, so `xs.second()` resolves to the
@@ -180,8 +156,8 @@ loses to the real attribute — extensions never shadow declared members
 ### implicit imports, lowered
 
 when a call site uses an extension defined in another module, the lowering emits
-the precise import of the backing function into the output, keyed off the
-provenance ty recorded:
+the precise import of the backing function into the output, keyed off ty's
+resolution of the call site:
 
 ```by
 import textwrap
@@ -202,7 +178,22 @@ imported — the implicit-import convenience costs nothing at runtime
 
 ## round-tripping
 
-the reverse transpiler re-sugars both halves from `LoweringMap` provenance:
-a free function tagged `ExtensionMethod` becomes an `extension` block, and a
-call tagged `ExtensionCall` becomes receiver-method form. backing functions and
-calls written by hand without that provenance are left as ordinary python
+the reverse transpiler re-sugars both halves from the marker-comment
+provenance: a backing function tagged `# basedpython: extension …` becomes an
+`extension` block (consecutive same-header functions share one block), and a
+call of a same-file backing function becomes receiver-method form —
+`__by_ext__list__second(xs)` → `xs.second()`, property calls drop back to
+bare attributes, `functools.partial(…, xs)` references to `xs.second`.
+backing-shaped functions and calls written by hand without the marker are
+left as ordinary python, and a call of a backing function *imported* from
+another module conservatively stays as the explicit call
+
+## current limitations
+
+- an extension member cannot be reached through an optional chain
+    (`xs?.second()`) yet — the transpiler reports an error rather than emit
+    code that breaks the chain's short-circuit
+- extension members resolve on a single receiver type, not across a union
+- an unapplied method reference (`f = xs.second`) lowers to
+    `functools.partial`, which binds the receiver eagerly like a bound method
+    but is not one at runtime

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -357,6 +357,16 @@
             }
           ]
         },
+        "ambiguous-extension-member": {
+          "title": "detects attribute accesses supplied by more than one extension",
+          "description": "## What it does\nChecks for attribute accesses that resolve to a member supplied by more\nthan one applicable basedpython extension.\n\n## Why is this bad?\nWhen two extensions in scope both add the same member to the receiver's\ntype, the access is ambiguous — which implementation runs would depend\non arbitrary ordering. Constrain one of the extensions (or drop the\nimport that brings the second into scope) so exactly one applies.\n\n## Example\n\n```by\nextension list:\n    def second(self) -> Element: ...\n\nextension list:\n    def second(self) -> Element: ...\n\n[1, 2].second()  # error: ambiguous extension member\n```",
+          "default": "error",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Level"
+            }
+          ]
+        },
         "ambiguous-protocol-member": {
           "title": "detects protocol classes with ambiguous interfaces",
           "description": "## What it does\n\nChecks for protocol classes with members that will lead to ambiguous interfaces.\n\n## Why is this bad?\n\nAssigning to an undeclared variable in a protocol class, or to an undeclared attribute\nthrough a protocol method's `self` or `cls` receiver, leads to an ambiguous interface\nwhich may lead to the type checker inferring unexpected things. It's recommended to\nensure that all members of a protocol class are explicitly declared.\n\n## Examples\n\n```py\nfrom typing import ClassVar, Protocol\n\n\nclass BaseProto(Protocol):\n    a: int  # fine (explicitly declared as `int`)\n    instance_member: str\n    class_member: ClassVar[str]\n\n    # fine: a method definition using `def` is considered a declaration\n    def method_member(self) -> int: ...\n\n    def method(self) -> None:\n        self.instance_member = \"value\"  # fine (declared in the class body)\n        self.implicit = \"value\"  # error: [ambiguous-protocol-member]\n\n    @classmethod\n    def class_method(cls) -> None:\n        cls.class_member = \"value\"  # fine (declared in the class body)\n        cls.implicit_class = \"value\"  # error: [ambiguous-protocol-member]\n\n    # no explicit declaration, leading to ambiguity\n    c = \"some variable\"  # error\n    # no explicit declaration, leading to ambiguity\n    b = method_member  # error\n\n    # This creates implicit assignments of `d` and `e` in the protocol class body.\n    # Were they really meant to be considered protocol members?\n    # error: \"`d` is not declared as a protocol member\"\n    # error: \"`e` is not declared as a protocol member\"\n    for d, e in enumerate(range(42)):\n        pass\n\n\nclass SubProto(BaseProto, Protocol):\n    a = 42  # fine (declared in superclass)\n```",
@@ -770,6 +780,16 @@
         "invalid-explicit-override": {
           "title": "detects methods that are decorated with `@override` but do not override any method in a superclass",
           "description": "## What it does\n\nChecks for methods that are decorated with `@override` but do not override any method in a superclass.\n\n## Why is this bad?\n\nDecorating a method with `@override` declares to the type checker that the intention is that it should\noverride a method from a superclass.\n\n## Example\n\n```toml\n[environment]\npython-version = \"3.12\"\n```\n\n```python\nfrom typing import override\n\n\nclass A:\n    @override\n    def foo(self): ...  # error\n\n\nclass B(A):\n    @override\n    def ffooo(self): ...  # error\n\n\nclass C:\n    @override\n    def __repr__(self): ...  # fine: overrides `object.__repr__`\n\n\nclass D(A):\n    @override\n    def foo(self): ...  # fine: overrides `A.foo`\n```",
+          "default": "error",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Level"
+            }
+          ]
+        },
+        "invalid-extension": {
+          "title": "detects invalid basedpython extension declarations",
+          "description": "## What it does\nChecks for invalid basedpython `extension` declarations: an extended\nname that does not resolve to a class, a bracket type parameter the\nextended type does not declare, or a member that would add stored state.\n\n## Why is this bad?\nAn extension adds behaviour to an existing type. Its name must reference\na class declaration, its bracket parameters reuse (and constrain) that\nclass's own type parameters by name, and its members are resolved at\ntranspile time with nowhere to store new fields on already-constructed\ninstances.\n\n## Example\n\n```by\nextension list[T: int]:  # error: `list` declares no type parameter `T`\n    def total(self) -> int:\n        return sum(self)\n```",
           "default": "error",
           "oneOf": [
             {


### PR DESCRIPTION
extension blocks add methods and computed properties to an existing type, reusing its own type parameters by name. parser marker + ty member-lookup fallback + __by_ext__ backing-function lowering + reverse re-sugar

