### PR TITLE
feat(ty): infer-parameter-type-from-default analysis option

### DIFF
--- a/crates/ty/docs/configuration.md
+++ b/crates/ty/docs/configuration.md
@@ -118,6 +118,41 @@ Defaults to `false`.
 
 ---
 
+### `infer-parameter-type-from-default`
+
+Whether an unannotated parameter that has a default value should be given the (promoted)
+type of that default, rather than an implicit gradual type. This is a basedpython feature.
+
+When set to `true`, this deliberately breaks the gradual guarantee: `def f(a=1)` declares
+`a` as `int` instead of leaving it unannotated, so passing a `str` at a call site is an
+error.
+
+Defaults to `false`.
+
+**Default value**: `false`
+
+**Type**: `bool`
+
+**Example usage**:
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.ty.analysis]
+    # Infer unannotated parameter types from their defaults
+    infer-parameter-type-from-default = true
+    ```
+
+=== "ty.toml"
+
+    ```toml
+    [analysis]
+    # Infer unannotated parameter types from their defaults
+    infer-parameter-type-from-default = true
+    ```
+
+---
+
 ### `replace-imports-with-any`
 
 A list of module glob patterns whose imports should be replaced with `typing.Any`.
@@ -643,6 +678,41 @@ Defaults to `false`.
     [overrides.analysis]
     # Turn off fluid specializations
     disable-fluid-specializations = true
+    ```
+
+---
+
+#### `infer-parameter-type-from-default`
+
+Whether an unannotated parameter that has a default value should be given the (promoted)
+type of that default, rather than an implicit gradual type. This is a basedpython feature.
+
+When set to `true`, this deliberately breaks the gradual guarantee: `def f(a=1)` declares
+`a` as `int` instead of leaving it unannotated, so passing a `str` at a call site is an
+error.
+
+Defaults to `false`.
+
+**Default value**: `false`
+
+**Type**: `bool`
+
+**Example usage**:
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.ty.overrides.analysis]
+    # Infer unannotated parameter types from their defaults
+    infer-parameter-type-from-default = true
+    ```
+
+=== "ty.toml"
+
+    ```toml
+    [overrides.analysis]
+    # Infer unannotated parameter types from their defaults
+    infer-parameter-type-from-default = true
     ```
 
 ---

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -1505,6 +1505,25 @@ pub struct AnalysisOptions {
     )]
     pub disable_fluid_specializations: Option<bool>,
 
+    /// Whether an unannotated parameter that has a default value should be given the (promoted)
+    /// type of that default, rather than an implicit gradual type. This is a basedpython feature.
+    ///
+    /// When set to `true`, this deliberately breaks the gradual guarantee: `def f(a=1)` declares
+    /// `a` as `int` instead of leaving it unannotated, so passing a `str` at a call site is an
+    /// error.
+    ///
+    /// Defaults to `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"false"#,
+        value_type = "bool",
+        example = r#"
+        # Infer unannotated parameter types from their defaults
+        infer-parameter-type-from-default = true
+        "#
+    )]
+    pub infer_parameter_type_from_default: Option<bool>,
+
     /// A list of module glob patterns for which `unresolved-import` diagnostics should be suppressed.
     ///
     /// Details on supported glob patterns:
@@ -1566,6 +1585,7 @@ impl AnalysisOptions {
             allowed_unresolved_imports,
             replace_imports_with_any,
             disable_fluid_specializations,
+            infer_parameter_type_from_default,
         } = self;
 
         let AnalysisSettings {
@@ -1573,6 +1593,7 @@ impl AnalysisOptions {
             allowed_unresolved_imports: allowed_unresolved_imports_default,
             replace_imports_with_any: replace_imports_with_any_default,
             disable_fluid_specializations: disable_fluid_specializations_default,
+            infer_parameter_type_from_default: infer_parameter_type_from_default_default,
         } = AnalysisSettings::default();
 
         let allowed_unresolved_imports =
@@ -1604,6 +1625,8 @@ impl AnalysisOptions {
             replace_imports_with_any,
             disable_fluid_specializations: disable_fluid_specializations
                 .unwrap_or(disable_fluid_specializations_default),
+            infer_parameter_type_from_default: infer_parameter_type_from_default
+                .unwrap_or(infer_parameter_type_from_default_default),
         }
     }
 }

