### PR TITLE
infer types for unannotated pytest fixture parameters

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/external/pytest.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/pytest.md
@@ -83,3 +83,63 @@ def test_add(a: int, b: int) -> None: ...
 @pytest.mark.parametrize("a, missing", [(1, 2)])  # error: [invalid-parametrize]
 def test_missing(a: int) -> None: ...
 ```
+
+## Unannotated parameters take the fixture's type
+
+An unannotated parameter is bound by pytest to the fixture of that name, so it takes the fixture's
+provided type rather than staying gradual — for a user fixture, for a builtin like `tmp_path`, and
+across a `conftest.py`.
+
+`conftest.py`:
+
+```py
+import pytest
+
+@pytest.fixture
+def db() -> str:
+    return "sqlite://"
+```
+
+`test_unannotated.py`:
+
+```py
+import pytest
+from typing import Iterator
+
+@pytest.fixture
+def port() -> int:
+    return 5432
+
+@pytest.fixture
+def handle() -> Iterator[bytes]:
+    yield b""
+
+def test_it(port, handle, db, tmp_path) -> None:
+    reveal_type(port)  # revealed: int
+    reveal_type(handle)  # revealed: bytes
+    reveal_type(db)  # revealed: str
+    reveal_type(tmp_path)  # revealed: Path
+    # the injected type is usable: a real attribute resolves, a bogus one is an error
+    reveal_type(tmp_path.name)  # revealed: str
+    port.bit_length()
+    port.no_such_method  # error: [unresolved-attribute]
+```
+
+## Parametrized names are arguments, not fixtures
+
+A name `@pytest.mark.parametrize` supplies comes from the marker's value rows, not the registry, so
+it is not fixture-typed even when a fixture of that name exists.
+
+`test_parametrized.py`:
+
+```py
+import pytest
+
+@pytest.fixture
+def value() -> int:
+    return 1
+
+@pytest.mark.parametrize("value", ["a", "b"])
+def test_it(value) -> None:
+    reveal_type(value)  # revealed: Unknown
+```

--- a/crates/ty_python_semantic/resources/mdtest/pytest.md
+++ b/crates/ty_python_semantic/resources/mdtest/pytest.md
@@ -8,7 +8,8 @@ fixtures and `parametrize` — against the real package.
 pytest fills a test or fixture parameter by *name* from a registry: the function's own module, then
 the `conftest.py` chain, then builtin fixtures. A parameter annotation that disagrees with the
 resolved fixture's type is an error; the fixture's provided type is its return annotation, with a
-yield fixture's `Iterator[T]` / `Generator[T, ...]` unwrapped to `T`.
+yield fixture's `Iterator[T]` / `Generator[T, ...]` unwrapped to `T`. An *unannotated* parameter
+takes that provided type instead of the implicit `Unknown` an ordinary parameter would get.
 
 ## Fixture resolution and type checking
 
@@ -198,4 +199,271 @@ def fixture(function: None = ..., *, scope: str = ..., name: str | None = None) 
 ```py
 def test_it(missing) -> None:  # error: [unknown-fixture]
     ...
