### PR TITLE
`var` mutable variable declarations

### DIFF
--- a/crates/by_transforms/src/transforms/modifiers.rs
+++ b/crates/by_transforms/src/transforms/modifiers.rs
@@ -926,6 +926,74 @@ mod tests {
     }
 
     #[test]
+    fn var_decl() {
+        // `var` is the mutable counterpart of `let`: the keyword is stripped and
+        // nothing is declared beyond the assignment itself — no `Final`
+        check("var a = 1\n", "a = 1\n");
+    }
+
+    #[test]
+    fn var_decl_typed() {
+        check("var a: int = 1\n", "a: int = 1\n");
+    }
+
+    #[test]
+    fn var_decl_valueless_typed() {
+        check("var a: int\n", "a: int\n");
+    }
+
+    #[test]
+    fn var_decl_in_class() {
+        check(
+            indoc! {"
+                class A:
+                    var a = 1
+                    var b: int = 2
+                    var c: str
+            "},
+            indoc! {"
+                class A:
+                    a = 1
+                    b: int = 2
+                    c: str
+            "},
+        );
+    }
+
+    #[test]
+    fn var_decl_in_function() {
+        check(
+            indoc! {"
+                def f():
+                    var a = 1
+                    return a
+            "},
+            indoc! {"
+                def f():
+                    a = 1
+                    return a
+            "},
+        );
+    }
+
+    #[test]
+    fn var_decl_with_modifier_chain() {
+        // a visibility modifier ahead of `var` is stripped with it, matching the
+        // bare-assignment modifier forms
+        check("private var a = 1\n", "a = 1\n");
+    }
+
+    #[test]
+    fn var_as_identifier_is_not_a_declaration() {
+        // as with `let`, `var` only introduces a declaration when shaped like
+        // `var NAME =` or `var NAME :` — otherwise it is an ordinary identifier
+        check("var = 5\n", "var = 5\n");
+        check("var: int = 5\n", "var: int = 5\n");
+        check("print(var)\n", "print(var)\n");
+        check("var, y = 1, 2\n", "var, y = 1, 2\n");
+    }
+
+    #[test]
     fn let_decl_in_class() {
         check(
             indoc! {"

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -1049,6 +1049,16 @@ pub fn is_top_star_marker(expr: &Expr) -> bool {
     name.id.is_empty() && matches!(name.ctx, ExprContext::Invalid)
 }
 
+/// basedpython: returns `true` if `expr` is the parser-synthesized marker for a
+/// declaration keyword on an *unannotated* assignment — `var a = 1`,
+/// `override a = 1`, `final override a = 1`. Those parse as an `AnnAssign` whose
+/// annotation is `Name(id="__modifier_assign__", ctx=Invalid)` spanning the
+/// keyword prefix. The marker carries no type, so the statement declares nothing
+/// and binds exactly like the `a = 1` it lowers to.
+pub fn is_untyped_declaration_marker(expr: &Expr) -> bool {
+    matches!(expr, Expr::Name(name) if name.id.as_str() == "__modifier_assign__")
+}
+
 /// basedpython: use-site variance marker, one of `out X`, `in X`, `in out X`
 /// in a subscript element. Encoded by the parser as
 /// `Subscript(Name(id, ctx=Invalid), inner)` where `id` is one of

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -348,6 +348,37 @@ if True:
         Ok(())
     }
 
+    /// basedpython: a `var` declaration round-trips — the parser models it as an
+    /// annotated assignment over a synthetic marker, so the surface keyword has
+    /// to be recovered from the marker's source range rather than printed as an
+    /// annotation.
+    #[test]
+    fn var_declaration_round_trip() -> Result<()> {
+        for input in [
+            "var a = 1\n",
+            "var a: int = 1\n",
+            "var a: int\n",
+            "private var a = 1\n",
+        ] {
+            let options = PyFormatOptions::from_extension(Path::new("test.by"));
+            let actual = format_module_source(input, options)?.as_code().to_string();
+            assert_eq!(input, actual);
+        }
+        Ok(())
+    }
+
+    /// basedpython: the same recovery applies to the other keyword prefixes on
+    /// an unannotated assignment.
+    #[test]
+    fn modifier_assignment_round_trip() -> Result<()> {
+        for input in ["override a = 1\n", "final override a = 1\n"] {
+            let options = PyFormatOptions::from_extension(Path::new("test.by"));
+            let actual = format_module_source(input, options)?.as_code().to_string();
+            assert_eq!(input, actual);
+        }
+        Ok(())
+    }
+
     /// Use this test to debug the formatting of some snipped
     #[ignore]
     #[test]

--- a/crates/ruff_python_formatter/src/statement/stmt_ann_assign.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_ann_assign.rs
@@ -99,6 +99,23 @@ fn synthetic_modifier_annot<'ast, 'src>(
     Some((src.get(start..end)?.trim(), s.slice.as_ref()))
 }
 
+/// detect the synthetic marker the parser emits for a declaration keyword on an
+/// unannotated assignment — `var a = 1`, `override a = 1`, `final override a = 1`.
+/// the annotation is a bare `Name("__modifier_assign__")` whose range spans the
+/// surface keyword prefix, so the prefix is recovered from source like
+/// [`synthetic_final`] does
+fn synthetic_modifier_assign<'src>(ann: &Expr, src: &'src str) -> Option<&'src str> {
+    let Expr::Name(name) = ann else {
+        return None;
+    };
+    if name.id.as_str() != "__modifier_assign__" {
+        return None;
+    }
+    let start = u32::from(name.range.start()) as usize;
+    let end = u32::from(name.range.end()) as usize;
+    Some(src.get(start..end)?.trim())
+}
+
 impl FormatNodeRule<StmtAnnAssign> for FormatStmtAnnAssign {
     fn fmt_fields(&self, item: &StmtAnnAssign, f: &mut PyFormatter) -> FormatResult<()> {
         let StmtAnnAssign {
@@ -149,6 +166,17 @@ impl FormatNodeRule<StmtAnnAssign> for FormatStmtAnnAssign {
                     type_ann.format()
                 ]
             )?;
+            if let Some(v) = value {
+                write!(f, [space(), token("="), space(), v.format()])?;
+            }
+            return Ok(());
+        }
+        if f.options().is_basedpython()
+            && let Some(prefix) = synthetic_modifier_assign(annotation, f.context().source())
+        {
+            // `<keyword chain> <target> = <value>` — the keyword prefix is
+            // rendered verbatim from source; the statement carries no annotation
+            write!(f, [text(prefix), space(), target.format()])?;
             if let Some(v) = value {
                 write!(f, [space(), token("="), space(), v.format()])?;
             }

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -360,8 +360,8 @@ impl<'src> Parser<'src> {
         }
 
         // The current token must itself be a modifier or an introducer
-        // (`let` and bare `abstract a: T`) for a chain or introducer to be possible.
-        if !is_modifier_kw(kw) && kw != "let" {
+        // (`let` / `var` and bare `abstract a: T`) for a chain or introducer to be possible.
+        if !is_modifier_kw(kw) && !matches!(kw, "let" | "var") {
             return None;
         }
 
@@ -418,6 +418,50 @@ impl<'src> Parser<'src> {
                             self.bump(TokenKind::Name);
                         }
                         return Some(self.parse_let_decl(start));
+                    }
+                    if text == "var" {
+                        // `var` is the mutable counterpart of `let`. it declares
+                        // nothing beyond what the surface already says, so it
+                        // lowers through the modifier-assignment path: the
+                        // keyword is stripped and `NAME [: T] = value` is left
+                        // behind. shape-gated exactly like `let` so an ordinary
+                        // identifier named `var` is never hijacked
+                        let following = self.peek_nth(idx + 1).0;
+                        if self.peek_nth(idx).0 != TokenKind::Name
+                            || !matches!(
+                                following,
+                                TokenKind::Colon
+                                    | TokenKind::Equal
+                                    | TokenKind::Newline
+                                    | TokenKind::Semi
+                                    | TokenKind::EndOfFile
+                            )
+                        {
+                            return None;
+                        }
+                        self.error_if_not_basedpython(
+                            "`var` declarations are not valid in .py files".to_string(),
+                        );
+                        if following == TokenKind::Colon {
+                            return Some(
+                                self.parse_modifier_annot_decl(start, "__modifier_annot__"),
+                            );
+                        }
+                        if following != TokenKind::Equal {
+                            // a bare `var x` carries neither a type nor a value,
+                            // so there is nothing for it to declare — unlike
+                            // `let x`, which declares an uninitialized `Final`.
+                            // parse it anyway so the rest of the file still
+                            // parses; the error blocks any output
+                            self.add_error(
+                                ParseErrorType::OtherError(
+                                    "`var` declaration requires a type or an initializer"
+                                        .to_string(),
+                                ),
+                                range,
+                            );
+                        }
+                        return Some(self.parse_modifier_assign_decl(start));
                     }
                     if is_modifier_kw(text) {
                         idx += 1;
@@ -821,8 +865,9 @@ impl<'src> Parser<'src> {
     /// Parses `final x = 5` → produces a synthetic `AnnAssign` that the
     /// `modifiers` transform rewrites to `x: Final = 5` at module scope or `x = 5` inside a class.
     /// Parses a basedpython modifier-chain assignment such as `final a = 1`,
-    /// `override a = 1`, or `final override a = 1` — any non-empty sequence of
-    /// modifier keywords (see [`is_modifier_kw`]) followed by `name = value`.
+    /// `override a = 1`, `final override a = 1`, or the `var a = 1` declaration —
+    /// any non-empty sequence of modifier keywords (see [`is_modifier_kw`])
+    /// followed by `name = value`.
     ///
     /// Produces a synthetic [`AnnAssign`] whose annotation is a `Name` with id
     /// `"__modifier_assign__"` and a range covering the modifier prefix in the
@@ -835,19 +880,23 @@ impl<'src> Parser<'src> {
     fn parse_modifier_assign_decl(&mut self, start: TextSize) -> Stmt {
         let modifier_start = self.current_token_range().start();
         // consume modifier keywords until we reach the variable name (the Name
-        // token immediately followed by `=`).
+        // token immediately followed by `=`, or by the end of the statement for
+        // the initializer-less `var x` the caller has already rejected).
         loop {
             let (next_kind, _) = self.peek_nth(0);
-            if next_kind == TokenKind::Equal {
+            if matches!(
+                next_kind,
+                TokenKind::Equal | TokenKind::Newline | TokenKind::Semi | TokenKind::EndOfFile
+            ) {
                 break;
             }
             self.bump(TokenKind::Name);
         }
         let name = self.parse_identifier();
-        self.bump(TokenKind::Equal);
-        let value = self
-            .parse_expression_list(ExpressionContext::yield_or_starred_bitwise_or())
-            .expr;
+        let value = self.eat(TokenKind::Equal).then(|| {
+            self.parse_expression_list(ExpressionContext::yield_or_starred_bitwise_or())
+                .expr
+        });
         let target = Expr::Name(ast::ExprName {
             id: name.id.clone(),
             ctx: ExprContext::Store,
@@ -865,7 +914,7 @@ impl<'src> Parser<'src> {
         Stmt::AnnAssign(ast::StmtAnnAssign {
             target: Box::new(target),
             annotation: Box::new(annotation),
-            value: Some(Box::new(value)),
+            value: value.map(Box::new),
             simple: true,
             range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -101,6 +101,90 @@ fn basedpython_valueless_untyped_let_parses_cleanly() {
 }
 
 #[test]
+fn basedpython_var_declaration_shapes() {
+    // `var NAME = v` and `var NAME: T [= v]` are mutable declarations: the
+    // keyword is carried by a synthetic marker annotation and the statement
+    // means exactly `NAME [: T] = v`
+    for (source, has_value) in [
+        ("var x = 5", true),
+        ("var x: int = 5", true),
+        ("var x: int", false),
+        ("private var x = 5", true),
+    ] {
+        let parsed = parse_basedpython_module(source);
+        let [Stmt::AnnAssign(assign)] = parsed.syntax().body.as_slice() else {
+            panic!("expected a single AnnAssign for `{source}`");
+        };
+        assert_eq!(
+            assign.value.is_some(),
+            has_value,
+            "wrong initializer for `{source}`"
+        );
+        let Expr::Name(target) = assign.target.as_ref() else {
+            panic!("expected a name target for `{source}`");
+        };
+        assert_eq!(target.id.as_str(), "x");
+    }
+}
+
+#[test]
+fn basedpython_bare_var_is_rejected() {
+    // unlike `let x` (an uninitialized `Final`), `var x` declares nothing —
+    // neither a type nor a value — so it is a parse error rather than a
+    // statement that lowers to nothing
+    let error = parse(
+        "var x\n",
+        ParseOptions::from(Mode::Module).with_basedpython(true),
+    )
+    .expect_err("bare `var` must be rejected");
+    assert!(
+        matches!(
+            &error.error,
+            ParseErrorType::OtherError(message)
+                if message == "`var` declaration requires a type or an initializer"
+        ),
+        "unexpected error: {error:?}"
+    );
+}
+
+#[test]
+fn basedpython_var_keyword_never_panics() {
+    // as with `let`, `var` is only the declaration keyword in the declaration
+    // shapes; every other use is an ordinary identifier and must parse
+    for source in [
+        "var",
+        "var = 5",
+        "var: int = 5",
+        "var(x)",
+        "x = var + 1",
+        "var, y = 1, 2",
+        "for var in items:\n    pass",
+        "var x = 5",
+        "var x: int = 5",
+    ] {
+        // success here is simply not panicking
+        let _ = parse(
+            source,
+            ParseOptions::from(Mode::Module).with_basedpython(true),
+        );
+    }
+}
+
+#[test]
+fn basedpython_var_as_identifier_is_not_a_declaration() {
+    // `var = 5` binds a variable named `var`; the declaration path must not
+    // claim it
+    let parsed = parse_basedpython_module("var = 5\n");
+    let [Stmt::Assign(assign)] = parsed.syntax().body.as_slice() else {
+        panic!("expected a plain assignment");
+    };
+    let [Expr::Name(target)] = assign.targets.as_slice() else {
+        panic!("expected a single name target");
+    };
+    assert_eq!(target.id.as_str(), "var");
+}
+
+#[test]
 fn basedpython_local_once_param_modifiers() {
     // `local` / `once` before a parameter name are lifetime modifiers that the
     // parser consumes (no AST field). the parameter keeps its real name, and the

--- a/crates/ty_ide/src/semantic_tokens.rs
+++ b/crates/ty_ide/src/semantic_tokens.rs
@@ -5201,6 +5201,30 @@ final c: str = \"x\"
     }
 
     #[test]
+    fn semantic_tokens_var_keyword() {
+        // `var` declares through the modifier markers — untyped through the bare
+        // one, typed through the subscripted one — so both forms highlight
+        let test = SemanticTokenTest::new_by(
+            "
+var a = 5
+var b: int = 5
+",
+        );
+
+        let tokens = test.highlight_file();
+
+        assert_snapshot!(test.to_snapshot(&tokens), @r#"
+        "var" @ 1..4: Keyword
+        "a" @ 5..6: Variable [definition]
+        "5" @ 9..10: Number
+        "var" @ 11..14: Keyword
+        "b" @ 15..16: Variable [definition]
+        "int" @ 18..21: Class
+        "5" @ 24..25: Number
+        "#);
+    }
+
+    #[test]
     fn semantic_tokens_modifier_annotation_keywords() {
         // the modifiers that carry no type meaning still declare a type, and it
         // is highlighted like any other annotation

--- a/crates/ty_python_core/src/definition.rs
+++ b/crates/ty_python_core/src/definition.rs
@@ -3,6 +3,7 @@ use std::ops::Deref;
 use ruff_db::files::{File, FileRange};
 use ruff_db::parsed::{ParsedModuleRef, parsed_module};
 use ruff_python_ast::find_node::covering_node;
+use ruff_python_ast::helpers::is_untyped_declaration_marker;
 use ruff_python_ast::name::Name;
 use ruff_python_ast::traversal::suite;
 use ruff_python_ast::{self as ast, AnyNodeRef, Expr};
@@ -1133,7 +1134,15 @@ impl<'db> DefinitionKind<'db> {
             // Annotated assignment is always a declaration. It is also a binding if there is a RHS
             // or if we are in a stub file. Unfortunately, it is common for stubs to omit even an `...` value placeholder.
             DefinitionKind::AnnotatedAssignment(ann_assign) => {
-                if in_stub || ann_assign.value(module).is_some() {
+                // basedpython: `var a = 1` / `override a = 1` are annotated
+                // assignments only in shape — the annotation is a marker for the
+                // keyword prefix and states no type, so they bind without
+                // declaring, exactly like the `a = 1` they lower to
+                if ann_assign.value(module).is_some()
+                    && is_untyped_declaration_marker(ann_assign.annotation(module))
+                {
+                    DefinitionCategory::Binding
+                } else if in_stub || ann_assign.value(module).is_some() {
                     DefinitionCategory::DeclarationAndBinding
                 } else {
                     DefinitionCategory::Declaration

--- a/crates/ty_python_semantic/resources/mdtest/basedpython_modifier_annotations.md
+++ b/crates/ty_python_semantic/resources/mdtest/basedpython_modifier_annotations.md
@@ -72,6 +72,27 @@ abstract n: int = 1
 n = 2
 ```
 
+## an unannotated modifier declares nothing
+
+Without a type there is nothing to declare, so `override x = v` means exactly `x = v` — including
+for readers that prefer a declaration over an inference.
+
+`m.by`:
+
+```by
+override exported = 1
+
+class C:
+    override count = 0
+```
+
+```by
+from m import exported, C
+
+reveal_type(exported)  # revealed: 1
+reveal_type(C.count)  # revealed: int
+```
+
 ## inside a class body
 
 ```by

--- a/crates/ty_python_semantic/resources/mdtest/basedpython_var.md
+++ b/crates/ty_python_semantic/resources/mdtest/basedpython_var.md
@@ -1,0 +1,124 @@
+# basedpython: `var` declarations
+
+`var` is the mutable counterpart of `let`: it marks the declaration site of a variable and nothing
+more. `var x = v` means exactly `x = v` and `var x: T = v` means exactly `x: T = v`, so — unlike
+`let`, which declares `Final` (see `basedpython_final.md`) — the binding stays writable and an
+untyped `var` puts no declared type on the name.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+## an untyped `var` infers its value's type
+
+```by
+var a = 1
+reveal_type(a)  # revealed: 1
+```
+
+## an untyped `var` leaves the binding unconstrained
+
+There is no declared type, so a later assignment of an unrelated type is as legal as it is for a
+plain python assignment.
+
+```by
+var a = 1
+a = "x"
+reveal_type(a)  # revealed: "x"
+```
+
+## a typed `var` declares its type
+
+```by
+var b: int = 1
+reveal_type(b)  # revealed: 1
+
+b = 2
+b = "nope"  # error: [invalid-assignment]
+```
+
+## a typed `var` rejects a bad initializer
+
+```by
+var bad: int = "nope"  # error: [invalid-assignment]
+```
+
+## a valueless `var` still declares
+
+```by
+var c: int
+
+c = 1
+reveal_type(c)  # revealed: 1
+
+c = "nope"  # error: [invalid-assignment]
+```
+
+## `var` is not `final`
+
+Contrast `let d = 1`, where the second assignment is an error.
+
+```by
+var d = 1
+d = 2
+```
+
+## inside a class body
+
+```by
+class C:
+    var tag: str = "c"
+    var count = 0
+
+reveal_type(C.tag)  # revealed: str
+reveal_type(C.count)  # revealed: int
+C.tag = "x"
+C.tag = 1  # error: [invalid-assignment]
+```
+
+## inside a function body
+
+```by
+def f() -> int:
+    var total: int = 0
+    total = total + 1
+    return total
+```
+
+## a modifier may precede `var`
+
+```by
+private var e: int = 1
+e = 2
+e = "nope"  # error: [invalid-assignment]
+```
+
+## an untyped `var` is not a declaration for importers either
+
+A `var` that states no type must not record a declared `Unknown`, or every reader that prefers a
+declaration over an inference — an importer, a class attribute lookup — would lose the type.
+
+`m.by`:
+
+```by
+var exported = 1
+```
+
+```by
+from m import exported
+
+reveal_type(exported)  # revealed: 1
+```
+
+## `var` is still an ordinary identifier
+
+The declaration forms are `var NAME = v` and `var NAME: T [= v]`; everything else is a plain name.
+
+```by
+var = 5
+reveal_type(var)  # revealed: 5
+
+print(var)
+var, y = 1, 2
+```

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 use ruff_db::files::File;
 use ruff_db::parsed::ParsedModuleRef;
 use ruff_db::source::source_text;
-use ruff_python_ast::helpers::is_dotted_name;
+use ruff_python_ast::helpers::{is_dotted_name, is_untyped_declaration_marker};
 use ruff_python_ast::name::Name;
 use ruff_python_ast::{
     self as ast, AnyNodeRef, ArgOrKeyword, ArgumentsSourceOrder, ExprContext, HasNodeIndex,
@@ -4212,6 +4212,27 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 ));
                 diagnostic.info("a final variable is declared with `let`, which lowers to `Final`");
             }
+        }
+
+        // basedpython: a declaration keyword on an unannotated assignment
+        // (`var a = 1`, `override a = 1`) states no type, so it binds without
+        // declaring — the definition is categorized as a binding to match. going
+        // through the declaration path instead would record a declared `Unknown`
+        // and hide the inferred type from every reader that prefers a
+        // declaration (an importer of the module, a class attribute lookup)
+        if is_untyped_declaration_marker(annotation)
+            && let Some(value) = value
+        {
+            self.store_expression_type(annotation, Type::unknown());
+            self.store_qualifiers(annotation, TypeQualifiers::empty());
+            let add = self.add_binding(target.into(), definition);
+            let value_ty = self.infer_maybe_standalone_expression(value, add.type_context());
+            let target_ty = self
+                .stub_placeholder_binding_type(value)
+                .unwrap_or(value_ty);
+            self.store_expression_type(target, target_ty);
+            add.insert(self, target_ty);
+            return;
         }
 
         // PEP 681 lets a field specifier appear in the annotation's `Annotated`

--- a/docs/basedpython/features/modifiers.md
+++ b/docs/basedpython/features/modifiers.md
@@ -70,13 +70,16 @@ subclassed. neither emits a runtime artefact
 `abstract def` with no body is filled in with `: raise NotImplementedError`
 instead of the usual `: ...`
 
-## let / class-var / newtype
+## let / var / class-var / newtype
 
 | basedpython            | Python output                          |
 | ---------------------- | -------------------------------------- |
 | `let MAX = 100`        | `MAX: Final = 100`                     |
 | `let x: int`           | `x: Final[int]`                        |
 | `let x`                | `x: Final`                             |
+| `var x = 1`            | `x = 1`                                |
+| `var x: int = 1`       | `x: int = 1`                           |
+| `var x: int`           | `x: int`                               |
 | `class count = 0`      | `count: ClassVar = 0` (inside a class) |
 | `newtype UserId = int` | `UserId = NewType("UserId", int)`      |
 
@@ -85,6 +88,29 @@ class-variable form (distinct from the regular `let x = ...` which is `Final`).
 the initializer may be omitted: `let x: int` declares a read-only attribute and
 a bare `let x` an uninitialized `Final`, both bound by a single later assignment.
 `newtype` introduces a distinct `typing.NewType`-backed type at module scope
+
+## var
+
+`var` is the mutable counterpart of `let`: it marks the declaration site of a
+variable and nothing else. the keyword is stripped at transpile time and the
+statement means exactly what the assignment under it means — no `Final`, and an
+untyped `var` puts no declared type on the name:
+
+```by
+var count = 0
+count = 1        # fine; `let count = 0` would reject this
+
+var name: str = ""
+name = 1         # error: `str` is declared
+```
+
+`var` works at module, class, and function scope, and composes with the
+modifier keywords (`private var x = 1`). unlike `let`, it may not be written
+bare: `var x` states neither a type nor a value, so there is nothing to declare
+and it is rejected — write `var x: T` or `let x`
+
+`var` on an `init(...)` parameter is a different feature — the attribute
+shorthand described in [init method](init-method.md)
 
 ## assignment modifiers
 

--- a/docs/basedpython/features/properties.md
+++ b/docs/basedpython/features/properties.md
@@ -31,11 +31,13 @@ class Person:
         self._age = value
 ```
 
-> **STATUS: planned for version 0.0.1a6, not yet implemented.** the `var`
-> keyword, the `get`/`set` accessor block, `field`, `lateinit`, and the
-> `let x: T` accessor form described below are not yet recognized by the
-> parser. `let x: T = init` at class scope partially works as the
-> [modifier](modifiers.md) form. tracking item: properties v0.0.1a6
+> **STATUS: planned for version 0.0.1a6, not yet implemented.** the `get`/`set`
+> accessor block, `field`, `lateinit`, and the `let x: T` accessor form
+> described below are not yet recognized by the parser. `var x: T = init` and
+> `let x: T = init` at class scope already parse as the
+> [modifier](modifiers.md) forms — a plain class attribute and a `Final` one,
+> not yet the property lowering described here. tracking item: properties
+> v0.0.1a6
 
 without accessors the declaration stays a plain attribute — no descriptor
 overhead
@@ -253,10 +255,10 @@ class Bag:
 
 ## scope and placement
 
-property declarations recognised only inside class body. `var` at module
-scope is parse error (use plain assignment). `let` at module scope keeps
-its existing [modifier-style meaning](modifiers.md) — module-level
-constant, no property semantics
+accessor blocks are recognised only inside a class body. `var` and `let`
+themselves are declarations in every scope: outside a class they keep their
+[modifier-style meaning](modifiers.md) — `let` is a module-level constant and
+`var` a plain mutable declaration, neither with property semantics
 
 accessor blocks recognised only directly following a `let`/`var`
 declaration. stray `get()` / `set(...)` elsewhere parses as normal call


### PR DESCRIPTION
`var x = v` / `var x: T [= v]` in any scope, stripped at transpile time. an unannotated keyword prefix now binds without declaring, so it no longer records a declared `Unknown` for importers and class attribute lookups