--- a/crates/ty_python_semantic/resources/mdtest/basedpython_infer_parameter_type_from_default.md
+++ b/crates/ty_python_semantic/resources/mdtest/basedpython_infer_parameter_type_from_default.md
@@ -1,0 +1,78 @@
+# basedpython: infer parameter type from default
+
+by default, an unannotated parameter follows the gradual guarantee: it is left unannotated even when
+it has a default value, so any argument is accepted at the call site.
+
+the `analysis.infer-parameter-type-from-default` option deliberately breaks that guarantee. when it
+is enabled, an unannotated parameter with a default is declared with the default's promoted type, so
+`def f(a=1)` treats `a` as `int` (not `Literal[1]`, and not gradual).
+
+this is a basedpython enhancement that also applies to plain python files.
+
+## enabled
+
+```toml
+[environment]
+python-version = "3.12"
+
+[analysis]
+infer-parameter-type-from-default = true
+```
+
+the parameter's type inside the body is the promoted type of the default:
+
+```py
+def f(a=1):
+    reveal_type(a)  # revealed: int
+
+def g(a="s", b=True):
+    reveal_type(a)  # revealed: str
+    reveal_type(b)  # revealed: bool
+```
+
+the signature is checked at call sites: an incompatible argument is now an error:
+
+```py
+f(2)  # ok
+f("x")  # error: [invalid-argument-type]
+
+g("hello", False)  # ok
+g(1, True)  # error: [invalid-argument-type]
+```
+
+a parameter with no default is unaffected and stays gradual:
+
+```py
+def h(a, b=1):
+    reveal_type(a)  # revealed: Unknown
+    reveal_type(b)  # revealed: int
+
+h("anything", 2)  # ok
+```
+
+an explicit annotation always wins over the default:
+
+```py
+def annotated(a: str = "s"):
+    reveal_type(a)  # revealed: str
+
+annotated("t")  # ok
+annotated(1)  # error: [invalid-argument-type]
+```
+
+## disabled (default)
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+with the option off, the gradual guarantee holds: an unannotated parameter with a default stays
+gradual and accepts any argument.
+
+```py
+def f(a=1):
+    reveal_type(a)  # revealed: Unknown | Literal[1]
+
+f("x")  # ok
+```

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -116,6 +116,14 @@ pub struct AnalysisSettings {
     /// When disabled, inferred generic specializations are not widened flow-sensitively by
     /// later uses of a binding; each binding keeps its creation-time specialization.
     pub disable_fluid_specializations: bool,
+
+    /// Whether an unannotated parameter with a default value is given the (promoted) type of
+    /// that default, rather than an implicit gradual type.
+    ///
+    /// This deliberately breaks the gradual guarantee: with it enabled, `def f(a=1)` declares
+    /// `a` as `int` instead of leaving it unannotated, so passing a `str` at the call site is
+    /// an error.
+    pub infer_parameter_type_from_default: bool,
 }
 
 impl Default for AnalysisSettings {
@@ -125,6 +133,7 @@ impl Default for AnalysisSettings {
             allowed_unresolved_imports: ModuleGlobSet::empty(),
             replace_imports_with_any: ModuleGlobSet::empty(),
             disable_fluid_specializations: false,
+            infer_parameter_type_from_default: false,
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -1205,6 +1205,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     } else {
                         UnionType::from_two_elements(db, base, default_ty)
                     }
+                } else if self.settings().infer_parameter_type_from_default {
+                    // basedpython: give the parameter the default's (promoted) type instead of
+                    // folding an implicit gradual `Unknown` in. deliberately breaks the gradual
+                    // guarantee (`def f(a=1)` sees `a: int` in the body)
+                    default_ty.promote(db)
                 } else {
                     UnionType::from_two_elements(db, Type::unknown(), default_ty)
                 }

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -4318,6 +4318,15 @@ impl<'db> Parameter<'db> {
                     false,
                     annotation.is_starred_expr(),
                 )
+            } else if let Some(default_type) = kind.default_type()
+                && db
+                    .analysis_settings(function_definition.file(db))
+                    .infer_parameter_type_from_default
+            {
+                // basedpython: an unannotated parameter with a default is declared with the
+                // default's promoted type, so call sites are checked against it. deliberately
+                // breaks the gradual guarantee
+                (default_type.promote(db), false, false)
             } else {
                 (Type::unknown(), true, false)
             };
