### PR TITLE
added inferred type annotations for class attributes

### DIFF
--- a/crates/by_transforms/src/transforms/ast_driver.rs
+++ b/crates/by_transforms/src/transforms/ast_driver.rs
@@ -37,8 +37,8 @@ use super::{
     annotation, anon_named_tuple, auto_quote, callable, character_type, checked_cast, coalesce,
     coalesce_chain, compat, context_params, decl_site_variance, decorator_keyword, dedent_string,
     dynamic_keyword, empty_declarations, extension, float_const, force_unwrap, frameworks,
-    generic_call, generics, grapheme_string, identity_swap, implicit_typing, init_method,
-    just_float, kw_subscript, literal_types, local_once, main_function, modifiers,
+    generic_call, generics, grapheme_string, identity_swap, implicit_typing, inferred_annotation,
+    init_method, just_float, kw_subscript, literal_types, local_once, main_function, modifiers,
     mutable_defaults, none_chain, optional_type, overload, parametric_is, postfix_await, propagate,
     reified_generic, repeated_underscore, sentinel, some_ctor, soundness, string_tag,
     super_keyword, symbolic_type_op, top_star, trailing_lambda, tuple_index, type_is,
@@ -470,6 +470,7 @@ pub(crate) fn run_against_source<'a>(
         type_reification::TypeReificationPass::new(config.min_version, config.is_stub);
     let parametric_is_pass = parametric_is::ParametricIsPass::new(source_ref);
     let implicit_typing_pass = implicit_typing::ImplicitTypingPass::new();
+    let inferred_annotation_pass = inferred_annotation::InferredAnnotationPass::new();
     let tuple_types_pass = annotation::TupleLiteralTypePass::new(source_ref);
     let literal_types_pass = literal_types::LiteralTypePass::new(source_ref);
     let callable_pass = callable::CallableSyntaxPass::new(source_ref);
@@ -608,6 +609,10 @@ pub(crate) fn run_against_source<'a>(
         // token equality / witness probe / unchecked runtime probe)
         &parametric_is_pass,
         &implicit_typing_pass,
+        // synthesize declared types for bare class-body assignments
+        // (`class A: a = 1` → `a: int = 1`); a zero-width insertion at the
+        // target name, disjoint from the value-position lowerings above
+        &inferred_annotation_pass,
         &tuple_types_pass,
         &literal_types_pass,
         &callable_pass,

--- a/crates/by_transforms/src/transforms/enums.rs
+++ b/crates/by_transforms/src/transforms/enums.rs
@@ -708,7 +708,7 @@ mod tests {
             indoc! {"
                 from __future__ import annotations
                 class E:
-                    MAX = 10
+                    MAX: int = 10
 
                 class _E_A(E):
                     __slots__ = ()

--- a/crates/by_transforms/src/transforms/inferred_annotation.rs
+++ b/crates/by_transforms/src/transforms/inferred_annotation.rs
@@ -1,0 +1,270 @@
+//! type-aware pass: synthesize a declared type for a bare class-body
+//! assignment from ty's inferred type.
+//!
+//! ```by
+//! class A:
+//!     a = 1
+//! ```
+//!
+//! lowers to `a: int = 1` — the attribute's inferred type is promoted
+//! (`Literal[1]` → `int`) and spliced in as an annotation, so the class's
+//! implicit attribute types become declared.
+//!
+//! only a bare `<name> = <value>` directly in a class body is rewritten.
+//! multi-target (`a = b = 1`) and unpacking (`a, b = ...`) assignments are
+//! left alone, as are assignments whose value has no faithful annotation
+//! (an `Unknown` / `Any` part). classes where an annotation would change
+//! runtime semantics — dataclasses, framework models, `NamedTuple`s,
+//! `TypedDict`s, enums — are skipped entirely: in those a bare assignment is
+//! a class variable or member, and annotating it would turn it into a field.
+
+use ruff_python_ast::visitor::{Visitor, walk_stmt};
+use ruff_python_ast::{Expr, Stmt, StmtAssign, StmtClassDef};
+use ruff_text_size::{Ranged, TextRange};
+
+use crate::transforms::ast_driver::{PassContext, TypeAwarePass};
+use crate::type_info::TypeInfo;
+
+pub(crate) struct InferredAnnotationPass;
+
+impl InferredAnnotationPass {
+    pub(crate) fn new() -> Self {
+        Self
+    }
+}
+
+impl TypeAwarePass for InferredAnnotationPass {
+    fn run(&self, stmts: &[Stmt], types: &dyn TypeInfo, ctx: &mut PassContext) {
+        let mut state = State {
+            types,
+            edits: Vec::new(),
+        };
+        for stmt in stmts {
+            state.visit_stmt(stmt);
+        }
+        ctx.text_edits.extend(state.edits);
+    }
+}
+
+struct State<'a> {
+    types: &'a dyn TypeInfo,
+    edits: Vec<(TextRange, String)>,
+}
+
+impl State<'_> {
+    fn process_class(&mut self, class: &StmtClassDef) {
+        if self.types.class_body_annotation_is_semantic(class) {
+            return;
+        }
+        for stmt in &class.body {
+            if let Stmt::Assign(assign) = stmt {
+                self.process_assign(assign);
+            }
+        }
+    }
+
+    fn process_assign(&mut self, assign: &StmtAssign) {
+        // only a single `<name> = <value>` — chained (`a = b = 1`) and
+        // unpacking (`a, b = ...`) targets have no single declared type
+        let [Expr::Name(name)] = assign.targets.as_slice() else {
+            return;
+        };
+        // dunders (`__slots__`, `__match_args__`, ...) are class machinery, not
+        // typed attributes — annotating them is noise (and `__slots__ = ()` is
+        // exactly what the enum lowering re-feeds through this pipeline)
+        if is_dunder(name.id.as_str()) {
+            return;
+        }
+        let Some(annotation) = self.types.inferred_annotation(&assign.value) else {
+            return;
+        };
+        let pos = name.range().end();
+        self.edits
+            .push((TextRange::new(pos, pos), format!(": {annotation}")));
+    }
+}
+
+fn is_dunder(name: &str) -> bool {
+    name.len() > 4 && name.starts_with("__") && name.ends_with("__")
+}
+
+impl<'ast> Visitor<'ast> for State<'_> {
+    fn visit_stmt(&mut self, stmt: &'ast Stmt) {
+        if let Stmt::ClassDef(class) = stmt {
+            self.process_class(class);
+        }
+        walk_stmt(self, stmt);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::python_passthrough::unchanged;
+    use crate::{Config, transpile};
+    use indoc::indoc;
+
+    fn check(input: &str, expected: &str) {
+        assert_eq!(
+            transpile(input, &Config::test_default()).unwrap(),
+            crate::python_passthrough::lazify_expected(expected)
+        );
+    }
+
+    #[test]
+    fn int_attribute() {
+        check(
+            indoc! {"
+                class A:
+                    a = 1
+            "},
+            indoc! {"
+                class A:
+                    a: int = 1
+            "},
+        );
+    }
+
+    #[test]
+    fn str_and_bool_attributes() {
+        check(
+            indoc! {"
+                class A:
+                    name = \"x\"
+                    flag = True
+            "},
+            indoc! {"
+                class A:
+                    name: str = \"x\"
+                    flag: bool = True
+            "},
+        );
+    }
+
+    #[test]
+    fn list_literal_attribute() {
+        check(
+            indoc! {"
+                class A:
+                    xs = [1, 2]
+            "},
+            indoc! {"
+                class A:
+                    xs: list[int] = [1, 2]
+            "},
+        );
+    }
+
+    #[test]
+    fn instance_attribute() {
+        check(
+            indoc! {"
+                class B: ...
+                class A:
+                    b = B()
+            "},
+            indoc! {"
+                class B: ...
+                class A:
+                    b: B = B()
+            "},
+        );
+    }
+
+    #[test]
+    fn empty_list_left_bare() {
+        // `[]` infers `list[Unknown]` — a dynamic part with no faithful
+        // annotation, so the assignment stays as-is
+        unchanged(indoc! {"
+            class A:
+                xs = []
+        "});
+    }
+
+    #[test]
+    fn already_annotated_unchanged() {
+        unchanged(indoc! {"
+            class A:
+                a: int = 1
+        "});
+    }
+
+    #[test]
+    fn chained_target_unchanged() {
+        unchanged(indoc! {"
+            class A:
+                a = b = 1
+        "});
+    }
+
+    #[test]
+    fn tuple_target_unchanged() {
+        unchanged(indoc! {"
+            class A:
+                a, b = 1, 2
+        "});
+    }
+
+    #[test]
+    fn module_level_assignment_unchanged() {
+        // the feature is scoped to class attributes; a module-level binding
+        // may be reassigned with a different type, so it stays inferred
+        unchanged("a = 1\n");
+    }
+
+    #[test]
+    fn method_local_unchanged() {
+        unchanged(indoc! {"
+            class A:
+                def f(self):
+                    x = 1
+                    return x
+        "});
+    }
+
+    #[test]
+    fn nested_class_attribute() {
+        check(
+            indoc! {"
+                class Outer:
+                    class Inner:
+                        a = 1
+            "},
+            indoc! {"
+                class Outer:
+                    class Inner:
+                        a: int = 1
+            "},
+        );
+    }
+
+    #[test]
+    fn dunder_slots_left_bare() {
+        unchanged(indoc! {"
+            class A:
+                __slots__ = (\"x\",)
+        "});
+    }
+
+    #[test]
+    fn dataclass_field_left_bare() {
+        // in a dataclass a bare assignment is a plain class variable, not a
+        // field; annotating it would turn it into a constructor parameter
+        unchanged(indoc! {"
+            from dataclasses import dataclass
+            @dataclass
+            class A:
+                a = 1
+        "});
+    }
+
+    #[test]
+    fn enum_member_left_bare() {
+        // a bare assignment in an enum is a member, not a typed attribute
+        unchanged(indoc! {"
+            from enum import Enum
+            class Color(Enum):
+                RED = 1
+                GREEN = 2
+        "});
+    }
+}

--- a/crates/by_transforms/src/transforms/mod.rs
+++ b/crates/by_transforms/src/transforms/mod.rs
@@ -24,6 +24,7 @@ pub(crate) mod generics;
 pub(crate) mod grapheme_string;
 pub(crate) mod identity_swap;
 pub(crate) mod implicit_typing;
+pub(crate) mod inferred_annotation;
 pub(crate) mod init_method;
 pub(crate) mod intersection;
 pub(crate) mod just_float;

--- a/crates/by_transforms/src/type_info.rs
+++ b/crates/by_transforms/src/type_info.rs
@@ -251,6 +251,20 @@ pub(crate) trait TypeInfo {
     /// `docs/basedpython/frameworks/index.md`
     fn framework_class_role(&self, class_def: &StmtClassDef) -> Option<FrameworkRole>;
 
+    /// the inferred annotation to synthesize for a bare class-body assignment
+    /// `<name> = <value>` — the promoted display of `value`'s type (`1` →
+    /// `"int"`, `[1]` → `"list[int]"`), or `None` when ty resolves no concrete
+    /// type or the promoted type carries a dynamic part (`Unknown` / `Any`)
+    /// with no faithful spelling
+    fn inferred_annotation(&self, expr: &Expr) -> Option<String>;
+
+    /// whether adding a type annotation to a bare `name = value` assignment in
+    /// `class_def`'s body would change the class's runtime semantics — true for
+    /// dataclass-like classes, framework models, `NamedTuple`s, `TypedDict`s
+    /// (annotated assignment becomes a field) and enums (bare assignment is a
+    /// member). the inferred-annotation transform must leave these alone
+    fn class_body_annotation_is_semantic(&self, class_def: &StmtClassDef) -> bool;
+
     /// whether `expr` is a field-specifier call — `pydantic.Field(...)`,
     /// `dataclasses.field(...)`, `attrs.field(...)`, and the like. the checker
     /// models these as assignable to the field's declared type, but their
@@ -599,6 +613,28 @@ impl TypeInfo for SemanticModel<'_> {
         let ty = class_def.inferred_type(self)?;
         let class = ty.as_class_literal()?;
         ty_python_semantic::types::class_framework_role(self.db(), class)
+    }
+
+    fn inferred_annotation(&self, expr: &Expr) -> Option<String> {
+        let ty = expr.inferred_type(self)?;
+        // a dynamic part (`Unknown` from an empty `[]`, an unresolved import,
+        // `Any`) has no faithful annotation — leave the assignment bare
+        if ty.has_dynamic(self.db()) {
+            return None;
+        }
+        let promoted = ty.promote(self.db());
+        Some(strip_binding_context_suffix(
+            &promoted.display(self.db()).to_string(),
+        ))
+    }
+
+    fn class_body_annotation_is_semantic(&self, class_def: &StmtClassDef) -> bool {
+        class_def
+            .inferred_type(self)
+            .and_then(Type::as_class_literal)
+            .is_some_and(|class| {
+                ty_python_semantic::types::class_body_annotation_is_semantic(self.db(), class)
+            })
     }
 
     fn is_field_specifier(&self, expr: &Expr) -> bool {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -69,7 +69,8 @@ pub(crate) use crate::types::class_base::ClassBase;
 use crate::types::constraints::ConstraintSetBuilder;
 use crate::types::context::{LintDiagnosticGuard, LintDiagnosticGuardBuilder};
 pub use crate::types::dedicated::role::{
-    FrameworkRole, FunctionFrameworkRole, class_framework_role, function_framework_role,
+    FrameworkRole, FunctionFrameworkRole, class_body_annotation_is_semantic, class_framework_role,
+    function_framework_role,
 };
 use crate::types::diagnostic::{INVALID_AWAIT, INVALID_TYPE_FORM};
 pub use crate::types::display::{DisplaySettings, TypeDetail, TypeDisplayDetails};
@@ -1553,7 +1554,7 @@ impl<'db> Type<'db> {
         )
     }
 
-    pub(crate) fn has_dynamic(self, db: &'db dyn Db) -> bool {
+    pub fn has_dynamic(self, db: &'db dyn Db) -> bool {
         any_over_type(db, self, false, |ty| ty.is_dynamic())
     }
 

--- a/crates/ty_python_semantic/src/types/dedicated/role.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/role.rs
@@ -13,8 +13,10 @@
 //! `docs/basedpython/frameworks/index.md`
 
 use crate::Db;
+use crate::types::class::CodeGeneratorKind;
 use crate::types::dedicated::{django, pydantic, pytest, sqlalchemy};
-use crate::types::{ClassLiteral, FunctionType, StaticClassLiteral};
+use crate::types::enums::is_enum_class;
+use crate::types::{ClassLiteral, FunctionType, StaticClassLiteral, Type};
 
 /// the kind of framework class-transformer that applies to a class
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
@@ -52,6 +54,18 @@ fn static_class_framework_role<'db>(
         return Some(FrameworkRole::SqlalchemyDeclarative);
     }
     None
+}
+
+/// whether adding a type annotation to a bare `name = value` assignment in
+/// `class`'s body would change the class's runtime semantics. true for
+/// dataclass-like classes and framework models (pydantic / django /
+/// sqlalchemy), `NamedTuple`s and `TypedDict`s — where an annotated
+/// assignment turns a plain class variable into a field — and for enums,
+/// where a bare assignment defines a member. the inferred-annotation
+/// transform must leave such classes' body assignments alone
+pub fn class_body_annotation_is_semantic<'db>(db: &'db dyn Db, class: ClassLiteral<'db>) -> bool {
+    CodeGeneratorKind::from_class(db, class).is_some()
+        || is_enum_class(db, Type::ClassLiteral(class))
 }
 
 /// the kind of pytest function whose parameters pytest fills from the fixture


### PR DESCRIPTION
class-body assignments like `a = 1` get their ty-inferred type spliced in as a declared annotation (`a: int = 1`). skips dataclasses / models / enums / NamedTuples / TypedDicts where an annotation changes field semantics, dunders, dynamic types, and non-single-name targets
