### PR TITLE
added UnsafeUnion type

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -3149,6 +3149,10 @@ fn completion_kind_from_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Comp
             Type::Intersection(intersection) => intersection
                 .iter_positive(db)
                 .find_map(|ty| imp(db, ty, visitor))?,
+            Type::UnsafeUnion(unsafe_union) => unsafe_union
+                .elements(db)
+                .iter()
+                .find_map(|&ty| imp(db, ty, visitor))?,
             Type::Dynamic(_)
             | Type::Divergent(_)
             | Type::Never
@@ -10624,6 +10628,42 @@ def f(x: Intersection[int, Any] | str):
             @"
         removeprefix
         removesuffix
+        ",
+        );
+    }
+
+    /// Tests that an unsafe union offers the members of *every* materialization,
+    /// where a plain `int | str` union would only offer the ones they share.
+    #[test]
+    fn unsafe_union_type_annotation() {
+        let builder = completion_test_builder(
+            r#"
+from ty_extensions import UnsafeUnion
+
+def f(x: UnsafeUnion[int, str]):
+    x.is<CURSOR>
+"#,
+        );
+        assert_snapshot!(
+            builder.build().snapshot(),
+            @"
+        is_integer
+        isalnum
+        isalpha
+        isascii
+        isdecimal
+        isdigit
+        isidentifier
+        islower
+        isnumeric
+        isprintable
+        isspace
+        istitle
+        isupper
+        splitlines
+        __annotations__
+        __contains__
+        __init_subclass__
         ",
         );
     }

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -3765,7 +3765,7 @@ class ManyCycles2:
         self.x3 = [1]
 
     def f1(self: "ManyCycles2"):
-        reveal_type(self.x3)  # revealed: list[int] | list[Divergent] | Unknown | list[Unknown]
+        reveal_type(self.x3)  # revealed: list[int] | list[Divergent] | UnsafeUnion[list[int], list[Divergent]]
 
         self.x1 = [self.x2] + [self.x3]
         self.x2 = [self.x1] + [self.x3]
@@ -3884,8 +3884,8 @@ class NestedListsConcat:
         self.x = [self.x] + []
         self.y = [self.y].__add__(y)
 
-reveal_type(NestedListsConcat().x)  # revealed: list[int] | list[Divergent] | Unknown
-reveal_type(NestedListsConcat().y)  # revealed: list[int] | list[Divergent] | Unknown
+reveal_type(NestedListsConcat().x)  # revealed: list[int] | list[Divergent]
+reveal_type(NestedListsConcat().y)  # revealed: list[int] | list[Divergent]
 ```
 
 ### Builtin types attributes

--- a/crates/ty_python_semantic/resources/mdtest/basedpython_combos.md
+++ b/crates/ty_python_semantic/resources/mdtest/basedpython_combos.md
@@ -34,7 +34,7 @@ reveal_type(b(1, name="z"))  # revealed: "asdf"
 ```by
 v: (*: int) -> int = lambda *a: sum(a)
 # variadic Protocol return narrows to the inferred lambda body type
-reveal_type(v(1, 2, 3))  # revealed: Unknown
+reveal_type(v(1, 2, 3))  # revealed: UnsafeUnion[int, Unknown | 0]
 ```
 
 ## marker callable

--- a/crates/ty_python_semantic/resources/mdtest/call/constructor.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/constructor.md
@@ -896,8 +896,9 @@ reveal_type(SimpleMixed("foo"))  # revealed: SimpleMixed
 
 ### Multiple matching `__new__` overloads
 
-If overload resolution for `__new__` falls back to `Unknown` because the argument is `Any` or
-`Unknown`, we should still validate downstream constructors:
+If overload resolution for `__new__` stays ambiguous because the argument is `Any` or `Unknown`, so
+that the call evaluates to the unsafe union of the possible returns, we should still validate
+downstream constructors:
 
 ```py
 from typing import Any, overload
@@ -916,16 +917,16 @@ class AmbiguousMixed:
 
 def _(a: Any, u: Unknown):
     # error: [too-many-positional-arguments]
-    reveal_type(AmbiguousMixed(a))  # revealed: Unknown
+    reveal_type(AmbiguousMixed(a))  # revealed: UnsafeUnion[str, AmbiguousMixed]
 
     # error: [too-many-positional-arguments]
-    reveal_type(AmbiguousMixed(u))  # revealed: Unknown
+    reveal_type(AmbiguousMixed(u))  # revealed: UnsafeUnion[str, AmbiguousMixed]
 ```
 
 ### Mixed `__new__` overloads should not become declaration-order dependent
 
 Reversing the declaration order of the same mixed overload set should not change the result when
-overload resolution falls back to `Unknown`.
+overload resolution stays ambiguous.
 
 ```py
 from typing import Any, overload
@@ -944,10 +945,10 @@ class ReverseAmbiguousMixed:
 
 def _(a: Any, u: Unknown):
     # error: [too-many-positional-arguments]
-    reveal_type(ReverseAmbiguousMixed(a))  # revealed: Unknown
+    reveal_type(ReverseAmbiguousMixed(a))  # revealed: UnsafeUnion[str, ReverseAmbiguousMixed]
 
     # error: [too-many-positional-arguments]
-    reveal_type(ReverseAmbiguousMixed(u))  # revealed: Unknown
+    reveal_type(ReverseAmbiguousMixed(u))  # revealed: UnsafeUnion[str, ReverseAmbiguousMixed]
 ```
 
 ### Overloaded non-instance `__new__` should preserve matched return type

--- a/crates/ty_python_semantic/resources/mdtest/call/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/overloads.md
@@ -1320,6 +1320,10 @@ This is the step 5 of the overload call evaluation algorithm which specifies tha
 
 This is only performed if the previous step resulted in more than one matching overload.
 
+Where the spec then evaluates an ambiguous call as `Any`, ty evaluates it as the
+[`UnsafeUnion`](../unsafe_union.md) of the remaining overloads' return types: a gradual type whose
+materializations are exactly the possible results.
+
 ### Single list argument
 
 `overloaded.pyi`:
@@ -1427,8 +1431,8 @@ def _(list_int: list[int], list_any: list[Any]):
     # All materializations of `list[Any]` are assignable to `list[int]` and `list[Any]`, but the
     # return type of first and second overloads are not equivalent, so the overload matching
     # is ambiguous.
-    reveal_type(f(list_any))  # revealed: Unknown
-    reveal_type(f(*(list_any,)))  # revealed: Unknown
+    reveal_type(f(list_any))  # revealed: UnsafeUnion[int, str]
+    reveal_type(f(*(list_any,)))  # revealed: UnsafeUnion[int, str]
 ```
 
 ### Single tuple argument