@@ -4463,12 +4472,7 @@ impl<'db> Parameter<'db> {
 
     /// Default-value type of the parameter, if any.
     pub(crate) fn default_type(&self) -> Option<Type<'db>> {
-        match self.kind {
-            ParameterKind::PositionalOnly { default_type, .. }
-            | ParameterKind::PositionalOrKeyword { default_type, .. }
-            | ParameterKind::KeywordOnly { default_type, .. } => default_type,
-            ParameterKind::Variadic { .. } | ParameterKind::KeywordVariadic { .. } => None,
-        }
+        self.kind.default_type()
     }
 
     /// Rewrites a positional-or-keyword parameter as keyword-only while preserving its metadata.
@@ -4524,6 +4528,15 @@ pub enum ParameterKind<'db> {
 }
 
 impl<'db> ParameterKind<'db> {
+    fn default_type(&self) -> Option<Type<'db>> {
+        match self {
+            ParameterKind::PositionalOnly { default_type, .. }
+            | ParameterKind::PositionalOrKeyword { default_type, .. }
+            | ParameterKind::KeywordOnly { default_type, .. } => *default_type,
+            ParameterKind::Variadic { .. } | ParameterKind::KeywordVariadic { .. } => None,
+        }
+    }
+
     #[expect(clippy::ref_option)]
     fn cycle_normalized_default(
         db: &'db dyn Db,

--- a/crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
@@ -171,6 +171,7 @@ Settings: Settings {
             globs: [],
         },
         disable_fluid_specializations: false,
+        infer_parameter_type_from_default: false,
     },
     overrides: [],
 }

--- a/crates/ty_test/src/config.rs
+++ b/crates/ty_test/src/config.rs
@@ -129,6 +129,8 @@ pub(crate) struct Analysis {
     pub(crate) replace_imports_with_any: Option<Vec<String>>,
 
     pub(crate) disable_fluid_specializations: Option<bool>,
+
+    pub(crate) infer_parameter_type_from_default: Option<bool>,
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/crates/ty_test/src/db.rs
+++ b/crates/ty_test/src/db.rs
@@ -64,6 +64,7 @@ impl Db {
                 allowed_unresolved_imports: allowed_unresolved_imports_default,
                 replace_imports_with_any: replace_imports_with_any_default,
                 disable_fluid_specializations: disable_fluid_specializations_default,
+                infer_parameter_type_from_default: infer_parameter_type_from_default_default,
             } = AnalysisSettings::default();
 
             let allowed_unresolved_imports = if let Some(allowed_unresolved_imports) =
@@ -103,6 +104,9 @@ impl Db {
                 disable_fluid_specializations: options
                     .disable_fluid_specializations
                     .unwrap_or(disable_fluid_specializations_default),
+                infer_parameter_type_from_default: options
+                    .infer_parameter_type_from_default
+                    .unwrap_or(infer_parameter_type_from_default_default),
             }
         } else {
             AnalysisSettings::default()

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -89,6 +89,13 @@
             "null"
           ]
         },
+        "infer-parameter-type-from-default": {
+          "description": "Whether an unannotated parameter that has a default value should be given the (promoted)\ntype of that default, rather than an implicit gradual type. This is a basedpython feature.\n\nWhen set to `true`, this deliberately breaks the gradual guarantee: `def f(a=1)` declares\n`a` as `int` instead of leaving it unannotated, so passing a `str` at a call site is an\nerror.\n\nDefaults to `false`.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "replace-imports-with-any": {
           "description": "A list of module glob patterns whose imports should be replaced with `typing.Any`.\n\nUnlike `allowed-unresolved-imports`, this setting replaces the module's type information\nwith `typing.Any` even if the module can be resolved. Import diagnostics are\nunconditionally suppressed for matching modules.\n\n- Prefix a pattern with `!` to exclude matching modules\n\nWhen multiple patterns match, later entries take precedence.\n\nGlob patterns can be used in combinations with each other. For example, to suppress errors for\nany module where the first component contains the substring `test`, use `*test*.**`.\n\nWhen multiple patterns match, later entries take precedence.",
           "type": [


### PR DESCRIPTION
opt-in setting that gives an unannotated parameter with a default the promoted type of that default (def f(a=1) -> a: int), deliberately breaking the gradual guarantee. applied in both the in-body binding and the public signature; defaults off
