### PR TITLE
fold tuple `*` and `+` on fixed-length literal tuples

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/assignment/augmented.md
+++ b/crates/ty_python_semantic/resources/mdtest/assignment/augmented.md
@@ -13,7 +13,7 @@ reveal_type(x)  # revealed: int | float
 
 x = (1, 2)
 x += (3, 4)
-reveal_type(x)  # revealed: tuple[Literal[1, 2, 3, 4], ...]
+reveal_type(x)  # revealed: tuple[Literal[1], Literal[2], Literal[3], Literal[4]]
 ```
 
 ## Walrus target

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -134,10 +134,11 @@ x: tuple[list[Literal[1]]] = (list1(1),)
 reveal_type(x)  # revealed: tuple[list[Literal[1]]]
 
 x: tuple[list[Literal[1]], ...] = (list1(1),) * 3
-reveal_type(x)  # revealed: tuple[list[Literal[1]], ...]
+reveal_type(x)  # revealed: tuple[list[Literal[1]], list[Literal[1]], list[Literal[1]]]
 
 x: tuple[list[Literal[1]], ...] = 3 * ((list1(1),) + (list1(1),))
-reveal_type(x)  # revealed: tuple[list[Literal[1]], ...]
+# revealed: tuple[list[Literal[1]], list[Literal[1]], list[Literal[1]], list[Literal[1]], list[Literal[1]], list[Literal[1]]]
+reveal_type(x)
 
 x: set[int | str] = {1, 2} | {3, 4}
 reveal_type(x)  # revealed: set[int | str]

--- a/crates/ty_python_semantic/resources/mdtest/binary/tuples.md
+++ b/crates/ty_python_semantic/resources/mdtest/binary/tuples.md
@@ -2,15 +2,18 @@
 
 ## Concatenation for heterogeneous tuples
 
+Concatenating two fixed-length tuples folds into a fixed-length tuple that preserves the exact
+element order and count, rather than widening to `tuple[T, ...]`.
+
 ```py
-reveal_type((1, 2) + (3, 4))  # revealed: tuple[Literal[1, 2, 3, 4], ...]
-reveal_type(() + (1, 2))  # revealed: tuple[Literal[1, 2], ...]
-reveal_type((1, 2) + ())  # revealed: tuple[Literal[1, 2], ...]
+reveal_type((1, 2) + (3, 4))  # revealed: tuple[Literal[1], Literal[2], Literal[3], Literal[4]]
+reveal_type(() + (1, 2))  # revealed: tuple[Literal[1], Literal[2]]
+reveal_type((1, 2) + ())  # revealed: tuple[Literal[1], Literal[2]]
 reveal_type(() + ())  # revealed: tuple[()]
 
 def _(x: tuple[int, str], y: tuple[None, tuple[int]]):
-    reveal_type(x + y)  # revealed: tuple[int | str | None | tuple[int], ...]
-    reveal_type(y + x)  # revealed: tuple[None | tuple[int] | int | str, ...]
+    reveal_type(x + y)  # revealed: tuple[int, str, None, tuple[int]]
+    reveal_type(y + x)  # revealed: tuple[None, tuple[int], int, str]
 ```
 
 ## Concatenation for homogeneous tuples
@@ -45,4 +48,39 @@ def _(one_two: OneTwo, x: IntTuple, y: StrTuple, three_four: ThreeFour):
     reveal_type(x + three_four)  # revealed: tuple[int, ...]
     reveal_type(one_two + x + three_four)  # revealed: tuple[int, ...]
     reveal_type(one_two + y + three_four + x)  # revealed: tuple[int | str, ...]
+```
+
+## Repetition for heterogeneous tuples
+
+Multiplying a fixed-length tuple by a literal integer folds into a fixed-length tuple whose elements
+are repeated, matching the runtime behaviour of `tuple.__mul__`. Repetition is commutative, and a
+`bool` factor is treated as `0` or `1`.
+
+```py
+reveal_type((1, "a") * 3)  # revealed: tuple[Literal[1], Literal["a"], Literal[1], Literal["a"], Literal[1], Literal["a"]]
+reveal_type(3 * (1, "a"))  # revealed: tuple[Literal[1], Literal["a"], Literal[1], Literal["a"], Literal[1], Literal["a"]]
+reveal_type((1, "a") * True)  # revealed: tuple[Literal[1], Literal["a"]]
+```
+
+A non-positive factor folds to the empty tuple.
+
+```py
+reveal_type((1, "a") * 0)  # revealed: tuple[()]
+reveal_type((1, "a") * -2)  # revealed: tuple[()]
+```
+
+A non-literal factor, or a factor that would produce a tuple longer than the folding limit, falls
+back to typeshed's `tuple.__mul__` (which widens to `tuple[T, ...]`).
+
+```py
+def _(n: int):
+    reveal_type((1, "a") * n)  # revealed: tuple[Literal[1, "a"], ...]
+    reveal_type((0,) * 1000)  # revealed: tuple[Literal[0], ...]
+```
+
+Homogeneous (variable-length) tuples are also left to `tuple.__mul__`.
+
+```py
+def _(x: tuple[int, ...]):
+    reveal_type(x * 3)  # revealed: tuple[int, ...]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/instance_layout_conflict.md
+++ b/crates/ty_python_semantic/resources/mdtest/instance_layout_conflict.md
@@ -146,14 +146,12 @@ class A:
     __slots__ = ()
     __slots__ += ("a", "b")
 
-reveal_type(A.__slots__)  # revealed: tuple[Literal["a", "b"], ...]
+reveal_type(A.__slots__)  # revealed: tuple[Literal["a"], Literal["b"]]
 
 class B:
     __slots__ = ("c", "d")
 
-# TODO: ideally this would trigger `[instance-layout-conflict]`
-# (but it's also not high-priority)
-class C(A, B): ...
+class C(A, B): ...  # error: [instance-layout-conflict]
 ```
 
 ## Explicitly annotated `__slots__`