+```
+
+## Unannotated parameters take the fixture's type
+
+An unannotated parameter is bound by pytest to the fixture of the same name, so the body sees that
+fixture's provided type — including through a rename, a yield fixture's unwrapping, and the
+`conftest.py` chain. A name that resolves to no fixture stays gradual, as does one whose fixture has
+no derivable type.
+
+```toml
+[environment]
+python = "/.venv"
+```
+
+`/.venv/<path-to-site-packages>/pytest/__init__.pyi`:
+
+```pyi
+from _pytest.fixtures import fixture as fixture
+```
+
+`/.venv/<path-to-site-packages>/_pytest/__init__.pyi`:
+
+```pyi
+```
+
+`/.venv/<path-to-site-packages>/_pytest/fixtures.pyi`:
+
+```pyi
+from typing import Any, Callable, overload
+
+class FixtureFunctionDefinition: ...
+
+class FixtureFunctionMarker:
+    def __call__(self, function: Callable[..., Any]) -> FixtureFunctionDefinition: ...
+
+@overload
+def fixture(function: Callable[..., Any], *, scope: str = ..., name: str | None = None) -> FixtureFunctionDefinition: ...
+@overload
+def fixture(function: None = ..., *, scope: str = ..., name: str | None = None) -> FixtureFunctionMarker: ...
+```
+
+`conftest.py`:
+
+```py
+import pytest
+
+@pytest.fixture
+def from_conftest() -> bytes:
+    return b""
+```
+
+`test_unannotated.py`:
+
+```py
+import pytest
+from typing import Iterator
+
+@pytest.fixture
+def number() -> int:
+    return 1
+
+@pytest.fixture(name="renamed")
+def _make_text() -> str:
+    return "x"
+
+@pytest.fixture
+def yielded() -> Iterator[bool]:
+    yield True
+
+@pytest.fixture
+def untyped():
+    return object()
+
+def test_it(number, renamed, yielded, from_conftest, untyped, missing) -> None:  # error: [unknown-fixture]
+    reveal_type(number)  # revealed: int
+    reveal_type(renamed)  # revealed: str
+    reveal_type(yielded)  # revealed: bool
+    reveal_type(from_conftest)  # revealed: bytes
+    reveal_type(untyped)  # revealed: Unknown
+    reveal_type(missing)  # revealed: Unknown
+```
+
+## A fixture's own parameters take fixture types
+
+Fixtures request fixtures the same way tests do, so an unannotated parameter of a `@pytest.fixture`
+function is typed from the registry too — including when the fixture it requests is defined later in
+the module.
+
+```toml
+[environment]
+python = "/.venv"
+```
+
+`/.venv/<path-to-site-packages>/pytest/__init__.pyi`:
+
+```pyi
+from _pytest.fixtures import fixture as fixture
+```
+
+`/.venv/<path-to-site-packages>/_pytest/__init__.pyi`:
+
+```pyi
+```
+
+`/.venv/<path-to-site-packages>/_pytest/fixtures.pyi`:
+
+```pyi
+from typing import Any, Callable, overload
+
+class FixtureFunctionDefinition: ...
+
+class FixtureFunctionMarker:
+    def __call__(self, function: Callable[..., Any]) -> FixtureFunctionDefinition: ...
+
+@overload
+def fixture(function: Callable[..., Any], *, scope: str = ..., name: str | None = None) -> FixtureFunctionDefinition: ...
+@overload
+def fixture(function: None = ..., *, scope: str = ..., name: str | None = None) -> FixtureFunctionMarker: ...
+```
+
+`test_chained.py`:
+
+```py
+import pytest
+
+@pytest.fixture
+def outer(inner) -> str:
+    reveal_type(inner)  # revealed: int
+    return str(inner)
+
+@pytest.fixture
+def inner() -> int:
+    return 1
+
+def test_it(outer) -> None:
+    reveal_type(outer)  # revealed: str
+```
+
+## Parametrized names are arguments, not fixtures
+
+`@pytest.mark.parametrize` supplies a name from its value rows rather than from the fixture
+registry, so a parametrized parameter is not fixture-typed even when a fixture of that name exists.
+
+```toml
+[environment]
+python = "/.venv"
+```
+
+`/.venv/<path-to-site-packages>/pytest/__init__.pyi`:
+
+```pyi
+from _pytest.fixtures import fixture as fixture
+from _pytest.mark.structures import MarkGenerator as MarkGenerator
+
+mark: MarkGenerator
+```
+
+`/.venv/<path-to-site-packages>/_pytest/__init__.pyi`:
+
+```pyi
+```
+
+`/.venv/<path-to-site-packages>/_pytest/mark/__init__.pyi`:
+
+```pyi
+```
+
+`/.venv/<path-to-site-packages>/_pytest/mark/structures.pyi`:
+
+```pyi
+from typing import Any
+
+class MarkDecorator:
+    def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
+
+class MarkGenerator:
+    def __getattr__(self, name: str) -> MarkDecorator: ...
+```
+
+`/.venv/<path-to-site-packages>/_pytest/fixtures.pyi`:
+
+```pyi
+from typing import Any, Callable, overload
+
+class FixtureFunctionDefinition: ...
+
+class FixtureFunctionMarker:
+    def __call__(self, function: Callable[..., Any]) -> FixtureFunctionDefinition: ...
+
+@overload
+def fixture(function: Callable[..., Any], *, scope: str = ..., name: str | None = None) -> FixtureFunctionDefinition: ...
+@overload
+def fixture(function: None = ..., *, scope: str = ..., name: str | None = None) -> FixtureFunctionMarker: ...
+```
+
+`test_parametrized.py`:
+
+```py
+import pytest
+
+@pytest.fixture
+def value() -> int:
+    return 1
+
+@pytest.mark.parametrize("value", ["a", "b"])
+def test_it(value) -> None:
+    # supplied by the marker, so the same-named fixture does not apply
+    reveal_type(value)  # revealed: Unknown
+
+@pytest.mark.parametrize("other", ["a", "b"])
+def test_mixed(other, value) -> None:
+    reveal_type(other)  # revealed: Unknown
+    reveal_type(value)  # revealed: int
+```
+
+## Ordinary functions are untouched
+
+A function pytest does not manage keeps the ordinary rules for an unannotated parameter, even when a
+fixture of that name is in scope.
+
+```toml
+[environment]
+python = "/.venv"
+```
+
+`/.venv/<path-to-site-packages>/pytest/__init__.pyi`:
+
+```pyi
+from _pytest.fixtures import fixture as fixture
+```
+
+`/.venv/<path-to-site-packages>/_pytest/__init__.pyi`:
+
+```pyi
+```
+
+`/.venv/<path-to-site-packages>/_pytest/fixtures.pyi`:
+
+```pyi
+from typing import Any, Callable, overload
+
+class FixtureFunctionDefinition: ...
+
+class FixtureFunctionMarker:
+    def __call__(self, function: Callable[..., Any]) -> FixtureFunctionDefinition: ...
+
+@overload
+def fixture(function: Callable[..., Any], *, scope: str = ..., name: str | None = None) -> FixtureFunctionDefinition: ...
+@overload
+def fixture(function: None = ..., *, scope: str = ..., name: str | None = None) -> FixtureFunctionMarker: ...
+```
+
+`test_ordinary.py`:
+
+```py
+import pytest
+
+@pytest.fixture
+def number() -> int:
+    return 1
+
+# a helper, not a test: pytest never calls it, so `number` is an ordinary parameter
+def helper(number) -> None:
+    reveal_type(number)  # revealed: Unknown
+
+def test_it() -> None:
+    helper("anything")
 ```

--- a/crates/ty_python_semantic/src/types/dedicated/pytest.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pytest.rs
@@ -6,7 +6,9 @@
 //! fixtures. no ordinary checker validates this, so a parameter annotated
 //! with a type that drifts from the fixture's real type checks the body
 //! against a lie, and a renamed fixture leaves a request that only fails at
-//! collection time.
+//! collection time. an *unannotated* parameter is the common case, and
+//! nothing else in the language can type it: only the registry knows what
+//! pytest will bind, so [`injected_parameter_type`] supplies it.
 //!
 //! detection is semantic: a function is a fixture because a decorator
 //! resolves to `_pytest.fixtures.fixture` (`KnownFunction::PytestFixture`),
@@ -21,13 +23,14 @@ use ruff_db::files::{File, FilePath, system_path_to_file};
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast::name::Name;
 use ruff_python_ast::{self as ast};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use ty_module_resolver::{KnownModule, ModuleName, file_to_module, resolve_module_confident};
 use ty_python_core::definition::Definition;
 use ty_python_core::semantic_index;
 
 use crate::Db;
 use crate::place::known_module_symbol;
+use crate::types::dedicated::role::function_framework_role;
 use crate::types::{
     FunctionType, KnownClass, KnownFunction, Type, definition_expression_type,
     infer_definition_types,
@@ -279,10 +282,92 @@ pub(in crate::types) fn is_mark_generator<'db>(db: &'db dyn Db, ty: Type<'db>) -
             == Some(KnownModule::PytestMarkStructures)
 }
 
+/// a `@pytest.mark.parametrize` marker on a test, with the expressions a
+/// check anchors its diagnostics to.
+pub(in crate::types) struct ParametrizeMarker<'ast> {
+    /// the `argnames` expression
+    pub(in crate::types) argnames: &'ast ast::Expr,
+    /// the names parsed out of `argnames`
+    pub(in crate::types) names: Vec<Name>,
+    /// the `argvalues` expression, when one is supplied
+    pub(in crate::types) argvalues: Option<&'ast ast::Expr>,
+}
+
+/// the `@pytest.mark.parametrize` marker `decorator` applies to `function`.
+/// `None` when `decorator` is any other decorator, or when its argnames are
+/// not static literals (dynamic → not checkable).
+pub(in crate::types) fn parametrize_marker<'ast>(
+    db: &dyn Db,
+    function: FunctionType<'_>,
+    decorator: &'ast ast::Decorator,
+) -> Option<ParametrizeMarker<'ast>> {
+    let ast::Expr::Call(call) = &decorator.expression else {
+        return None;
+    };
+    let ast::Expr::Attribute(attribute) = call.func.as_ref() else {
+        return None;
+    };
+    if attribute.attr.as_str() != "parametrize" {
+        return None;
+    }
+    let types = infer_definition_types(db, function.definition(db));
+    if !is_mark_generator(db, types.expression_type(attribute.value.as_ref())) {
+        return None;
+    }
+    let argnames = call.arguments.find_argument_value("argnames", 0)?;
+    Some(ParametrizeMarker {
+        names: parametrize_names(argnames)?,
+        argnames,
+        argvalues: call.arguments.find_argument_value("argvalues", 1),
+    })
+}
+
+/// the parameter names `@pytest.mark.parametrize` supplies to `function`.
+///
+/// pytest passes these as ordinary arguments from the marker's value rows, so
+/// they are not fixture requests: they neither resolve against the registry
+/// nor take a fixture's type.
+#[salsa::tracked(returns(ref), heap_size = ruff_memory_usage::heap_size)]
+pub(in crate::types) fn parametrized_names(
+    db: &dyn Db,
+    function: FunctionType<'_>,
+) -> FxHashSet<Name> {
+    let file = function.file(db);
+    let module = parsed_module(db, file).load(db);
+    let mut names: FxHashSet<Name> = function
+        .node(db, file, &module)
+        .decorator_list
+        .iter()
+        .filter_map(|decorator| parametrize_marker(db, function, decorator))
+        .flat_map(|marker| marker.names)
+        .collect();
+    names.shrink_to_fit();
+    names
+}
+
+/// the type an unannotated parameter named `name` of `function` receives.
+///
+/// pytest binds such a parameter by name from the fixture registry, so the
+/// body sees the fixture's provided type rather than an implicit `Unknown`.
+/// `None` — leaving the parameter gradual — when `function` is not a pytest
+/// function, when the name is supplied by `parametrize` instead, or when no
+/// fixture resolves or the resolved one's type cannot be derived.
+pub(in crate::types) fn injected_parameter_type<'db>(
+    db: &'db dyn Db,
+    function: FunctionType<'db>,
+    name: &str,
+) -> Option<Type<'db>> {
+    function_framework_role(db, function)?;
+    if parametrized_names(db, function).contains(name) {
+        return None;
+    }
+    resolve_fixture(db, function.file(db), name)?.provided_type
+}
+
 /// parse `@pytest.mark.parametrize` argnames — a comma-separated string or a
 /// list/tuple of string literals — into the parametrized names. `None` when
 /// the argnames are not a static string literal (dynamic → not checkable).
-pub(in crate::types) fn parametrize_names(argnames: &ast::Expr) -> Option<Vec<Name>> {
+fn parametrize_names(argnames: &ast::Expr) -> Option<Vec<Name>> {
     fn names_from_elements(elements: &[ast::Expr]) -> Option<Vec<Name>> {
         elements
             .iter()

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -384,10 +384,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return;
         }
 
+        self.check_parametrize(function_node, function);
+
         // parametrized names are supplied as arguments, not by fixtures, so
-        // collect them first to exclude them from the fixture resolution below
-        let mut parametrized = FxHashSet::default();
-        self.check_parametrize(function_node, function, &mut parametrized);
+        // they are excluded from the fixture resolution below
+        let parametrized = pytest::parametrized_names(db, function);
 
         let file = self.file();
         let callable = function.signature(db);
@@ -452,17 +453,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
     }
 
-    /// Check every `@pytest.mark.parametrize` marker on `function_node`,
-    /// recording the parametrized names in `parametrized`.
-    fn check_parametrize(
-        &self,
-        function_node: &ast::StmtFunctionDef,
-        function: FunctionType<'db>,
-        parametrized: &mut FxHashSet<ast::name::Name>,
-    ) {
+    /// Check every `@pytest.mark.parametrize` marker on `function_node`: each
+    /// name against the function's parameters, and each value row's length
+    /// against the number of names.
+    fn check_parametrize(&self, function_node: &ast::StmtFunctionDef, function: FunctionType<'db>) {
         let db = self.db();
-        let definition = function.definition(db);
-        let types = infer_definition_types(db, definition);
         let callable = function.signature(db);
         let parameter_names: FxHashSet<&ast::name::Name> = callable
             .iter()
@@ -477,42 +472,27 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .unwrap_or_default();
 
         for decorator in &function_node.decorator_list {
-            let ast::Expr::Call(call) = &decorator.expression else {
-                continue;
-            };
-            let ast::Expr::Attribute(attribute) = call.func.as_ref() else {
-                continue;
-            };
-            if attribute.attr.as_str() != "parametrize" {
-                continue;
-            }
-            if !pytest::is_mark_generator(db, types.expression_type(attribute.value.as_ref())) {
-                continue;
-            }
-            let Some(argnames) = call.arguments.find_argument_value("argnames", 0) else {
-                continue;
-            };
-            let Some(names) = pytest::parametrize_names(argnames) else {
+            let Some(marker) = pytest::parametrize_marker(db, function, decorator) else {
                 continue;
             };
 
-            for name in &names {
-                parametrized.insert(name.clone());
-                if !parameter_names.contains(name) {
-                    if let Some(builder) = self.context.report_lint(&INVALID_PARAMETRIZE, argnames)
-                    {
-                        builder.into_diagnostic(format_args!(
-                            "`{}` has no parameter `{name}` to parametrize",
-                            function_node.name,
-                        ));
-                    }
+            for name in &marker.names {
+                if !parameter_names.contains(name)
+                    && let Some(builder) = self
+                        .context
+                        .report_lint(&INVALID_PARAMETRIZE, marker.argnames)
+                {
+                    builder.into_diagnostic(format_args!(
+                        "`{}` has no parameter `{name}` to parametrize",
+                        function_node.name,
+                    ));
                 }
             }
 
-            if names.len() > 1 {
-                if let Some(argvalues) = call.arguments.find_argument_value("argvalues", 1) {
-                    self.check_parametrize_arity(argvalues, names.len());
-                }
+            if marker.names.len() > 1
+                && let Some(argvalues) = marker.argvalues
+            {
+                self.check_parametrize_arity(argvalues, marker.names.len());
             }
         }
     }
@@ -1225,6 +1205,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 ty
             } else if let Some(ty) = inherited {
                 ty
+            } else if let Some(ty) = self.pytest_fixture_parameter_type(parameter) {
+                ty
             } else {
                 Type::unknown()
             };
@@ -1232,6 +1214,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             self.add_binding(parameter.into(), definition)
                 .insert(self, ty);
         }
+    }
+
+    /// basedpython: for an unannotated parameter of a pytest test or fixture,
+    /// the type of the fixture pytest binds it to by name. an annotated
+    /// parameter is instead *checked* against that fixture, by
+    /// [`check_pytest_function`].
+    ///
+    /// [`check_pytest_function`]: Self::check_pytest_function
+    fn pytest_fixture_parameter_type(&self, parameter: &ast::Parameter) -> Option<Type<'db>> {
+        let db = self.db();
+        let function = nearest_enclosing_function(db, self.index, self.scope())?;
+        pytest::injected_parameter_type(db, function, parameter.name.as_str())
     }
 
     /// basedpython: for an unannotated parameter inside the implementation of

--- a/docs/basedpython/frameworks/pytest.md
+++ b/docs/basedpython/frameworks/pytest.md
@@ -1,12 +1,13 @@
 # pytest support
 
-basedpython understands pytest's fixture system. fixture parameters check correctly against their types, and tests using basedpython features work at runtime.
+basedpython understands pytest's fixture system. fixture parameters are typed from the fixtures they request, and tests using basedpython features work at runtime.
 
 ## what works
 
 ### fixtures and dependency injection
 
 - fixture parameters resolve correctly by name
+- an unannotated parameter takes the fixture's type, so the body sees `int` rather than `Unknown` for a fixture returning `int` — no annotation needed just to get checking
 - fixture type mismatches are caught: if a test requests `db: Database` but the fixture provides `Connection`, you'll get a type error
 - builtin fixtures: `tmp_path`, `monkeypatch`, `capsys`, `tmp_path_factory`, and others from pytest's stubs all have their correct types
 - yield fixtures: `Iterator[T]` and `Generator[T, ...]` unwrap to `T`
@@ -29,7 +30,7 @@ basedpython understands pytest's fixture system. fixture parameters check correc
 
 ### plugin-provided fixtures
 
-third-party pytest plugins that inject fixtures via entry points aren't discovered. builtin fixtures work, but plugin fixtures like `django_db` or `flask_app` won't be recognized by the type checker.
+third-party pytest plugins that inject fixtures via entry points aren't discovered. builtin fixtures work, but plugin fixtures like `django_db` or `flask_app` won't be recognized by the type checker, so an unannotated parameter requesting one stays `Unknown`.
 
 **workaround:** annotate the parameter explicitly:
 


### PR DESCRIPTION
pytest binds a test/fixture parameter by name from the fixture registry, but only annotated parameters were checked against it — an unannotated one was left as Unknown. it now takes the fixture's provided type

also extracts the parametrize marker recognition into pytest.rs so the check pass and the new inference share one definition of what a marker is