### PR TITLE
[ty] polyfill explicit version-gated typing/warnings imports in basedpython

### DIFF
--- a/crates/by_transforms/src/transforms/typing_redirect.rs
+++ b/crates/by_transforms/src/transforms/typing_redirect.rs
@@ -4,7 +4,7 @@ use ruff_python_ast::{Stmt, StmtImportFrom};
 use ruff_text_size::Ranged;
 
 use crate::config::Config;
-use ruff_python_ast::PythonVersion;
+use ty_python_semantic::{basedpython_typing_added_in, basedpython_warnings_added_in};
 
 /// Rewrites `from typing import X` (and `from warnings import deprecated`) to
 /// `from typing_extensions import X` for names not yet in the stdlib at the
@@ -24,42 +24,6 @@ impl<'src> TypingRedirect<'src> {
         }
     }
 
-    /// Returns the Python version when `name` was added to `typing`.
-    /// Returns `None` if it has been in `typing` since before 3.10.
-    fn typing_added_in(name: &str) -> Option<PythonVersion> {
-        match name {
-            // 3.11
-            "Never"
-            | "assert_never"
-            | "LiteralString"
-            | "Required"
-            | "NotRequired"
-            | "Self"
-            | "Unpack"
-            | "TypeVarTuple"
-            | "dataclass_transform"
-            | "reveal_type"
-            | "assert_type"
-            | "get_overloads"
-            | "clear_overloads" => Some(PythonVersion::PY311),
-            // 3.12
-            "override" | "TypeAliasType" => Some(PythonVersion::PY312),
-            // 3.13
-            "TypeIs" | "ReadOnly" | "get_protocol_members" | "is_protocol" | "NoDefault" => {
-                Some(PythonVersion::PY313)
-            }
-            _ => None,
-        }
-    }
-
-    /// Returns the Python version when `name` was added to `warnings`.
-    fn warnings_added_in(name: &str) -> Option<PythonVersion> {
-        match name {
-            "deprecated" => Some(PythonVersion::PY313),
-            _ => None,
-        }
-    }
-
     fn process_import(&mut self, node: &StmtImportFrom) {
         // Skip relative imports and star imports.
         if node.level > 0 {
@@ -71,9 +35,9 @@ impl<'src> TypingRedirect<'src> {
         };
         let module_str = module.id.as_str();
 
-        let added_in: fn(&str) -> Option<PythonVersion> = match module_str {
-            "typing" => Self::typing_added_in,
-            "warnings" => Self::warnings_added_in,
+        let added_in = match module_str {
+            "typing" => basedpython_typing_added_in,
+            "warnings" => basedpython_warnings_added_in,
             _ => return,
         };
 

--- a/crates/ty_python_semantic/resources/mdtest/basedpython_typing_import.md
+++ b/crates/ty_python_semantic/resources/mdtest/basedpython_typing_import.md
@@ -1,0 +1,74 @@
+# basedpython: version-gated typing imports
+
+basedpython makes version-gated `typing` (and `warnings`) members available regardless of the target
+Python version. When a name postdates the target version, the transpiler rewrites
+`from typing import X` to `from typing_extensions import X`; the type checker mirrors that redirect
+so an explicit import resolves the same way the emitted code will.
+
+```toml
+[environment]
+python-version = "3.10"
+```
+
+## `reveal_type` imported explicitly
+
+`typing.reveal_type` was added in 3.11, so on a 3.10 target it is resolved from `typing_extensions`.
+
+```by
+from typing import reveal_type
+
+reveal_type(1)  # revealed: 1
+```
+
+## other 3.11 names
+
+```by
+from typing import Self, assert_type, Never, LiteralString
+
+class C:
+    def clone(self) -> Self:
+        return self
+
+reveal_type(C().clone())  # revealed: C
+```
+
+## a split import keeps the non-gated half
+
+A name already available at the target version (`TypeVar`) is resolved from `typing` as usual, while
+the gated name falls back to `typing_extensions`.
+
+```by
+from typing import TypeVar, Self
+
+T = TypeVar("T")
+```
+
+## `warnings.deprecated`
+
+`warnings.deprecated` was added in 3.13; on a 3.10 target it resolves from `typing_extensions`.
+
+```by
+from warnings import deprecated
+
+@deprecated("use something else")
+def old() -> None: ...
+```
+
+## genuinely missing members still error
+
+The fallback only covers the curated set of version-gated names, so a name that exists in neither
+`typing` nor `typing_extensions` still reports an unresolved import.
+
+```by
+# error: [unresolved-import]
+from typing import NotARealTypingMember
+```
+
+## non-typing modules are unaffected
+
+The redirect is scoped to `typing` and `warnings`; other modules resolve normally.
+
+```by
+# error: [unresolved-import]
+from os import definitely_not_a_real_os_member
+```

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -13,7 +13,9 @@ pub use diagnostic::{
     add_inferred_python_version_hint_to_diagnostic, inferred_python_version_source_annotation,
 };
 pub use fixes::{fix_all_diagnostics, suppress_all_diagnostics};
-pub use place::BASEDPYTHON_IMPLICIT_TYPING_NAMES;
+pub use place::{
+    BASEDPYTHON_IMPLICIT_TYPING_NAMES, basedpython_typing_added_in, basedpython_warnings_added_in,
+};
 use ruff_db::diagnostic::{Annotation, Diagnostic, DiagnosticId, Severity, Span};
 use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -713,6 +713,50 @@ pub(crate) fn is_basedpython_implicit_typing_name(name: &str) -> bool {
         .is_ok()
 }
 
+/// The Python version in which `name` was added to the `typing` module, or
+/// `None` if it has been available since before 3.10.
+///
+/// basedpython makes these names available regardless of the target Python
+/// version. This is the single source of truth for that set: `by_transforms`'
+/// `typing_redirect` pass rewrites `from typing import <name>` to
+/// `from typing_extensions import <name>` when the name postdates the minimum
+/// version, and the type checker mirrors that redirect when resolving imports
+/// (see `infer_import_from_definition`).
+pub fn basedpython_typing_added_in(name: &str) -> Option<PythonVersion> {
+    match name {
+        // 3.11
+        "Never"
+        | "assert_never"
+        | "LiteralString"
+        | "Required"
+        | "NotRequired"
+        | "Self"
+        | "Unpack"
+        | "TypeVarTuple"
+        | "dataclass_transform"
+        | "reveal_type"
+        | "assert_type"
+        | "get_overloads"
+        | "clear_overloads" => Some(PythonVersion::PY311),
+        // 3.12
+        "override" | "TypeAliasType" => Some(PythonVersion::PY312),
+        // 3.13
+        "TypeIs" | "ReadOnly" | "get_protocol_members" | "is_protocol" | "NoDefault" => {
+            Some(PythonVersion::PY313)
+        }
+        _ => None,
+    }
+}
+
+/// The Python version in which `name` was added to the `warnings` module, or
+/// `None`. See [`basedpython_typing_added_in`].
+pub fn basedpython_warnings_added_in(name: &str) -> Option<PythonVersion> {
+    match name {
+        "deprecated" => Some(PythonVersion::PY313),
+        _ => None,
+    }
+}
+
 /// Lookup the type of `symbol` in the `typing_extensions` module namespace.
 ///
 /// Returns `Place::Undefined` if the `typing_extensions` module isn't available for some reason.

--- a/crates/ty_python_semantic/src/types/infer/builder/imports.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/imports.rs
@@ -1,12 +1,16 @@
 use ruff_python_ast as ast;
 use ruff_text_size::{Ranged, TextRange};
 use ty_module_resolver::{
-    ModuleName, ModuleNameResolutionError, ModuleResolveMode, resolve_module, search_paths,
+    KnownModule, Module, ModuleName, ModuleNameResolutionError, ModuleResolveMode, resolve_module,
+    search_paths,
 };
 
 use crate::{
     Program, TypeQualifiers, add_inferred_python_version_hint_to_diagnostic,
-    place::{DefinedPlace, Definedness, Place, PlaceAndQualifiers, TypeOrigin},
+    place::{
+        DefinedPlace, Definedness, Place, PlaceAndQualifiers, TypeOrigin,
+        basedpython_typing_added_in, basedpython_warnings_added_in, typing_extensions_symbol,
+    },
     types::{
         ModuleLiteralType, Type, TypeAndQualifiers,
         diagnostic::{
@@ -302,6 +306,30 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
     }
 
+    /// basedpython: resolve a version-gated `typing`/`warnings` member from
+    /// `typing_extensions` when it is absent from the module at the target
+    /// Python version. Returns `None` for any other module or name, so ordinary
+    /// unresolved imports still report as usual.
+    fn basedpython_typing_import_redirect(
+        &self,
+        module: Module<'db>,
+        name: &str,
+    ) -> Option<PlaceAndQualifiers<'db>> {
+        let db = self.db();
+        let redirected = if module.is_known(db, KnownModule::Typing) {
+            basedpython_typing_added_in(name).is_some()
+        } else if module.is_known(db, KnownModule::Warnings) {
+            basedpython_warnings_added_in(name).is_some()
+        } else {
+            false
+        };
+        if !redirected {
+            return None;
+        }
+        let place = typing_extensions_symbol(db, name);
+        (!place.place.is_undefined()).then_some(place)
+    }
+
     pub(super) fn infer_import_from_definition(
         &mut self,
         import_from: &ast::StmtImportFrom,
@@ -367,6 +395,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         // First try loading the requested attribute from the module.
         if !skip_self_referential_member_lookup {
+            let mut member = module_literal.static_member(db, name);
+            // basedpython: version-gated `typing`/`warnings` members are always
+            // available. When the member is missing at the target Python version,
+            // fall back to `typing_extensions`, mirroring the transpiler's import
+            // redirect so the checker resolves what the emitted code will import.
+            if member.place.is_undefined()
+                && self.is_basedpython_file()
+                && let Some(redirected) = self.basedpython_typing_import_redirect(module, name)
+            {
+                member = redirected;
+            }
             if let PlaceAndQualifiers {
                 place:
                     Place::Defined(DefinedPlace {
@@ -376,7 +415,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         ..
                     }),
                 qualifiers,
-            } = module_literal.static_member(db, name)
+            } = member
             {
                 if &alias.name != "*" && boundness == Definedness::PossiblyUndefined {
                     // TODO: Consider loading _both_ the attribute and any submodule and unioning them


### PR DESCRIPTION
`from typing import reveal_type` (and other version-gated names like `Self`, `Never`, `warnings.deprecated`) failed the checker on older Python targets even though the transpiler redirects them to `typing_extensions` at runtime. resolve them from `typing_extensions` on the checker side too, so the check and the emitted code agree. the transpiler's version map is now the single source of truth in `ty_python_semantic::place`, reused by `by_transforms`.