--- a/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
@@ -10,6 +10,7 @@ use crate::types::diagnostic::{
     DIVISION_BY_ZERO, report_unsupported_augmented_assignment, report_unsupported_binary_operation,
 };
 use crate::types::set_theoretic::RecursivelyDefined;
+use crate::types::tuple::Tuple;
 use crate::types::typevar::TypeVarConstraints;
 use crate::types::{
     DynamicType, InternedConstraintSet, KnownClass, KnownInstanceType, LiteralValueTypeKind,
@@ -1099,6 +1100,33 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             .ok()
             .map(|binding| binding.return_type(db)),
 
+            // fold `(a, b) * n` (and `n * (a, b)`) into a fixed-length tuple with the
+            // elements repeated `n` times, matching the runtime behaviour of
+            // `tuple.__mul__`. without this, typeshed's stub widens the result to
+            // `tuple[T, ...]`, discarding the exact element order and count
+            (Type::NominalInstance(_), _, ast::Operator::Mult)
+                if right_ty.as_int_like_literal().is_some() =>
+            {
+                self.fold_tuple_repeat(left_ty, right_ty).or_else(|| {
+                    Type::try_call_bin_op_return_type_with_tcx(db, left_ty, op, right_ty, tcx)
+                })
+            }
+            (_, Type::NominalInstance(_), ast::Operator::Mult)
+                if left_ty.as_int_like_literal().is_some() =>
+            {
+                self.fold_tuple_repeat(right_ty, left_ty).or_else(|| {
+                    Type::try_call_bin_op_return_type_with_tcx(db, left_ty, op, right_ty, tcx)
+                })
+            }
+
+            // fold `(a, b) + (c,)` into `(a, b, c)`. as with `*`, typeshed's `tuple.__add__`
+            // otherwise widens the concatenation to `tuple[T, ...]`
+            (Type::NominalInstance(_), Type::NominalInstance(_), ast::Operator::Add) => {
+                self.fold_tuple_concat(left_ty, right_ty).or_else(|| {
+                    Type::try_call_bin_op_return_type_with_tcx(db, left_ty, op, right_ty, tcx)
+                })
+            }
+
             // We've handled all of the special cases that we support for literals, so we need to
             // fall back on looking for dunder methods on one of the operand types.
             (
@@ -1159,6 +1187,58 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 op,
             ) => Type::try_call_bin_op_return_type_with_tcx(db, left_ty, op, right_ty, tcx),
         }
+    }
+
+    /// Fold `tuple * n` into a fixed-length tuple whose elements are those of `tuple_ty`
+    /// repeated `n` times, where `multiplier` is a literal integer (or `bool`).
+    ///
+    /// Returns `None` — leaving the caller to fall back on typeshed's `tuple.__mul__`, which
+    /// widens to `tuple[T, ...]` — when `tuple_ty` is not an exact fixed-length tuple, when
+    /// `multiplier` is not a literal integer, or when the repeated tuple would grow beyond
+    /// `MAX_LENGTH`. A non-positive multiplier folds to the empty tuple.
+    fn fold_tuple_repeat(&self, tuple_ty: Type<'db>, multiplier: Type<'db>) -> Option<Type<'db>> {
+        /// Repeating into a longer tuple discards the exact element types, so cap the work.
+        const MAX_LENGTH: usize = 512;
+
+        let db = self.db();
+        let factor = multiplier.as_int_like_literal()?;
+        let spec = tuple_ty.exact_tuple_instance_spec(db)?;
+        let Tuple::Fixed(fixed) = spec.as_ref() else {
+            return None;
+        };
+
+        let elements = fixed.all_elements();
+        let factor = usize::try_from(factor).unwrap_or(0);
+        let new_length = elements.len().checked_mul(factor)?;
+        if new_length > MAX_LENGTH {
+            return None;
+        }
+
+        let mut repeated = Vec::with_capacity(new_length);
+        for _ in 0..factor {
+            repeated.extend_from_slice(elements);
+        }
+        Some(Type::heterogeneous_tuple(db, repeated))
+    }
+
+    /// Fold `left + right` into a single fixed-length tuple concatenating their elements.
+    ///
+    /// Returns `None` — leaving the caller to fall back on typeshed's `tuple.__add__` — unless
+    /// both operands are exact fixed-length tuples.
+    fn fold_tuple_concat(&self, left_ty: Type<'db>, right_ty: Type<'db>) -> Option<Type<'db>> {
+        let db = self.db();
+        let left = left_ty.exact_tuple_instance_spec(db)?;
+        let right = right_ty.exact_tuple_instance_spec(db)?;
+        let (Tuple::Fixed(left), Tuple::Fixed(right)) = (left.as_ref(), right.as_ref()) else {
+            return None;
+        };
+        Some(Type::heterogeneous_tuple(
+            db,
+            left.all_elements()
+                .iter()
+                .chain(right.all_elements())
+                .copied(),
+        ))
     }
 
     /// Raise a diagnostic if the given type cannot be divided by zero.


### PR DESCRIPTION
`(1, "a") * 3` now folds to `tuple[Literal[1], Literal["a"], ...×3]` and `(1, 2) + (3, 4)` to `tuple[Literal[1], Literal[2], Literal[3], Literal[4]]`, mirroring `tuple.__mul__` / `tuple.__add__` at runtime instead of widening to `tuple[T, ...]`. non-fixed tuples, non-literal factors, and oversized results fall back to typeshed. a side effect is that `instance-layout-conflict` now fires on the previously-TODO slots case, since `__slots__ += (...)` yields a fixed-length tuple