@@ -1473,8 +1477,8 @@ def _(int_str: tuple[int, str], int_any: tuple[int, Any], any_any: tuple[Any, An
 
     # All materializations of `tuple[Any, Any]` are assignable to the parameters of all the
     # overloads, but the return types aren't equivalent, so the overload matching is ambiguous
-    reveal_type(f(any_any))  # revealed: Unknown
-    reveal_type(f(*(any_any,)))  # revealed: Unknown
+    reveal_type(f(any_any))  # revealed: UnsafeUnion[int, str]
+    reveal_type(f(*(any_any,)))  # revealed: UnsafeUnion[int, str]
 ```
 
 ### `Unknown` passed into an overloaded function annotated with protocols
@@ -1514,7 +1518,7 @@ def f(a: Foo, b: list[str], c: list[LiteralString], e):
     # specified currently), `(str | LiteralString) & Unknown` might also be a reasonable type
     # here (the union of all overload returns, intersected with `Unknown`) -- here that would
     # simplify to `str & Unknown`.
-    reveal_type(a.join(e))  # revealed: Unknown
+    reveal_type(a.join(e))  # revealed: UnsafeUnion[LiteralString, str]
 ```
 
 ### Multiple arguments
@@ -1564,8 +1568,8 @@ def _(list_int: list[int], list_any: list[Any], int_str: tuple[int, str], int_an
     # All materializations of first argument is assignable to the second overload and for the second
     # argument, they're assignable to the third overload, so no overloads are filtered out; the
     # return types of the remaining overloads are not equivalent, so overload matching is ambiguous
-    reveal_type(f(list_int, any_any))  # revealed: Unknown
-    reveal_type(f(*(list_int, any_any)))  # revealed: Unknown
+    reveal_type(f(list_int, any_any))  # revealed: UnsafeUnion[A, B]
+    reveal_type(f(*(list_int, any_any)))  # revealed: UnsafeUnion[A, B]
 ```
 
 ### `LiteralString` and `str`
@@ -1597,8 +1601,8 @@ def _(literal: LiteralString, string: str, any: Any):
 
     # `Any` matches both overloads, but the return types are not equivalent.
     # Pyright and mypy both reveal `str` here, contrary to the spec.
-    reveal_type(f(any))  # revealed: Unknown
-    reveal_type(f(*(any,)))  # revealed: Unknown
+    reveal_type(f(any))  # revealed: UnsafeUnion[LiteralString, str]
+    reveal_type(f(*(any,)))  # revealed: UnsafeUnion[LiteralString, str]
 ```
 
 ### Generics
@@ -1710,7 +1714,7 @@ def _(a_int: A[int], a_str: A[str], a_any: A[Any]):
 def _(b_int: B[int], b_str: B[str], b_any: B[Any]):
     reveal_type(b_int.method())  # revealed: int
     reveal_type(b_str.method())  # revealed: str
-    reveal_type(b_any.method())  # revealed: Unknown
+    reveal_type(b_any.method())  # revealed: UnsafeUnion[int, str]
 ```
 
 ### Variadic argument
@@ -1754,11 +1758,11 @@ def _(arg: list[Any]):
     # Matches both overload and the return types are equivalent
     reveal_type(f1(*arg))  # revealed: A
     # Matches both overload but the return types aren't equivalent
-    reveal_type(f2(*arg))  # revealed: Unknown
+    reveal_type(f2(*arg))  # revealed: UnsafeUnion[A, B]
     # Filters out the final overload and the return types are equivalent
     reveal_type(f3(*arg))  # revealed: A
     # Filters out the final overload but the return types aren't equivalent
-    reveal_type(f4(*arg))  # revealed: Unknown
+    reveal_type(f4(*arg))  # revealed: UnsafeUnion[A, B]
 ```
 
 ### Variadic argument with generics
@@ -2016,8 +2020,8 @@ from typing import Any
 from overloaded import A, B, C, f
 
 def _(arg: tuple[A | B, Any]):
-    reveal_type(f(arg))  # revealed: A | Unknown
-    reveal_type(f(*(arg,)))  # revealed: A | Unknown
+    reveal_type(f(arg))  # revealed: A | UnsafeUnion[B, C]
+    reveal_type(f(*(arg,)))  # revealed: A | UnsafeUnion[B, C]
 ```
 
 #### Both argument lists ambiguous
@@ -2050,8 +2054,8 @@ from typing import Any
 from overloaded import A, B, C, f
 
 def _(arg: tuple[A | B, Any]):
-    reveal_type(f(arg))  # revealed: Unknown
-    reveal_type(f(*(arg,)))  # revealed: Unknown
+    reveal_type(f(arg))  # revealed: UnsafeUnion[A, C] | UnsafeUnion[B, C]
+    reveal_type(f(*(arg,)))  # revealed: UnsafeUnion[A, C] | UnsafeUnion[B, C]
 ```
 
 ### Unknown argument with TypeVar overload

--- a/crates/ty_python_semantic/resources/mdtest/metaclass.md
+++ b/crates/ty_python_semantic/resources/mdtest/metaclass.md
@@ -267,13 +267,13 @@ reveal_type(Foo())  # revealed: Unknown
 
 def _(a: Any):
     # error: [too-many-positional-arguments]
-    reveal_type(Foo(a))  # revealed: Unknown
+    reveal_type(Foo(a))  # revealed: UnsafeUnion[int, Foo]
 ```
 
 ### Mixed metaclass `__call__` overloads should not become declaration-order dependent
 
 Reversing the declaration order of the same mixed overload set should not change the result when
-overload resolution falls back to `Unknown`.
+overload resolution stays ambiguous.
 
 ```py
 from typing import Any, TypeVar, overload
@@ -294,10 +294,10 @@ class ReverseMetaTarget(metaclass=ReverseMeta):
 
 def _(a: Any, u: Unknown):
     # error: [too-many-positional-arguments]
-    reveal_type(ReverseMetaTarget(a))  # revealed: Unknown
+    reveal_type(ReverseMetaTarget(a))  # revealed: UnsafeUnion[str, ReverseMetaTarget]
 
     # error: [too-many-positional-arguments]
-    reveal_type(ReverseMetaTarget(u))  # revealed: Unknown
+    reveal_type(ReverseMetaTarget(u))  # revealed: UnsafeUnion[str, ReverseMetaTarget]
 ```
 
 ### Overloaded metaclass `__call__` preserving strict-subclass return

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2483,7 +2483,7 @@ def _(payload: Payload | Payload2) -> None:
 ```
 
 With a gradual default, the specialized known-key overload and generic default overload both match,
-so we currently fall back to `Unknown`:
+so the result is the unsafe union of both overloads' returns:
 
 ```py
 from typing import Any, TypedDict
@@ -2492,7 +2492,7 @@ class GradualDefault(TypedDict, total=False):
     x: int
 
 def _(td: GradualDefault, default: Any) -> None:
-    reveal_type(td.get("x", default))  # revealed: Unknown
+    reveal_type(td.get("x", default))  # revealed: UnsafeUnion[int, int | Any]
 ```
 
 Synthesized `get()` on unions falls back to generic resolution when a key is missing from one arm:

--- a/crates/ty_python_semantic/resources/mdtest/unsafe_union.md
+++ b/crates/ty_python_semantic/resources/mdtest/unsafe_union.md
@@ -1,0 +1,307 @@
+# Unsafe unions
+
+`UnsafeUnion[T1, T2, ..., Tn]` is a gradual type whose materializations are exactly `T1`, `T2`, ...,
+`Tn`. It fuses a union with an intersection: a union on the way in, an intersection on the way out.
+
+## Assignment into an unsafe union
+
+### Every materialization is accepted
+
+Anything the plain union accepts is accepted, so every element is assignable to it — as is the union
+of the elements:
+
+```py
+from ty_extensions import UnsafeUnion
+
+def f(a: UnsafeUnion[int, str]): ...
+
+f(1)
+f("s")
+
+def g(x: int | str, y: bool):
+    f(x)
+    f(y)
+```
+
+### Unrelated types are still rejected
+
+Unlike `Any`, the menu of materializations is finite:
+
+```py
+from ty_extensions import UnsafeUnion
+
+def f(a: UnsafeUnion[int, str]): ...
+
+# error: [invalid-argument-type]
+f(b"bytes")
+# error: [invalid-argument-type]
+f(None)
+```
+
+## Assignment out of an unsafe union
+
+The value is one of its materializations, so it goes wherever any single materialization can go:
+
+```py
+from ty_extensions import UnsafeUnion
+
+def takes_int(x: int): ...
+def takes_str(x: str): ...
+def takes_bytes(x: bytes): ...
+def takes_object(x: object): ...
+def f(a: UnsafeUnion[int, str]):
+    takes_int(a)
+    takes_str(a)
+    takes_object(a)
+
+    # error: [invalid-argument-type]
+    takes_bytes(a)
+
+    b: int = a
+    c: str = a
+    # error: [invalid-assignment]
+    d: bytes = a
+```
+
+## Member access
+
+### A member of any materialization resolves
+
+This is the intersection face:
+
+```py
+from ty_extensions import UnsafeUnion
+
+def f(a: UnsafeUnion[int, str]):
+    reveal_type(a.imag)  # revealed: Literal[0]
+    reveal_type(a.upper())  # revealed: str
+    reveal_type(a.__class__)  # revealed: UnsafeUnion[type[int], type[str]]
+```
+
+### A member no materialization has is an error
+
+```py
+from ty_extensions import UnsafeUnion
+
+def f(a: UnsafeUnion[int, str]):
+    # error: [unresolved-attribute]
+    reveal_type(a.nonexistent)  # revealed: Unknown
+```
+
+### The imprecision keeps propagating
+
+When several materializations have the member, the result is itself an unsafe union:
+
+```py
+from ty_extensions import UnsafeUnion
+
+class A:
+    x: int
+
+class B:
+    x: str
+
+def f(a: UnsafeUnion[A, B]):
+    reveal_type(a.x)  # revealed: UnsafeUnion[int, str]
+```
+
+## Simplification
+
+### A single materialization is not a choice
+
+```py
+from ty_extensions import UnsafeUnion, static_assert
+from ty_extensions._internal import is_equivalent_to
+
+static_assert(is_equivalent_to(UnsafeUnion[int, int], int))
+static_assert(is_equivalent_to(UnsafeUnion[int, UnsafeUnion[str, bytes]], UnsafeUnion[int, str, bytes]))
+```
+
+### The order of the menu does not matter
+
+```py
+from ty_extensions import UnsafeUnion, static_assert
+from ty_extensions._internal import is_equivalent_to
+
+static_assert(is_equivalent_to(UnsafeUnion[int, str], UnsafeUnion[str, int]))
+static_assert(not is_equivalent_to(UnsafeUnion[int, str], UnsafeUnion[int, bytes]))
+static_assert(not is_equivalent_to(UnsafeUnion[int, str], int | str))
+```
+
+### `Any` swallows the menu and `Never` contributes nothing
+
+```py
+from typing import Any
+
+from typing_extensions import Never
+
+from ty_extensions import UnsafeUnion, static_assert
+from ty_extensions._internal import is_equivalent_to
+
+static_assert(is_equivalent_to(UnsafeUnion[int, Any], Any))
+static_assert(is_equivalent_to(UnsafeUnion[int, Never], int))
+```
+
+## Gradual properties
+
+### Subtyping and assignability
+
+An unsafe union is not a fully static type: it is a subtype only of `object`.
+
+```py
+from ty_extensions import UnsafeUnion, static_assert
+from ty_extensions._internal import is_subtype_of, is_assignable_to
+
+static_assert(not is_subtype_of(UnsafeUnion[int, str], int))
+static_assert(not is_subtype_of(int, UnsafeUnion[int, str]))
+static_assert(is_subtype_of(UnsafeUnion[int, str], object))
+
+static_assert(is_assignable_to(UnsafeUnion[int, str], int))
+static_assert(is_assignable_to(int, UnsafeUnion[int, str]))
+static_assert(not is_assignable_to(UnsafeUnion[int, str], bytes))
+static_assert(not is_assignable_to(bytes, UnsafeUnion[int, str]))
+```
+
+### Materializations
+
+The top and bottom materializations are the union and the intersection of the elements:
+
+```py
+from ty_extensions import Bottom, Intersection, Top, UnsafeUnion, static_assert
+from ty_extensions._internal import is_equivalent_to
+
+static_assert(is_equivalent_to(Top[UnsafeUnion[int, str]], int | str))
+static_assert(is_equivalent_to(Bottom[UnsafeUnion[int, str]], Intersection[int, str]))
+```
+
+### Disjointness
+
+It overlaps whatever any of its materializations overlaps, so it is disjoint from a type only when
+every materialization is:
+
+```py
+from ty_extensions import UnsafeUnion, static_assert
+from ty_extensions._internal import is_disjoint_from
+
+static_assert(not is_disjoint_from(UnsafeUnion[int, str], int))
+static_assert(is_disjoint_from(UnsafeUnion[int, str], None))
+```
+
+## Operators
+
+An operator resolves through the materializations that support it:
+
+```py
+from ty_extensions import UnsafeUnion
+
+def f(a: UnsafeUnion[int, str]):
+    reveal_type(a + 1)  # revealed: int
+    reveal_type(-a)  # revealed: int
+    reveal_type(a[0])  # revealed: str
+```
+
+## Ambiguous overload calls
+
+### A gradual argument infers the menu of possible returns
+
+Rather than discarding the information as `Unknown`:
+
+```py
+from typing import Any, overload
+
+@overload
+def f(a: int) -> int: ...
+@overload
+def f(a: str) -> str: ...
+def f(a: int | str) -> int | str:
+    return a
+
+def _(a: Any):
+    reveal_type(f(a))  # revealed: UnsafeUnion[int, str]
+    reveal_type(f(a).imag)  # revealed: Literal[0]
+    reveal_type(f(a).upper())  # revealed: str
+```
+
+### An overloaded `__new__` returning something else
+
+A `__new__` that can return something other than an instance of the class carries the same
+ambiguity, and used to degrade to `Unknown`:
+
+```py
+from typing import Any, overload
+
+class C:
+    @overload
+    def __new__(cls, a: int) -> "C": ...
+    @overload
+    def __new__(cls, a: str) -> int: ...
+    def __new__(cls, a: int | str) -> "C | int":
+        return 1
+
+def _(a: Any):
+    reveal_type(C(a))  # revealed: UnsafeUnion[int, C]
+```
+
+### An overloaded `__new__` never returning an instance
+
+```py
+from typing import Any, overload
+
+class E:
+    @overload
+    def __new__(cls, a: int) -> int: ...
+    @overload
+    def __new__(cls, a: str) -> str: ...
+    def __new__(cls, a: int | str) -> "int | str":
+        return 1
+
+def _(a: Any):
+    reveal_type(E(a))  # revealed: UnsafeUnion[int, str]
+```
+
+### Instance returns still collapse to the class
+
+When every matching overload returns an instance of the constructed class, that class is still the
+answer:
+
+```py
+from typing import Any, overload
+
+class C:
+    @overload
+    def __new__(cls, a: int) -> "C": ...
+    @overload
+    def __new__(cls, a: str) -> "D": ...
+    def __new__(cls, a: int | str) -> "C":
+        return super().__new__(cls)
+
+class D(C): ...
+
+def _(a: Any):
+    reveal_type(C(a))  # revealed: C
+```
+
+### Agreeing return types are not a choice
+
+```py
+from typing import Any, overload
+
+@overload
+def f(a: int) -> bytes: ...
+@overload
+def f(a: str) -> bytes: ...
+def f(a: int | str) -> bytes:
+    return b""
+
+def _(a: Any):
+    reveal_type(f(a))  # revealed: bytes
+```
+
+## Invalid forms
+
+```py
+from ty_extensions import UnsafeUnion
+
+# error: [invalid-type-form]
+def f(a: UnsafeUnion): ...
+```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -107,6 +107,7 @@ pub use crate::types::typevar::{
     BindingContext, BoundTypeVarIdentity, BoundTypeVarInstance, ParamSpecAttrKind,
     TypeVarBoundOrConstraints, TypeVarKind, TypeVarNonce,
 };
+pub use crate::types::unsafe_union::UnsafeUnionType;
 pub use crate::types::variance::TypeVarVariance;
 use crate::types::variance::VarianceInferable;
 use crate::types::visitor::any_over_type;
@@ -185,6 +186,7 @@ mod type_form;
 mod typed_dict;
 mod typevar;
 mod unpacker;
+mod unsafe_union;
 mod variance;
 pub(crate) mod visibility;
 mod visitor;
@@ -1007,6 +1009,11 @@ pub enum Type<'db> {
     Union(UnionType<'db>),
     /// The set of objects in all of the types in the intersection
     Intersection(IntersectionType<'db>),
+    /// `ty_extensions.UnsafeUnion[A, B]`: a gradual type whose materializations are exactly
+    /// `A` and `B`. It is a union in target position (both an `A` and a `B` can be assigned
+    /// to it) and an intersection in source position (it can be used as an `A` or as a `B`,
+    /// and offers the members of both). See [`UnsafeUnionType`].
+    UnsafeUnion(UnsafeUnionType<'db>),
     /// An enum instance with one or more canonical enum members excluded.
     EnumComplement(EnumComplementType<'db>),
     /// Represents objects whose `__bool__` method is deterministic:
@@ -1305,12 +1312,16 @@ impl<'db> Type<'db> {
         if cycle.iteration() <= crate::TAINTED_CYCLES {
             let self_degraded_by_overload =
                 any_over_type(db, self, false, |ty| {
-                    matches!(ty, Type::Dynamic(DynamicType::AmbiguousOverload))
+                    matches!(
+                        ty,
+                        Type::Dynamic(DynamicType::AmbiguousOverload) | Type::UnsafeUnion(_)
+                    )
                 }) && !any_over_type(db, self, false, |ty| ty.is_divergent())
                     && any_over_type(db, previous, false, |ty| ty.is_divergent());
             // Generally, the precision of type inference improves with each iteration.
             // However, overload is an exception; as iterations progress, overload matching may become ambiguous, and a reversal of precision can occur.
-            // This kind of precision degradation can be determined by whether the type contains `DynamicType::AmbiguousOverload`.
+            // This kind of precision degradation can be determined by whether the type contains
+            // `DynamicType::AmbiguousOverload` or an unsafe union, the two results of an ambiguous overload match.
             if self_degraded_by_overload {
                 UnionType::from_elements_cycle_recovery(db, [previous, self])
             } else {
@@ -2058,9 +2069,10 @@ impl<'db> Type<'db> {
                 NegativeIntersectionElements::Single(*self),
             )),
 
-            Type::Union(_) | Type::Intersection(_) | Type::EnumComplement(_) => {
-                IntersectionBuilder::new(db).add_negative(*self).build()
-            }
+            Type::Union(_)
+            | Type::Intersection(_)
+            | Type::EnumComplement(_)
+            | Type::UnsafeUnion(_) => IntersectionBuilder::new(db).add_negative(*self).build(),
         }
     }
 
@@ -2093,7 +2105,7 @@ impl<'db> Type<'db> {
             | Type::TypeAlias(_)
             | Type::SubclassOf(_) => true,
             Type::TypeForm(typeform) => typeform.type_argument(db).is_spellable(db),
-            Type::Intersection(_) => false,
+            Type::Intersection(_) | Type::UnsafeUnion(_) => false,
             Type::EnumComplement(complement) => complement.is_spellable(db),
             Type::Divergent(_)
             | Type::SpecialForm(_)
@@ -2129,6 +2141,7 @@ impl<'db> Type<'db> {
             | Type::TypeAlias(_) => true,
 
             Type::Intersection(_)
+            | Type::UnsafeUnion(_)
             | Type::EnumComplement(_)
             | Type::Divergent(_)
             | Type::SpecialForm(_)
@@ -2350,6 +2363,11 @@ impl<'db> Type<'db> {
             Type::Intersection(intersection) => intersection
                 .recursive_type_normalized_impl(db, div, nested)
                 .map(Type::Intersection),
+            // Like unions and intersections, an unsafe union is "flat" from the perspective
+            // of recursive types, so `nested` is passed through unchanged.
+            Type::UnsafeUnion(unsafe_union) => unsafe_union.try_map_elements(db, |element| {
+                element.recursive_type_normalized_impl(db, div, nested)
+            }),
             Type::EnumComplement(complement) => complement
                 .to_intersection(db)
                 .recursive_type_normalized_impl(db, div, nested),
@@ -2630,6 +2648,9 @@ impl<'db> Type<'db> {
                 .enum_complement(db)
                 .is_some_and(|complement| complement.is_singleton(db)),
             Type::EnumComplement(complement) => complement.is_singleton(db),
+            // Even if every element were a singleton, they are different singletons; which one
+            // this type is remains unknown.
+            Type::UnsafeUnion(_) => false,
             Type::AlwaysTruthy | Type::AlwaysFalsy => false,
             Type::TypeIs(type_is) => type_is.is_bound(db),
             Type::TypeGuard(type_guard) => type_guard.is_bound(db),
@@ -2725,6 +2746,7 @@ impl<'db> Type<'db> {
             | Type::Divergent(_)
             | Type::Never
             | Type::Union(..)
+            | Type::UnsafeUnion(_)
             | Type::AlwaysTruthy
             | Type::AlwaysFalsy
             | Type::Callable(_)
@@ -2778,6 +2800,14 @@ impl<'db> Type<'db> {
             })),
             Type::Intersection(inter) => {
                 Some(inter.map_with_boundness_and_qualifiers(db, |elem| {
+                    elem.find_name_in_mro_with_policy(db, name, policy)
+                        // Fall back to Unbound, similar to the union case (see above).
+                        .unwrap_or_default()
+                }))
+            }
+
+            Type::UnsafeUnion(unsafe_union) => {
+                Some(unsafe_union.map_with_boundness_and_qualifiers(db, |elem| {
                     elem.find_name_in_mro_with_policy(db, name, policy)
                         // Fall back to Unbound, similar to the union case (see above).
                         .unwrap_or_default()
@@ -3298,6 +3328,9 @@ impl<'db> Type<'db> {
             Type::EnumComplement(complement) => {
                 enums::instance_member_for_enum_complement(db, *complement, name)
             }
+
+            Type::UnsafeUnion(unsafe_union) => unsafe_union
+                .map_with_boundness_and_qualifiers(db, |elem| elem.instance_member(db, name)),
 
             Type::Dynamic(_) | Type::Divergent(_) | Type::Never => Place::bound(self).into(),
 
@@ -4121,6 +4154,16 @@ impl<'db> Type<'db> {
 
                 Type::EnumComplement(complement) => {
                     enums::member_lookup_for_enum_complement(db, complement, name_str, policy)
+                }
+
+                // The member is available as long as *some* materialization has it. This is the
+                // intersection face of an unsafe union, and the reason `UnsafeUnion[int, str]`
+                // answers both `.imag` and `.upper`.
+                Type::UnsafeUnion(unsafe_union) => {
+                    let receiver = Some(receiver.unwrap_or(this));
+                    unsafe_union.map_with_boundness_and_qualifiers(db, |elem| {
+                        elem.member_lookup_with_policy_and_receiver(db, name_str, policy, receiver)
+                    })
                 }
 
                 Type::Dynamic(..) | Type::Divergent(_) | Type::Never => Place::bound(this).into(),
@@ -5127,6 +5170,17 @@ impl<'db> Type<'db> {
                 self,
                 intersection
                     .positive_elements_or_object(db)
+                    .map(|element| element.bindings(db)),
+            ),
+
+            // Callable as long as *some* materialization is, like an intersection; but the
+            // results of the callable materializations combine back into an unsafe union
+            // rather than an intersection.
+            Type::UnsafeUnion(unsafe_union) => Bindings::from_unsafe_union(
+                self,
+                unsafe_union
+                    .elements(db)
+                    .iter()
                     .map(|element| element.bindings(db)),
             ),
 
@@ -6231,6 +6285,7 @@ impl<'db> Type<'db> {
                 InstanceProjection::OverApproximation(Type::NewTypeInstance(newtype)),
             ),
             Type::Union(union) => union.to_instance(db),
+            Type::UnsafeUnion(unsafe_union) => unsafe_union.to_instance(db),
             // If there is no bound or constraints on a typevar `T`, `T: object` implicitly, which
             // has no instance type. Otherwise, synthesize a typevar with bound or constraints
             // mapped through `to_instance`.
@@ -6571,6 +6626,35 @@ impl<'db> Type<'db> {
 
             Type::Intersection(_) => Ok(todo_type!("Type::Intersection.in_type_expression")),
 
+            Type::UnsafeUnion(unsafe_union) => {
+                let mut invalid_expressions = smallvec::SmallVec::default();
+                let ty = unsafe_union.map_elements(db, |element| {
+                    match element.in_type_expression(
+                        db,
+                        scope_id,
+                        typevar_binding_context,
+                        inference_flags,
+                    ) {
+                        Ok(type_expr) => type_expr,
+                        Err(InvalidTypeExpressionError {
+                            fallback_type,
+                            invalid_expressions: new_invalid_expressions,
+                        }) => {
+                            invalid_expressions.extend(new_invalid_expressions);
+                            fallback_type
+                        }
+                    }
+                });
+                if invalid_expressions.is_empty() {
+                    Ok(ty)
+                } else {
+                    Err(InvalidTypeExpressionError {
+                        fallback_type: ty,
+                        invalid_expressions,
+                    })
+                }
+            }
+
             Type::TypeAlias(alias) => alias.value_type(db).in_type_expression(
                 db,
                 scope_id,
@@ -6608,6 +6692,9 @@ impl<'db> Type<'db> {
             Type::SpecialForm(special_form) => special_form.to_meta_type(db),
             Type::PropertyInstance(property) => property.instance_class(db).to_class_literal(db),
             Type::Union(union) => union.map(db, |ty| ty.to_meta_type(db)),
+            Type::UnsafeUnion(unsafe_union) => {
+                unsafe_union.map_elements(db, |element| element.to_meta_type(db))
+            }
             Type::TypeIs(_) | Type::TypeGuard(_) => KnownClass::Bool.to_class_literal(db),
             Type::TypeForm(_) => Type::object().to_meta_type(db),
             Type::LiteralValue(literal) => match literal.kind() {
@@ -6682,6 +6769,9 @@ impl<'db> Type<'db> {
     pub(crate) fn dunder_class(self, db: &'db dyn Db) -> Type<'db> {
         match self {
             Type::Union(union) => union.map(db, |element| element.dunder_class(db)),
+            Type::UnsafeUnion(unsafe_union) => {
+                unsafe_union.map_elements(db, |element| element.dunder_class(db))
+            }
             Type::Intersection(intersection) => intersection
                 .try_dunder_class(db)
                 .unwrap_or_else(|| self.to_meta_type(db)),
@@ -7010,6 +7100,30 @@ impl<'db> Type<'db> {
             Type::Union(union) => union.map_leave_aliases(db, |element| {
                 element.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
             }),
+
+            // Materializing an unsafe union picks *one* of its materializations, so the top
+            // materialization is the union of the elements' tops and the bottom materialization
+            // is the intersection of their bottoms.
+            Type::UnsafeUnion(unsafe_union) => match type_mapping {
+                TypeMapping::Materialize(MaterializationKind::Top) => UnionType::from_elements(
+                    db,
+                    unsafe_union.elements(db).iter().map(|element| {
+                        element.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
+                    }),
+                ),
+                TypeMapping::Materialize(MaterializationKind::Bottom) => unsafe_union
+                    .elements(db)
+                    .iter()
+                    .fold(IntersectionBuilder::new(db), |builder, element| {
+                        builder.add_positive(
+                            element.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                        )
+                    })
+                    .build(),
+                _ => unsafe_union.map_elements(db, |element| {
+                    element.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
+                }),
+            },
             Type::Intersection(intersection) => {
                 let mut builder = IntersectionBuilder::new(db);
                 for positive in intersection.positive(db) {
@@ -7314,6 +7428,11 @@ impl<'db> Type<'db> {
 
             Type::Union(union) => {
                 for element in union.elements(db) {
+                    element.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+                }
+            }
+            Type::UnsafeUnion(unsafe_union) => {
+                for element in unsafe_union.elements(db) {
                     element.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
                 }
             }
@@ -7685,7 +7804,7 @@ impl<'db> Type<'db> {
 
             Self::TypedDict(typed_dict) => typed_dict.type_definition(db),
 
-            Self::Union(_) => None,
+            Self::Union(_) | Self::UnsafeUnion(_) => None,
             Self::Intersection(intersection) => {
                 let alternatives = intersection.finite_alternatives(db)?;
                 let [alternative] = alternatives.as_slice() else {
@@ -8041,6 +8160,8 @@ impl<'db> VarianceInferable<'db> for Type<'db> {
                 .iter()
                 .map(|ty| ty.variance_of(db, typevar))
                 .collect(),
+
+            Type::UnsafeUnion(unsafe_union) => unsafe_union.variance_of(db, typevar),
 
             // Products are covariant in their conjuncts. For negative
             // conjuncts, they're contravariant. To see this, suppose we have

--- a/crates/ty_python_semantic/src/types/attribute_write.rs
+++ b/crates/ty_python_semantic/src/types/attribute_write.rs
@@ -11,9 +11,7 @@ use ty_module_resolver::KnownModule;
 
 use super::call::CallArguments;
 use super::callable::CallableTypeKind;
-use super::{
-    IntersectionType, KnownClass, KnownInstanceType, MemberLookupPolicy, Type, TypeQualifiers,
-};
+use super::{KnownClass, KnownInstanceType, MemberLookupPolicy, Type, TypeQualifiers};
 use crate::Db;
 use crate::place::{DefinedPlace, Definedness, Place, PlaceAndQualifiers, builtins_symbol};
 
@@ -29,10 +27,11 @@ pub(super) enum AttributeWriteRequirement<'db> {
         object_ty: Type<'db>,
         element_tys: &'db [Type<'db>],
     },
-    /// A write to an intersection may target any positive intersection element.
+    /// A write that may target any one of several element types: the positive elements of an
+    /// intersection, or the materializations of an unsafe union.
     Any {
         object_ty: Type<'db>,
-        intersection: IntersectionType<'db>,
+        element_tys: Vec<Type<'db>>,
     },
     /// A value may be assigned without an attribute-specific constraint.
     Unconstrained,
@@ -242,9 +241,16 @@ pub(super) fn attribute_write_requirement<'db>(
             // TODO: Handle negative intersection elements.
             AttributeWriteRequirement::Any {
                 object_ty,
-                intersection,
+                element_tys: intersection.positive(db).iter().copied().collect(),
             }
         }
+
+        // A write succeeds if it succeeds for some materialization, the same any-arm rule as an
+        // intersection.
+        Type::UnsafeUnion(unsafe_union) => AttributeWriteRequirement::Any {
+            object_ty,
+            element_tys: unsafe_union.elements(db).to_vec(),
+        },
 
         Type::EnumComplement(complement) => {
             attribute_write_requirement(db, complement.remaining_literal_union(db), attribute)
@@ -698,6 +704,7 @@ pub(super) fn assignment_attribute_members<'db>(
             }
             Type::Union(..)
             | Type::Intersection(..)
+            | Type::UnsafeUnion(..)
             | Type::TypeAlias(..)
             | Type::Dynamic(..)
             | Type::Divergent(_)

--- a/crates/ty_python_semantic/src/types/bool.rs
+++ b/crates/ty_python_semantic/src/types/bool.rs
@@ -298,6 +298,12 @@ impl<'db> Type<'db> {
 
             Type::Union(union) => try_union(*union)?,
 
+            // Which materialization this is, is unknown, so the truthiness is only certain when
+            // every materialization agrees: exactly the union face's answer.
+            Type::UnsafeUnion(unsafe_union) => unsafe_union
+                .to_union(db)
+                .try_bool_impl(db, allow_short_circuit, visitor)?,
+
             Type::Intersection(intersection) => {
                 if let Some(alternatives) = intersection.finite_alternative_union(db) {
                     alternatives.try_bool_impl(db, allow_short_circuit, visitor)?

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -10,7 +10,7 @@ use crate::{
     types::{
         BoundTypeVarInstance, ClassBase, ClassType, DivergentType, DynamicType,
         IntersectionBuilder, KnownClass, MemberLookupPolicy, SpecialFormType, SubclassOfInner,
-        SubclassOfType, Type, TypeVarBoundOrConstraints, UnionBuilder,
+        SubclassOfType, Type, TypeVarBoundOrConstraints, UnionBuilder, UnsafeUnionType,
         constraints::ConstraintSet,
         context::InferContext,
         diagnostic::{INVALID_SUPER_ARGUMENT, UNAVAILABLE_IMPLICIT_SUPER_ARGUMENTS},
@@ -742,6 +742,24 @@ impl<'db> BoundSuperType<'db> {
                     }
                 }
                 return Ok(builder.build());
+            }
+            // `super()` in one materialization is a valid `super()` for the unsafe union, the
+            // same any-element rule as an intersection.
+            Type::UnsafeUnion(unsafe_union) => {
+                let mut elements = Vec::new();
+                for element in unsafe_union.elements(db) {
+                    if let Ok(good_element) = delegate_to(*element) {
+                        elements.push(good_element);
+                    }
+                }
+                if elements.is_empty() {
+                    return Err(BoundSuperError::AbstractOwnerType {
+                        owner_type,
+                        pivot_class: pivot_class_type,
+                        typevar_context: None,
+                    });
+                }
+                return Ok(UnsafeUnionType::from_elements(db, elements));
             }
             Type::EnumComplement(complement) => {
                 return delegate_to(complement.to_intersection(db));

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -71,7 +71,8 @@ use crate::types::{
     InternedConstraintSet, IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType,
     LiteralValueTypeKind, NominalInstanceType, PropertyInstanceType, SpecialFormType,
     TypeAliasType, TypeContext, TypeMapping, TypeVarBoundOrConstraints, TypeVarVariance,
-    UnionAccumulator, UnionBuilder, UnionType, WrapperDescriptorKind, enums, list_members,
+    UnionAccumulator, UnionBuilder, UnionType, UnsafeUnionType, WrapperDescriptorKind, enums,
+    list_members,
 };
 use crate::{DisplaySettings, FxOrderSet, Program};
 use ruff_db::diagnostic::{Annotation, Diagnostic, Span, SubDiagnostic, SubDiagnosticSeverity};
@@ -357,11 +358,38 @@ impl<'db> CallableItem<'db> {
 }
 
 /// A single element in a union of callables.
-/// This could be a single callable or an intersection of callables.
-/// If there are multiple items, they form an intersection.
+/// This could be a single callable or several callables combined by [`ItemCombination`].
 #[derive(Debug, Clone)]
 struct BindingsElement<'db> {
     items: SmallVec<[CallableItem<'db>; 1]>,
+    combination: ItemCombination,
+}
+
+/// How the multiple items of a [`BindingsElement`] combine into one result.
+///
+/// Both kinds bind the same way — the call succeeds if *some* item does — and differ only in
+/// how the successful items' types are recombined.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ItemCombination {
+    /// The items are the elements of an intersection.
+    Intersection,
+    /// The items are the materializations of an [`UnsafeUnion`].
+    ///
+    /// [`UnsafeUnion`]: Type::UnsafeUnion
+    UnsafeUnion,
+}
+
+impl ItemCombination {
+    /// Recombine per-item types (return types, callable types) the way this combination does.
+    fn combine<'db, I>(self, db: &'db dyn Db, types: I) -> Type<'db>
+    where
+        I: IntoIterator<Item = Type<'db>>,
+    {
+        match self {
+            ItemCombination::Intersection => IntersectionType::from_elements(db, types),
+            ItemCombination::UnsafeUnion => UnsafeUnionType::from_elements(db, types),
+        }
+    }
 }
 
 impl<'db> BindingsElement<'db> {
@@ -388,7 +416,7 @@ impl<'db> BindingsElement<'db> {
 
     fn return_type(&self, db: &'db dyn Db) -> Type<'db> {
         if self.is_callable() {
-            IntersectionType::from_elements(
+            self.combination.combine(
                 db,
                 self.items
                     .iter()
@@ -674,7 +702,28 @@ impl<'db> Bindings<'db> {
     where
         I: IntoIterator<Item = Bindings<'db>>,
     {
-        // Flatten all input bindings into a single intersection element
+        Self::from_combined(callable_type, bindings_iter, ItemCombination::Intersection)
+    }
+
+    /// Creates a new `Bindings` from an iterator of [`Bindings`]s for the materializations of
+    /// an unsafe union. All input bindings are combined into a single element.
+    /// Panics if the iterator is empty.
+    pub(crate) fn from_unsafe_union<I>(callable_type: Type<'db>, bindings_iter: I) -> Self
+    where
+        I: IntoIterator<Item = Bindings<'db>>,
+    {
+        Self::from_combined(callable_type, bindings_iter, ItemCombination::UnsafeUnion)
+    }
+
+    fn from_combined<I>(
+        callable_type: Type<'db>,
+        bindings_iter: I,
+        combination: ItemCombination,
+    ) -> Self
+    where
+        I: IntoIterator<Item = Bindings<'db>>,
+    {
+        // Flatten all input bindings into a single element
         let mut implicit_dunder_new_is_possibly_unbound = true;
         let mut implicit_dunder_init_is_possibly_unbound = true;
         let mut inner_items_acc = SmallVec::new();
@@ -690,6 +739,7 @@ impl<'db> Bindings<'db> {
         assert!(!inner_items_acc.is_empty());
         let elements = smallvec![BindingsElement {
             items: inner_items_acc,
+            combination,
         }];
         Self {
             callable_type,
@@ -1055,6 +1105,7 @@ impl<'db> Bindings<'db> {
                 .into_iter()
                 .map(|elem| BindingsElement {
                     items: elem.items.into_iter().map(|item| item.map(f)).collect(),
+                    combination: elem.combination,
                 })
                 .collect(),
         }
@@ -1372,8 +1423,8 @@ impl<'db> Bindings<'db> {
             // Find the highest priority error among bindings in this element
             let max_priority = element.error_priority(context.db());
 
-            // Construct the intersection type from the bindings
-            let intersection_type = IntersectionType::from_elements(
+            // Reconstruct the combined callable type from the bindings
+            let intersection_type = element.combination.combine(
                 context.db(),
                 element.items.iter().map(CallableItem::callable_type),
             );
@@ -3093,6 +3144,7 @@ impl<'db> From<CallableBinding<'db>> for Bindings<'db> {
             callable_type: from.callable_type,
             elements: smallvec_inline![BindingsElement {
                 items: smallvec_inline![CallableItem::Regular(from)],
+                combination: ItemCombination::Intersection,
             }],
             implicit_dunder_new_is_possibly_unbound: false,
             implicit_dunder_init_is_possibly_unbound: false,
@@ -3118,6 +3170,7 @@ impl<'db> From<Binding<'db>> for Bindings<'db> {
             callable_type,
             elements: smallvec_inline![BindingsElement {
                 items: smallvec_inline![CallableItem::Regular(callable_binding)],
+                combination: ItemCombination::Intersection,
             }],
             implicit_dunder_new_is_possibly_unbound: false,
             implicit_dunder_init_is_possibly_unbound: false,
@@ -4101,8 +4154,22 @@ impl<'db> CallableBinding<'db> {
         };
 
         if !are_return_types_equivalent_for_all_matching_overloads {
-            // Overload matching is ambiguous.
-            self.overload_call_return_type = Some(OverloadCallReturnType::Ambiguous);
+            // Overload matching is ambiguous: the call resolves to one of the remaining
+            // overloads, but which one depends on how the gradual argument materializes. The
+            // possible results are exactly those overloads' return types, which is what an
+            // unsafe union describes.
+            let possible_return_types = self
+                .matching_overloads()
+                .map(|(_, overload)| overload.return_type())
+                .collect::<Vec<_>>();
+            let return_type = match UnsafeUnionType::from_elements(db, possible_return_types) {
+                // A dynamic return type admits every materialization, so the menu is no longer
+                // finite. Keep the marker type instead, which records that this `Unknown` came
+                // from a degraded overload match.
+                Type::Dynamic(_) => Type::Dynamic(DynamicType::AmbiguousOverload),
+                return_type => return_type,
+            };
+            self.overload_call_return_type = Some(OverloadCallReturnType::Ambiguous(return_type));
         }
     }
 
@@ -4240,7 +4307,7 @@ impl<'db> CallableBinding<'db> {
             return match overload_call_return_type {
                 OverloadCallReturnType::ArgumentTypeExpansion(return_type) => return_type,
                 OverloadCallReturnType::ArgumentTypeExpansionLimitReached(_) => Type::unknown(),
-                OverloadCallReturnType::Ambiguous => Type::Dynamic(DynamicType::AmbiguousOverload),
+                OverloadCallReturnType::Ambiguous(return_type) => return_type,
             };
         }
         if let Some((_, first_overload)) = self.matching_overloads().next() {
@@ -4491,7 +4558,9 @@ impl<'db> IntoIterator for CallableBinding<'db> {
 enum OverloadCallReturnType<'db> {
     ArgumentTypeExpansion(Type<'db>),
     ArgumentTypeExpansionLimitReached(usize),
-    Ambiguous,
+    /// The call matched several overloads with differing return types, because an argument was
+    /// gradual. The type is the unsafe union of the possible return types.
+    Ambiguous(Type<'db>),
 }
 
 #[derive(Debug)]

--- a/crates/ty_python_semantic/src/types/call/bind/constructor.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/constructor.rs
@@ -5,7 +5,9 @@ use crate::types::constraints::ConstraintSetBuilder;
 use crate::types::dedicated::django;
 use crate::types::generics::Specialization;
 use crate::types::signatures::Parameter;
-use crate::types::{BoundTypeVarInstance, ClassLiteral, DynamicType, Type, TypeContext};
+use crate::types::{
+    BoundTypeVarInstance, ClassLiteral, DynamicType, Type, TypeContext, UnsafeUnionType,
+};
 
 /// Bindings for a constructor call.
 ///
@@ -209,8 +211,6 @@ impl<'db> ConstructorBinding<'db> {
 
     /// Compute the overall effective return type of this `ConstructorBinding`.
     pub(super) fn return_type(&self, db: &'db dyn Db) -> Type<'db> {
-        let constructed_instance_type = self.constructed_instance_type();
-
         // If we are checking downstream constructors, and the downstream constructor resolves to a
         // non-instance return, that becomes the effective constructor return. This can only happen
         // if we are a metaclass `__call__` returning an instance of the constructed class, but
@@ -240,7 +240,13 @@ impl<'db> ConstructorBinding<'db> {
             return pinned;
         }
 
-        constructed_instance_type
+        self.instance_return_type(db)
+    }
+
+    /// The type of the constructed instance itself, used when no overload dictates a more
+    /// specific return type.
+    fn instance_return_type(&self, db: &'db dyn Db) -> Type<'db> {
+        self.constructed_instance_type()
             .apply_optional_specialization(db, self.instance_return_specialization(db))
     }
 
@@ -404,24 +410,28 @@ impl<'db> ConstructorBinding<'db> {
         // consider all overloads' return types. (This increases the chances of an `Unknown`
         // return, but still preserves more precise returns in unambiguous cases.)
         if matching_overloads.clone().next().is_none() {
-            self.analyze_overload_returns(db, self.callable().overloads().iter())
+            self.analyze_overload_returns(db, self.callable().overloads().iter(), false)
         } else {
-            self.analyze_overload_returns(db, matching_overloads)
+            self.analyze_overload_returns(db, matching_overloads, true)
         }
     }
 
     /// Combine return types from an iterator of overloads to determine the effective explicit
     /// return type of the constructor call. See `explicit_return_type` for details.
+    ///
+    /// `matched` records whether these are the overloads that matched the call. When several of
+    /// them disagree, the call could produce any one of their returns, which is exactly an unsafe
+    /// union. When no overload matched at all we are recovering from an error instead, so we fall
+    /// back to `Unknown` rather than letting a speculative menu cause follow-on diagnostics.
     fn analyze_overload_returns<'a>(
         &self,
         db: &'db dyn Db,
         overloads: impl IntoIterator<Item = &'a Binding<'db>>,
+        matched: bool,
     ) -> Option<Type<'db>>
     where
         'db: 'a,
     {
-        // If we see both instance and non-instance returns, we return Unknown.
-        // If we see multiple different non-instance returns, we also return Unknown.
         // If we see multiple instance returns, we return `None` (we know we are constructing an
         // instance of the constructed class, but we don't have more precise information.)
         // Otherwise, we return the single non-instance return if present, or the single
@@ -429,7 +439,7 @@ impl<'db> ConstructorBinding<'db> {
         // could be a specific subclass of the constructed class.)
         let mut sole_instance_return = None;
         let mut saw_instance_return = false;
-        let mut non_instance_return = None;
+        let mut non_instance_returns: Vec<Type<'db>> = Vec::new();
         for overload in overloads {
             let (return_ty, is_instance_return) = self.single_overload_return(db, overload);
             if is_instance_return {
@@ -439,22 +449,25 @@ impl<'db> ConstructorBinding<'db> {
                     sole_instance_return = Some(return_ty);
                     saw_instance_return = true;
                 }
-            } else {
-                non_instance_return = Some(match non_instance_return {
-                    None => return_ty,
-                    Some(previous) if previous == return_ty => return_ty,
-                    Some(_) => Type::unknown(),
-                });
+            } else if !non_instance_returns.contains(&return_ty) {
+                non_instance_returns.push(return_ty);
             }
         }
-        if let Some(non_instance_return) = non_instance_return {
-            if saw_instance_return {
-                Some(Type::unknown())
-            } else {
-                Some(non_instance_return)
+
+        match non_instance_returns.as_slice() {
+            [] => sole_instance_return,
+            [sole_non_instance_return] if !saw_instance_return => Some(*sole_non_instance_return),
+            _ => {
+                if !matched {
+                    return Some(Type::unknown());
+                }
+                if saw_instance_return {
+                    non_instance_returns.push(
+                        sole_instance_return.unwrap_or_else(|| self.instance_return_type(db)),
+                    );
+                }
+                Some(UnsafeUnionType::from_elements(db, non_instance_returns))
             }
-        } else {
-            sole_instance_return
         }
     }
 

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -291,6 +291,20 @@ impl<'db> Type<'db> {
                     })
             }
 
+            // Only the materializations that are callable can be the one at hand; a
+            // non-callable materialization does not disqualify the others.
+            Type::UnsafeUnion(unsafe_union) => {
+                let mut callables = SmallVec::new();
+                for element in unsafe_union.elements(db) {
+                    if let Some(element_callable) =
+                        element.try_upcast_to_callable_with_policy_and_context(db, policy, context)
+                    {
+                        callables.extend(element_callable.into_inner());
+                    }
+                }
+                (!callables.is_empty()).then(|| CallableTypes::new(callables))
+            }
+
             Type::EnumComplement(complement) => complement
                 .remaining_literal_union(db)
                 .try_upcast_to_callable_with_policy_and_context(db, policy, context),

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -162,6 +162,12 @@ impl<'db> ClassBase<'db> {
                     Some(valid_element)
                 }
             }
+            // Any one materialization could be the actual base, so the first valid one stands
+            // in for the whole type — the same rule as an intersection.
+            Type::UnsafeUnion(unsafe_union) => unsafe_union
+                .elements(db)
+                .iter()
+                .find_map(|element| ClassBase::try_from_type(db, *element, subclass)),
             Type::Union(union) => {
                 if let Some(module) = TypedDictModule::from_type(db, ty) {
                     return Some(ClassBase::TypedDict(module));
@@ -285,6 +291,7 @@ impl<'db> ClassBase<'db> {
                 | SpecialFormType::Top
                 | SpecialFormType::Bottom
                 | SpecialFormType::Intersection
+                | SpecialFormType::UnsafeUnion
                 | SpecialFormType::TypeOf
                 | SpecialFormType::CallableTypeOf
                 | SpecialFormType::RegularCallableTypeOf

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -1478,6 +1478,20 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     .fmt_detailed(f)?;
                 f.write_char(']')
             }
+            Type::UnsafeUnion(unsafe_union) => {
+                f.with_type(Type::SpecialForm(SpecialFormType::UnsafeUnion))
+                    .write_str("UnsafeUnion")?;
+                f.write_char('[')?;
+                for (index, element) in unsafe_union.elements(self.db).iter().enumerate() {
+                    if index > 0 {
+                        f.write_str(", ")?;
+                    }
+                    element
+                        .display_with(self.db, self.settings.clone())
+                        .fmt_detailed(f)?;
+                }
+                f.write_char(']')
+            }
             Type::Overlapping(overlapping) => {
                 f.with_type(Type::SpecialForm(SpecialFormType::Overlapping))
                     .write_str("Overlapping")?;

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -2106,6 +2106,10 @@ fn is_instance_truthiness<'db>(
             Truthiness::Ambiguous
         }
 
+        // Which materialization is at hand is unknown, so an `isinstance()` check against any
+        // one of them can never be statically true.
+        Type::UnsafeUnion(_) => Truthiness::Ambiguous,
+
         // Create a new intersection that maps type variables to their upper bounds,
         // and evaluate the truthiness of the `isinstance()` check with that type.
         // Along the way, short-circuit to `AlwaysTrue` if we find any positive element

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -3120,6 +3120,22 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             }
 
+            // Deletion succeeds if it succeeds for some materialization, the same any-arm rule
+            // as an intersection.
+            Type::UnsafeUnion(unsafe_union) => {
+                let elements = unsafe_union.elements(db);
+                if elements.iter().any(|element_ty| {
+                    self.validate_attribute_deletion(target, *element_ty, attribute, false)
+                }) {
+                    true
+                } else {
+                    if emit_diagnostics && let Some(element_ty) = elements.first() {
+                        self.validate_attribute_deletion(target, *element_ty, attribute, true);
+                    }
+                    false
+                }
+            }
+
             Type::EnumComplement(complement) => self.validate_attribute_deletion(
                 target,
                 complement.remaining_literal_union(db),
@@ -5340,7 +5356,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
                 // Intersections are currently not handled here because that would require
                 // the decorator to be explicitly annotated as returning an intersection.
-                Type::Intersection(_) | Type::EnumComplement(_) => None,
+                Type::Intersection(_) | Type::EnumComplement(_) | Type::UnsafeUnion(_) => None,
                 // All other types cannot have a callable kind propagated to them.
                 Type::Dynamic(_)
                 | Type::Divergent(_)
@@ -12065,6 +12081,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 | Type::PropertyInstance(_)
                 | Type::Union(_)
                 | Type::Intersection(_)
+                // the dunder lookup resolves across the materializations
+                | Type::UnsafeUnion(_)
                 | Type::EnumComplement(_)
                 | Type::AlwaysTruthy
                 | Type::AlwaysFalsy

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
@@ -200,10 +200,10 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
             }
             AttributeWriteRequirement::Any {
                 object_ty,
-                intersection,
+                element_tys,
             } => {
                 let mut valid = false;
-                for element_ty in intersection.positive(self.builder.db()) {
+                for element_ty in element_tys {
                     let requirement =
                         attribute_write_requirement(self.builder.db(), *element_ty, self.attribute);
                     if self.evaluate(&requirement, false) {

--- a/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
@@ -15,7 +15,7 @@ use crate::types::typevar::TypeVarConstraints;
 use crate::types::{
     DynamicType, InternedConstraintSet, KnownClass, KnownInstanceType, LiteralValueTypeKind,
     MemberLookupPolicy, Type, TypeContext, TypeVarBoundOrConstraints, TypedDictType, UnionBuilder,
-    UnionType, UnionTypeInstance,
+    UnionType, UnionTypeInstance, UnsafeUnionType,
 };
 
 enum BinaryExpressionOperandTypes<'db> {
@@ -425,6 +425,46 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     tcx,
                 )
             }),
+
+            // Only the materializations that support the operator can be the one at hand, so
+            // the results of those combine back into an unsafe union; the operator is
+            // unsupported only if no materialization supports it.
+            (Type::UnsafeUnion(lhs_unsafe_union), rhs, _) => {
+                let results: Vec<_> = lhs_unsafe_union
+                    .elements(db)
+                    .iter()
+                    .filter_map(|lhs_element| {
+                        self.infer_binary_expression_type_impl(
+                            node,
+                            emitted_division_by_zero_diagnostic,
+                            *lhs_element,
+                            rhs,
+                            op,
+                            visitor,
+                            tcx,
+                        )
+                    })
+                    .collect();
+                (!results.is_empty()).then(|| UnsafeUnionType::from_elements(db, results))
+            }
+            (lhs, Type::UnsafeUnion(rhs_unsafe_union), _) => {
+                let results: Vec<_> = rhs_unsafe_union
+                    .elements(db)
+                    .iter()
+                    .filter_map(|rhs_element| {
+                        self.infer_binary_expression_type_impl(
+                            node,
+                            emitted_division_by_zero_diagnostic,
+                            lhs,
+                            *rhs_element,
+                            op,
+                            visitor,
+                            tcx,
+                        )
+                    })
+                    .collect();
+                (!results.is_empty()).then(|| UnsafeUnionType::from_elements(db, results))
+            }
 
             (Type::TypeAlias(alias), rhs, _) => visitor.visit(db, (left_ty, op, right_ty), || {
                 self.infer_binary_expression_type_impl(

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -29,7 +29,8 @@ use crate::types::{
     InternedType, IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType,
     LintDiagnosticGuard, LiteralValueTypeKind, OverlappingType, Parameter, Parameters,
     SpecialFormType, SubclassOfType, Type, TypeAliasType, TypeContext, TypeFormType, TypeGuardType,
-    TypeIsType, TypeMapping, TypeVarKind, UnionBuilder, UnionType, any_over_type, todo_type,
+    TypeIsType, TypeMapping, TypeVarKind, UnionBuilder, UnionType, UnsafeUnionType, any_over_type,
+    todo_type,
 };
 use crate::{FxOrderSet, Program, add_inferred_python_version_hint_to_diagnostic};
 
@@ -2905,6 +2906,24 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         builder.add_positive(self.infer_type_expression(element))
                     })
                     .build();
+
+                if matches!(arguments_slice, ast::Expr::Tuple(_)) {
+                    self.store_expression_type(arguments_slice, ty);
+                }
+                ty
+            }
+            SpecialFormType::UnsafeUnion => {
+                let elements = match arguments_slice {
+                    ast::Expr::Tuple(tuple) => Either::Left(tuple.iter()),
+                    element => Either::Right(std::iter::once(element)),
+                };
+
+                let ty = UnsafeUnionType::from_elements(
+                    db,
+                    elements
+                        .map(|element| self.infer_type_expression(element))
+                        .collect::<Vec<_>>(),
+                );
 
                 if matches!(arguments_slice, ast::Expr::Tuple(_)) {
                     self.store_expression_type(arguments_slice, ty);

--- a/crates/ty_python_semantic/src/types/iteration.rs
+++ b/crates/ty_python_semantic/src/types/iteration.rs
@@ -276,7 +276,10 @@ impl<'db> Type<'db> {
                 | Type::TypeIs(_)
                 | Type::TypeGuard(_)
                 | Type::TypeForm(_)
-                | Type::TypedDict(_) => None
+                | Type::TypedDict(_)
+                // No fast path: fall through to `__iter__`/`__getitem__` resolution, which
+                // already looks members up across the materializations.
+                | Type::UnsafeUnion(_) => None
             }
         }
 

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -207,6 +207,17 @@ impl<'db> AllMembers<'db> {
                     .unwrap_or_default(),
             ),
 
+            // Completions offer the members of every materialization, since a member of any one
+            // of them resolves on the unsafe union.
+            Type::UnsafeUnion(unsafe_union) => self.members.extend(
+                unsafe_union
+                    .elements(db)
+                    .iter()
+                    .map(|ty| AllMembers::of(db, *ty).members)
+                    .reduce(|acc, members| acc.union(&members).cloned().collect())
+                    .unwrap_or_default(),
+            ),
+
             Type::EnumComplement(complement) => {
                 self.extend_with_type(db, complement.to_intersection(db));
             }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -518,6 +518,11 @@ impl ClassInfoConstraintFunction {
             Type::Union(union) => union.try_map(db, |element| {
                 self.generate_constraint(db, *element, is_positive)
             }),
+            // Any materialization could be the actual class-info argument, so narrowing must
+            // allow for all of them: the union face.
+            Type::UnsafeUnion(unsafe_union) => {
+                self.generate_constraint(db, unsafe_union.to_union(db), is_positive)
+            }
             Type::TypeVar(bound_typevar) => {
                 match bound_typevar.typevar(db).bound_or_constraints(db)? {
                     TypeVarBoundOrConstraints::UpperBound(bound) => {
@@ -4370,6 +4375,10 @@ fn is_or_contains_typeddict<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
             .elements(db)
             .iter()
             .any(|union_member_ty| is_or_contains_typeddict(db, *union_member_ty)),
+        Type::UnsafeUnion(unsafe_union) => unsafe_union
+            .elements(db)
+            .iter()
+            .any(|element| is_or_contains_typeddict(db, *element)),
         Type::TypeAlias(alias) => is_or_contains_typeddict(db, alias.value_type(db)),
 
         Type::Dynamic(_)
@@ -4535,6 +4544,10 @@ fn all_matching_typeddict_fields_have_literal_types<'db>(
                     *union_member_ty,
                     field_name,
                 )
+        }),
+        Type::UnsafeUnion(unsafe_union) => unsafe_union.elements(db).iter().all(|element| {
+            !is_or_contains_typeddict(db, *element)
+                || all_matching_typeddict_fields_have_literal_types(db, *element, field_name)
         }),
         Type::Overlapping(overlapping) => all_matching_typeddict_fields_have_literal_types(
             db,

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -2122,9 +2122,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 }
                 result
             }
-            AttributeWriteRequirement::Any { intersection, .. } => {
+            AttributeWriteRequirement::Any { element_tys, .. } => {
                 let mut result = self.never();
-                for element_ty in intersection.positive(db) {
+                for element_ty in element_tys {
                     let requirement = attribute_write_requirement(db, *element_ty, member_name);
                     let element_result = self.check_property_write_requirement(
                         db,

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -29,7 +29,7 @@ use crate::types::{
     ApplyTypeMappingVisitor, CallableType, ClassBase, ClassLiteral, ClassType, CycleDetector,
     IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
     MemberLookupPolicy, PropertyInstanceType, ProtocolInstanceType, SubclassOfInner,
-    SubclassOfType, TypeVarBoundOrConstraints, UnionType, UpcastPolicy,
+    SubclassOfType, TypeVarBoundOrConstraints, UnionType, UnsafeUnionType, UpcastPolicy,
 };
 use crate::{
     Db,
@@ -300,6 +300,7 @@ impl<'db> Type<'db> {
             | Type::SubclassOf(_)
             | Type::Union(_)
             | Type::Intersection(_)
+            | Type::UnsafeUnion(_)
             | Type::EnumComplement(_)
             | Type::Callable(_)
             | Type::KnownBoundMethod(
@@ -1071,6 +1072,31 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
     /// upper bound normalizes to this exact class object. That can only happen for a final class,
     /// so the exact object is the only valid specialization of the type variable.
     ///
+    /// Return a constraint set for two unsafe unions offering the same menu of
+    /// materializations: every element of each must be redundant with an element of the other.
+    ///
+    /// Requiring both directions keeps redundancy symmetric for unsafe unions, so that they are
+    /// equivalent exactly when their menus match, and one is never simplified out of a union or
+    /// intersection in favour of a different one.
+    fn check_unsafe_union_menus_match(
+        &self,
+        db: &'db dyn Db,
+        left: UnsafeUnionType<'db>,
+        right: UnsafeUnionType<'db>,
+    ) -> ConstraintSet<'db, 'c> {
+        let covered_by = |menu: &'db [Type<'db>], elements: &'db [Type<'db>]| {
+            elements.iter().when_all(db, self.constraints, |&element| {
+                menu.iter().when_any(db, self.constraints, |&candidate| {
+                    self.check_type_pair(db, element, candidate)
+                })
+            })
+        };
+
+        covered_by(right.elements(db), left.elements(db)).and(db, self.constraints, || {
+            covered_by(left.elements(db), right.elements(db))
+        })
+    }
+
     /// Return `None` for targets without a `.to_instance()` projection, allowing other type-pair
     /// branches to decide their relation.
     fn check_typevar_subclass_relation_to_target(
@@ -1435,6 +1461,48 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                     },
                 },
             ),
+
+            // An unsafe union is a union on the way *in* and an intersection on the way *out*.
+            //
+            // Out (source position): the value is treated as some one of its materializations,
+            // so it can go anywhere any single materialization can go. That is the intersection
+            // face, and it is what makes `UnsafeUnion[int, str]` usable as an `int`.
+            //
+            // In (target position): every materialization is a valid thing to store, so the type
+            // accepts whatever the plain union `A | B` accepts. That is the union face, and it is
+            // what makes both `f(1)` and `f("s")` valid for `f(a: UnsafeUnion[int, str])`.
+            //
+            // Neither face is a subtype relation: like every gradual type, an unsafe union is a
+            // subtype only of `object` (handled above). For redundancy — which drives union and
+            // intersection simplification, and equivalence — we require the two menus to match,
+            // so that `UnsafeUnion[int, str]` and `UnsafeUnion[str, int]` are equivalent but no
+            // unsafe union is ever silently simplified away.
+            (Type::UnsafeUnion(source_unsafe_union), _) => match self.relation {
+                TypeRelation::Subtyping | TypeRelation::SubtypingAssuming => self.never(),
+                TypeRelation::Assignability => source_unsafe_union.elements(db).iter().when_any(
+                    db,
+                    self.constraints,
+                    |&element| self.check_type_pair(db, element, target),
+                ),
+                TypeRelation::Redundancy { .. } => {
+                    let Type::UnsafeUnion(target_unsafe_union) = target else {
+                        return self.never();
+                    };
+                    self.check_unsafe_union_menus_match(
+                        db,
+                        source_unsafe_union,
+                        target_unsafe_union,
+                    )
+                }
+            },
+
+            (_, Type::UnsafeUnion(target_unsafe_union)) => match self.relation {
+                TypeRelation::Subtyping | TypeRelation::SubtypingAssuming => self.never(),
+                TypeRelation::Assignability => {
+                    self.check_type_pair(db, source, target_unsafe_union.to_union(db))
+                }
+                TypeRelation::Redundancy { .. } => self.never(),
+            },
 
             // In general, a TypeVar `T` is not redundant with a type `S` unless one of the two conditions is satisfied:
             // 1. `T` is a bound TypeVar and `T`'s upper bound is a subtype of `S`.
@@ -2849,6 +2917,17 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 .when_all(db, self.constraints, |e| {
                     self.check_type_pair(db, *e, other)
                 }),
+
+            // An unsafe union overlaps a type as soon as *one* of its materializations does,
+            // so it is disjoint only when every materialization is.
+            (Type::UnsafeUnion(unsafe_union), other) | (other, Type::UnsafeUnion(unsafe_union)) => {
+                unsafe_union
+                    .elements(db)
+                    .iter()
+                    .when_all(db, self.constraints, |element| {
+                        self.check_type_pair(db, *element, other)
+                    })
+            }
 
             // If we have two intersections, we test the positive elements of each one against the other intersection
             // Negative elements need a positive element on the other side in order to be disjoint.

--- a/crates/ty_python_semantic/src/types/special_form.rs
+++ b/crates/ty_python_semantic/src/types/special_form.rs
@@ -89,6 +89,8 @@ pub enum SpecialFormType {
     Not,
     /// The symbol `ty_extensions.Intersection`
     Intersection,
+    /// The symbol `ty_extensions.UnsafeUnion`
+    UnsafeUnion,
     /// The symbol `ty_extensions.Overlapping`
     Overlapping,
     /// The symbol `ty_extensions._internal.TypeOf`
@@ -204,6 +206,7 @@ impl SpecialFormType {
             | Self::Top
             | Self::Bottom
             | Self::Intersection
+            | Self::UnsafeUnion
             | Self::Overlapping
             | Self::CallableTypeOf
             | Self::RegularCallableTypeOf
@@ -330,6 +333,7 @@ impl SpecialFormType {
             AlwaysFalsy,
             Not,
             Intersection,
+            UnsafeUnion,
             Overlapping,
             TypeOf,
             CallableTypeOf,
@@ -379,6 +383,7 @@ impl SpecialFormType {
                     SpecialFormType::RegularCallableTypeOf => Self::RegularCallableTypeOf,
                     SpecialFormType::Concatenate => Self::Concatenate,
                     SpecialFormType::Intersection => Self::Intersection,
+                    SpecialFormType::UnsafeUnion => Self::UnsafeUnion,
                     SpecialFormType::Overlapping => Self::Overlapping,
                     SpecialFormType::Literal => Self::Literal,
                     SpecialFormType::LiteralString => Self::LiteralString,
@@ -441,6 +446,7 @@ impl SpecialFormType {
                     SpecialFormTypeBuilder::RegularCallableTypeOf => &[Self::RegularCallableTypeOf],
                     SpecialFormTypeBuilder::Concatenate => &[Self::Concatenate],
                     SpecialFormTypeBuilder::Intersection => &[Self::Intersection],
+                    SpecialFormTypeBuilder::UnsafeUnion => &[Self::UnsafeUnion],
                     SpecialFormTypeBuilder::Overlapping => &[Self::Overlapping],
                     SpecialFormTypeBuilder::Literal => &[Self::Literal],
                     SpecialFormTypeBuilder::LiteralString => &[Self::LiteralString],
@@ -560,6 +566,7 @@ impl SpecialFormType {
             | Self::Top
             | Self::Bottom
             | Self::Intersection
+            | Self::UnsafeUnion
             | Self::Overlapping => module.is_ty_extensions(),
 
             Self::Divergent
@@ -631,6 +638,7 @@ impl SpecialFormType {
             | Self::Top
             | Self::Bottom
             | Self::Intersection
+            | Self::UnsafeUnion
             | Self::Overlapping
             | Self::TypeOf
             | Self::CallableTypeOf
@@ -671,6 +679,7 @@ impl SpecialFormType {
             | Self::RegularCallableTypeOf
             | Self::Concatenate
             | Self::Intersection
+            | Self::UnsafeUnion
             | Self::Literal
             | Self::LiteralString
             | Self::Never
@@ -735,6 +744,7 @@ impl SpecialFormType {
             SpecialFormType::AlwaysFalsy => "AlwaysFalsy",
             SpecialFormType::Not => "Not",
             SpecialFormType::Intersection => "Intersection",
+            SpecialFormType::UnsafeUnion => "UnsafeUnion",
             SpecialFormType::Overlapping => "Overlapping",
             SpecialFormType::TypeOf => "TypeOf",
             SpecialFormType::CallableTypeOf => "CallableTypeOf",
@@ -789,6 +799,7 @@ impl SpecialFormType {
             | SpecialFormType::AlwaysFalsy
             | SpecialFormType::Not
             | SpecialFormType::Intersection
+            | SpecialFormType::UnsafeUnion
             | SpecialFormType::Overlapping
             | SpecialFormType::Top
             | SpecialFormType::Bottom => &[KnownModule::TyExtensions],
@@ -908,7 +919,7 @@ impl SpecialFormType {
             Self::TypeAlias => Err(InvalidTypeExpression::TypeAlias),
             Self::TypedDict(_) => Err(InvalidTypeExpression::TypedDict),
 
-            Self::Literal | Self::Union | Self::Intersection => {
+            Self::Literal | Self::Union | Self::Intersection | Self::UnsafeUnion => {
                 Err(InvalidTypeExpression::RequiresArguments(self))
             }
 

--- a/crates/ty_python_semantic/src/types/subscript.rs
+++ b/crates/ty_python_semantic/src/types/subscript.rs
@@ -24,7 +24,7 @@ use super::instance::SliceLiteral;
 use super::special_form::SpecialFormType;
 use super::{
     IntersectionBuilder, IntersectionType, KnownInstanceType, Type, TypeAliasType, TypedDictType,
-    UnionBuilder, UnionType, todo_type,
+    UnionBuilder, UnionType, UnsafeUnionType, todo_type,
 };
 
 /// The kind of subscriptable type that had an out-of-bounds index.
@@ -415,35 +415,79 @@ where
 fn map_intersection_subscript<'db, F>(
     db: &'db dyn Db,
     intersection: IntersectionType<'db>,
-    mut map_fn: F,
+    map_fn: F,
 ) -> Result<Type<'db>, SubscriptError<'db>>
 where
     F: FnMut(Type<'db>) -> Result<Type<'db>, SubscriptError<'db>>,
 {
     if let Some(alternatives) = intersection.finite_alternative_union(db) {
+        let mut map_fn = map_fn;
         return map_fn(alternatives);
     }
-
-    let mut results = Vec::new();
-    let mut errors = Vec::new();
 
     // Use `positive_elements_or_object` to ensure we always have at least one element.
     // An intersection with only negative elements (e.g., `~int & ~str`) is implicitly
     // `object & ~int & ~str`, so we fall back to `object`.
-    for element in intersection.positive_elements_or_object(db) {
+    map_any_element_subscript(
+        db,
+        intersection.positive_elements_or_object(db),
+        Type::Intersection(intersection),
+        |db, results| {
+            results
+                .into_iter()
+                .fold(IntersectionBuilder::new(db), |builder, result| {
+                    builder.add_positive(result)
+                })
+                .build()
+        },
+        map_fn,
+    )
+}
+
+fn map_unsafe_union_subscript<'db, F>(
+    db: &'db dyn Db,
+    unsafe_union: UnsafeUnionType<'db>,
+    map_fn: F,
+) -> Result<Type<'db>, SubscriptError<'db>>
+where
+    F: FnMut(Type<'db>) -> Result<Type<'db>, SubscriptError<'db>>,
+{
+    map_any_element_subscript(
+        db,
+        unsafe_union.elements(db).iter().copied(),
+        Type::UnsafeUnion(unsafe_union),
+        UnsafeUnionType::from_elements,
+        map_fn,
+    )
+}
+
+/// Subscript a type whose elements are alternatives of which only one need succeed: the positive
+/// elements of an intersection, or the materializations of an unsafe union.
+fn map_any_element_subscript<'db, E, C, F>(
+    db: &'db dyn Db,
+    elements: E,
+    full_object_ty: Type<'db>,
+    combine: C,
+    mut map_fn: F,
+) -> Result<Type<'db>, SubscriptError<'db>>
+where
+    E: IntoIterator<Item = Type<'db>>,
+    C: Fn(&'db dyn Db, Vec<Type<'db>>) -> Type<'db>,
+    F: FnMut(Type<'db>) -> Result<Type<'db>, SubscriptError<'db>>,
+{
+    let mut results = Vec::new();
+    let mut errors = Vec::new();
+
+    for element in elements {
         match map_fn(element) {
             Ok(result) => results.push(result),
             Err(error) => errors.push(error),
         }
     }
 
-    // If any element succeeded, return the intersection of successful results.
+    // If any element succeeded, return the combination of the successful results.
     if !results.is_empty() {
-        let mut builder = IntersectionBuilder::new(db);
-        for result in results {
-            builder = builder.add_positive(result);
-        }
-        return Ok(builder.build());
+        return Ok(combine(db, results));
     }
 
     // All elements failed. Check if any element has the method available
@@ -451,13 +495,12 @@ where
     // for elements that lack the method.
     let any_has_method = errors.iter().any(SubscriptError::any_method_available);
 
-    let mut builder = IntersectionBuilder::new(db);
+    let mut result_types = Vec::new();
     let mut collected_errors = Vec::new();
-    let full_object_ty = Type::Intersection(intersection);
 
     for error in errors {
         if !any_has_method || error.any_method_available() {
-            builder = builder.add_positive(error.result_type());
+            result_types.push(error.result_type());
             let error_iter = error.into_errors().into_iter();
             if any_has_method {
                 collected_errors.extend(
@@ -473,7 +516,7 @@ where
     }
 
     Err(SubscriptError::with_errors(
-        builder.build(),
+        combine(db, result_types),
         collected_errors,
     ))
 }
@@ -610,6 +653,18 @@ impl<'db> Type<'db> {
 
             (_, Type::Intersection(intersection)) => {
                 Some(map_intersection_subscript(db, intersection, |element| {
+                    value_ty.subscript(db, element, expr_context, tcx)
+                }))
+            }
+
+            (Type::UnsafeUnion(unsafe_union), _) => {
+                Some(map_unsafe_union_subscript(db, unsafe_union, |element| {
+                    element.subscript(db, slice_ty, expr_context, tcx)
+                }))
+            }
+
+            (_, Type::UnsafeUnion(unsafe_union)) => {
+                Some(map_unsafe_union_subscript(db, unsafe_union, |element| {
                     value_ty.subscript(db, element, expr_context, tcx)
                 }))
             }

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -1864,6 +1864,11 @@ pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
                 openness,
             })
         }
+        // Unpacking has to be valid whichever materialization this turns out to be, so the
+        // union face is the right shape here.
+        Type::UnsafeUnion(unsafe_union) => {
+            extract_unpacked_typed_dict_from_value_type(db, unsafe_union.to_union(db))
+        }
         Type::TypeAlias(alias) => {
             extract_unpacked_typed_dict_from_value_type(db, alias.value_type(db))
         }

--- a/crates/ty_python_semantic/src/types/unsafe_union.rs
+++ b/crates/ty_python_semantic/src/types/unsafe_union.rs
@@ -1,0 +1,209 @@
+//! `ty_extensions.UnsafeUnion` — a gradual type with a finite set of materializations
+//!
+//! `UnsafeUnion[A, B]` fuses a union with an intersection. like `A | B`, both an `A` and
+//! a `B` can be assigned *to* it. like `A & B`, a value *of* it can be used where an `A`
+//! or where a `B` is wanted, and every member of either type is available on it
+//!
+//! that is `Any` restricted to a finite menu: the materializations of `UnsafeUnion[A, B]`
+//! are `{A, B}` instead of "every type"
+//!
+//! - `X` is assignable to `UnsafeUnion[A, B]` iff `X` is assignable to `A | B` (the union
+//!   face, in target position)
+//! - `UnsafeUnion[A, B]` is assignable to `Y` iff `A` or `B` is assignable to `Y` (the
+//!   intersection face, in source position)
+//! - `UnsafeUnion[A, B]` is disjoint from `Y` iff both `A` and `B` are
+//! - the top materialization is `A | B`; the bottom materialization is `A & B`
+//!
+//! unlike `Any` the menu is finite, so the type still rejects things: passing an
+//! `UnsafeUnion[int, str]` where `bytes` is wanted is an error, and so is reaching for a
+//! member that neither `int` nor `str` has
+//!
+//! ty infers this type when an overload call is ambiguous because of a gradual argument
+//! (step 5 of the overload call evaluation algorithm): the surviving overloads' return
+//! types are exactly the menu of possible results
+
+use crate::Db;
+use crate::place::{
+    DefinedPlace, Definedness, Place, PlaceAndQualifiers, Provenance, PublicTypePolicy, TypeOrigin,
+};
+use crate::types::set_theoretic::UnionType;
+use crate::types::variance::VarianceInferable;
+use crate::types::{
+    BoundTypeVarIdentity, InstanceProjection, Type, TypeQualifiers, TypeVarVariance, visitor,
+};
+
+#[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
+pub struct UnsafeUnionType<'db> {
+    /// The possible materializations of this type. Always at least two elements: an
+    /// `UnsafeUnion` of one type is that type, and of no types is `Never`.
+    #[returns(deref)]
+    pub elements: Box<[Type<'db>]>,
+}
+
+pub(super) fn walk_unsafe_union<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
+    db: &'db dyn Db,
+    unsafe_union: UnsafeUnionType<'db>,
+    visitor: &V,
+) {
+    for element in unsafe_union.elements(db) {
+        visitor.visit_type(db, *element);
+    }
+}
+
+// the salsa heap is tracked separately
+impl get_size2::GetSize for UnsafeUnionType<'_> {}
+
+impl<'db> UnsafeUnionType<'db> {
+    /// Build the unsafe union of `elements`, simplifying it into a different variant of
+    /// [`Type`] where the menu of materializations collapses.
+    pub(crate) fn from_elements<I, T>(db: &'db dyn Db, elements: I) -> Type<'db>
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<Type<'db>>,
+    {
+        let mut collected: Vec<Type<'db>> = Vec::new();
+
+        for element in elements {
+            match element.into() {
+                // a dynamic element admits every materialization, which swallows the whole
+                // menu: `UnsafeUnion[int, Any]` can materialize to anything, so it *is* `Any`
+                dynamic @ Type::Dynamic(_) => return dynamic,
+                Type::UnsafeUnion(nested) => {
+                    for nested_element in nested.elements(db) {
+                        if !collected.contains(nested_element) {
+                            collected.push(*nested_element);
+                        }
+                    }
+                }
+                // `Never` is uninhabited, so it contributes no runtime values to choose
+                // from. keeping it would also make the whole type assignable to everything,
+                // since `Never` is assignable to every type
+                Type::Never => {}
+                element => {
+                    if !collected.contains(&element) {
+                        collected.push(element);
+                    }
+                }
+            }
+        }
+
+        match collected.as_slice() {
+            [] => Type::Never,
+            [single] => *single,
+            _ => Type::UnsafeUnion(Self::new(db, collected.into_boxed_slice())),
+        }
+    }
+
+    /// The top materialization: the union of every type this could materialize to.
+    ///
+    /// This is the type an `UnsafeUnion` is narrowed to when it is used *safely*, and the
+    /// face it presents to operations that must hold for every possible materialization.
+    pub(crate) fn to_union(self, db: &'db dyn Db) -> Type<'db> {
+        UnionType::from_elements(db, self.elements(db).iter().copied())
+    }
+
+    /// Apply `transform` to every element, rebuilding (and possibly collapsing) the menu.
+    pub(crate) fn map_elements(
+        self,
+        db: &'db dyn Db,
+        transform: impl FnMut(Type<'db>) -> Type<'db>,
+    ) -> Type<'db> {
+        Self::from_elements(db, self.elements(db).iter().copied().map(transform))
+    }
+
+    /// A fallible version of [`UnsafeUnionType::map_elements`].
+    pub(crate) fn try_map_elements(
+        self,
+        db: &'db dyn Db,
+        transform: impl FnMut(Type<'db>) -> Option<Type<'db>>,
+    ) -> Option<Type<'db>> {
+        let elements: Option<Vec<_>> = self.elements(db).iter().copied().map(transform).collect();
+        Some(Self::from_elements(db, elements?))
+    }
+
+    /// Project every element from a class-object type into its instance type.
+    pub(crate) fn to_instance(self, db: &'db dyn Db) -> Option<InstanceProjection<Type<'db>>> {
+        let mut is_exact = true;
+        let instance = self.try_map_elements(db, |element| {
+            let projection = element.to_instance(db)?;
+            is_exact &= projection.is_exact();
+            Some(projection.into_inner())
+        })?;
+        Some(InstanceProjection::new(instance, is_exact))
+    }
+
+    /// Look a member up on every element, keeping the ones that have it.
+    ///
+    /// This is the intersection face: the member is available as long as *some*
+    /// materialization has it, and is undefined only when none does. The result is itself
+    /// an unsafe union, so the imprecision keeps propagating rather than silently
+    /// collapsing into a safe union.
+    pub(crate) fn map_with_boundness_and_qualifiers(
+        self,
+        db: &'db dyn Db,
+        mut transform_fn: impl FnMut(&Type<'db>) -> PlaceAndQualifiers<'db>,
+    ) -> PlaceAndQualifiers<'db> {
+        let mut member_types = Vec::new();
+        let mut qualifiers = TypeQualifiers::empty();
+
+        let mut any_definitely_bound = false;
+        let mut origin = TypeOrigin::Declared;
+        let mut provenance = Provenance::Unknown;
+
+        for element in self.elements(db) {
+            let PlaceAndQualifiers {
+                place: member,
+                qualifiers: member_qualifiers,
+            } = transform_fn(element);
+            qualifiers |= member_qualifiers;
+            match member {
+                Place::Undefined => {}
+                Place::Defined(DefinedPlace {
+                    ty: member_ty,
+                    origin: member_origin,
+                    definedness: member_definedness,
+                    provenance: member_provenance,
+                    ..
+                }) => {
+                    origin = origin.merge(member_origin);
+                    if member_definedness == Definedness::AlwaysDefined {
+                        any_definitely_bound = true;
+                    }
+                    provenance = provenance.or(member_provenance);
+                    member_types.push(member_ty);
+                }
+            }
+        }
+
+        PlaceAndQualifiers {
+            place: if member_types.is_empty() {
+                Place::Undefined
+            } else {
+                Place::Defined(DefinedPlace {
+                    ty: Self::from_elements(db, member_types),
+                    origin,
+                    definedness: if any_definitely_bound {
+                        Definedness::AlwaysDefined
+                    } else {
+                        Definedness::PossiblyUndefined
+                    },
+                    public_type_policy: PublicTypePolicy::Raw,
+                    provenance,
+                })
+            },
+            qualifiers,
+        }
+    }
+}
+
+impl<'db> VarianceInferable<'db> for UnsafeUnionType<'db> {
+    /// An `UnsafeUnion` is invariant in its elements: each one is reachable in both
+    /// directions (a value can be assigned *to* the type through it, and read *out* of the
+    /// type as it), so neither polarity alone describes it.
+    fn variance_of(self, db: &'db dyn Db, typevar: BoundTypeVarIdentity<'db>) -> TypeVarVariance {
+        self.elements(db)
+            .iter()
+            .map(|element| TypeVarVariance::Invariant.compose(element.variance_of(db, typevar)))
+            .collect()
+    }
+}

--- a/crates/ty_python_semantic/src/types/visitor.rs
+++ b/crates/ty_python_semantic/src/types/visitor.rs
@@ -11,7 +11,7 @@ use crate::{
         EnumComplementType, GenericAlias, IntersectionType, KnownBoundMethodType,
         KnownInstanceType, NominalInstanceType, OverlappingType, PropertyInstanceType,
         ProtocolInstanceType, StaticClassLiteral, SubclassOfType, Type, TypeAliasType,
-        TypeFormType, TypeGuardType, TypeIsType, TypedDictType, UnionType,
+        TypeFormType, TypeGuardType, TypeIsType, TypedDictType, UnionType, UnsafeUnionType,
         bound_super::walk_bound_super_type,
         callable::walk_callable_type,
         class::walk_generic_alias,
@@ -30,6 +30,7 @@ use crate::{
         type_form::walk_typeform_type,
         typed_dict::walk_typed_dict_type,
         typevar::{TypeVarInstance, walk_bound_type_var_type, walk_type_var_type},
+        unsafe_union::walk_unsafe_union,
         walk_property_instance_type, walk_typeguard_type, walk_typeis_type,
     },
 };
@@ -47,6 +48,10 @@ pub(crate) trait TypeVisitor<'db> {
 
     fn visit_union_type(&self, db: &'db dyn Db, union: UnionType<'db>) {
         walk_union(db, union, self);
+    }
+
+    fn visit_unsafe_union_type(&self, db: &'db dyn Db, unsafe_union: UnsafeUnionType<'db>) {
+        walk_unsafe_union(db, unsafe_union, self);
     }
 
     fn visit_intersection_type(&self, db: &'db dyn Db, intersection: IntersectionType<'db>) {
@@ -152,6 +157,7 @@ pub(crate) trait TypeVisitor<'db> {
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub(super) enum NonAtomicType<'db> {
     Union(UnionType<'db>),
+    UnsafeUnion(UnsafeUnionType<'db>),
     Intersection(IntersectionType<'db>),
     EnumComplement(EnumComplementType<'db>),
     FunctionLiteral(FunctionType<'db>),
@@ -208,6 +214,9 @@ impl<'db> From<Type<'db>> for TypeKind<'db> {
                 TypeKind::NonAtomic(NonAtomicType::EnumComplement(complement))
             }
             Type::Union(union) => TypeKind::NonAtomic(NonAtomicType::Union(union)),
+            Type::UnsafeUnion(unsafe_union) => {
+                TypeKind::NonAtomic(NonAtomicType::UnsafeUnion(unsafe_union))
+            }
             Type::BoundMethod(method) => TypeKind::NonAtomic(NonAtomicType::BoundMethod(method)),
             Type::BoundSuper(bound_super) => {
                 TypeKind::NonAtomic(NonAtomicType::BoundSuper(bound_super))
@@ -269,6 +278,9 @@ pub(super) fn walk_non_atomic_type<'db, V: TypeVisitor<'db> + ?Sized>(
             visitor.visit_enum_complement_type(db, complement);
         }
         NonAtomicType::Union(union) => visitor.visit_union_type(db, union),
+        NonAtomicType::UnsafeUnion(unsafe_union) => {
+            visitor.visit_unsafe_union_type(db, unsafe_union);
+        }
         NonAtomicType::BoundMethod(method) => visitor.visit_bound_method_type(db, method),
         NonAtomicType::BoundSuper(bound_super) => visitor.visit_bound_super_type(db, bound_super),
         NonAtomicType::MethodWrapper(method_wrapper) => {

--- a/crates/ty_vendored/ty_extensions/__init__.pyi
+++ b/crates/ty_vendored/ty_extensions/__init__.pyi
@@ -62,6 +62,41 @@ s: Intersection[P, Q] = S()
 ```
 """
 
+UnsafeUnion: _SpecialForm
+"""
+`UnsafeUnion[T1, T2, ..., Tn]` fuses a union with an intersection: it is a *gradual* type whose
+possible materializations are exactly `T1`, `T2`, ..., `Tn`.
+
+Like a union, any `T1` or any `T2` can be assigned *to* it. Like an intersection, a value *of* it
+can be used where a `T1` or where a `T2` is wanted, and offers the members of both:
+
+```python
+def f(a: UnsafeUnion[int, str]):
+    a.imag    # ok: `int` has it
+    a.upper() # ok: `str` has it
+
+f(1)   # ok
+f("s") # ok
+```
+
+Unlike `Any` the menu of materializations is finite, so the type still rejects things: an
+`UnsafeUnion[int, str]` is not assignable to `bytes`, and a member that neither `int` nor `str`
+has is still an error.
+
+ty infers this type when a call to an overloaded function is ambiguous because an argument is
+gradual, since the surviving overloads' return types are exactly the possible results:
+
+```python
+@overload
+def g(a: int) -> int: ...
+@overload
+def g(a: str) -> str: ...
+
+def h(a: Any):
+    reveal_type(g(a))  # revealed: UnsafeUnion[int, str]
+```
+"""
+
 Top: _SpecialForm
 """
 `Top[T]` represents the "top materialization" of `T`.

--- a/docs/basedpython/features/index.md
+++ b/docs/basedpython/features/index.md
@@ -24,6 +24,7 @@ type-checking improvements with no new syntax — they work in `.by` and `.py` f
 - [intersection types](intersection.md)
 - [`or` / `and` type operators](or-and-types.md)
 - [negation types (`not T`)](not-type.md)
+- [unsafe unions](unsafe-union.md)
 - [`dynamic` type](dynamic.md)
 - [`typeof` keyword](typeof.md)
 - [star projections (`X[*]`)](star-projection.md)

--- a/docs/basedpython/features/unsafe-union.md
+++ b/docs/basedpython/features/unsafe-union.md
@@ -1,0 +1,91 @@
+# unsafe unions
+
+`UnsafeUnion[A, B]` is a gradual type whose materializations are exactly `A` and
+`B`. it fuses a union with an intersection: a union on the way *in*, an
+intersection on the way *out*
+
+```by
+from ty_extensions import UnsafeUnion
+
+def f(a: UnsafeUnion[int, str]):
+    a.imag    # ok — `int` has it
+    a.upper() # ok — `str` has it
+
+f(1)   # ok
+f("s") # ok
+```
+
+it is `Any` restricted to a finite menu. because the menu is finite, the type
+still rejects things: `UnsafeUnion[int, str]` is not assignable to `bytes`, and a
+member that neither `int` nor `str` has is still an error
+
+```by
+from ty_extensions import UnsafeUnion
+
+def takes_bytes(x: bytes): ...
+
+def f(a: UnsafeUnion[int, str]):
+    takes_bytes(a)   # error — neither materialization is a `bytes`
+    a.nonexistent    # error — no materialization has it
+```
+
+## the two faces
+
+- **in** (target position) it behaves as `A | B`: every materialization is a
+    valid thing to store, so it accepts whatever the plain union accepts
+- **out** (source position) it behaves as an intersection: the value *is* one of
+    its materializations, so it goes wherever any single materialization can go,
+    and offers the members of all of them
+
+neither face is a subtype relation. like every gradual type, an unsafe union is a
+subtype only of `object`. its top materialization is `A | B` and its bottom
+materialization is `A & B`
+
+it is disjoint from a type only when *every* materialization is:
+`UnsafeUnion[int, str]` overlaps `int`, and is disjoint from `None`
+
+## where it comes from
+
+writing `UnsafeUnion[...]` by hand is rare. the type exists mainly because ty
+infers it for an overload call that stays ambiguous because an argument is
+[`dynamic`](dynamic.md)
+
+```by
+from typing import overload
+
+@overload
+def f(a: int) -> int: ...
+@overload
+def f(a: str) -> str: ...
+def f(a: int | str) -> int | str:
+    return a
+
+def m(a: dynamic):
+    reveal_type(f(a))  # UnsafeUnion[int, str]
+```
+
+[step 5 of the overload call evaluation algorithm][overloads] says such a call
+evaluates to `Any`, throwing away everything we know. the call can only return an
+`int` or a `str`, and that is exactly what an unsafe union describes — so the
+result stays usable as either, while a `bytes` is still rejected
+
+the same applies to an overloaded constructor whose `__new__` can return
+something other than an instance of the class, and to a metaclass `__call__`
+
+## simplification
+
+a menu of one is not a choice, and nested menus flatten:
+
+```by
+UnsafeUnion[int, int]                    # int
+UnsafeUnion[int, UnsafeUnion[str, bytes]] # UnsafeUnion[int, str, bytes]
+```
+
+the order of the menu does not matter: `UnsafeUnion[int, str]` and
+`UnsafeUnion[str, int]` are the same type
+
+a materialization that admits every type swallows the menu, so
+`UnsafeUnion[int, Any]` is just `Any`. `Never` is uninhabited and contributes no
+values to choose from, so `UnsafeUnion[int, Never]` is `int`
+
+[overloads]: https://typing.python.org/en/latest/spec/overload.html#overload-call-evaluation


### PR DESCRIPTION
`UnsafeUnion[A, B]` is a gradual type whose materializations are exactly `A` and `B`: a union in target position, an intersection in source position. it is what an ambiguous overload call now evaluates to instead of `Unknown`, so the menu of possible returns survives.