### PR TITLE
added attribute types

### DIFF
--- a/crates/by_transforms/src/transforms/ast_driver.rs
+++ b/crates/by_transforms/src/transforms/ast_driver.rs
@@ -108,6 +108,11 @@ pub(crate) struct PassContext {
     /// [`walk_type_positions_skipping`](super::type_expr_walker::walk_type_positions_skipping)
     /// so they don't re-process an operation that no longer appears in the output
     pub(crate) claimed_type_op_ranges: Vec<TextRange>,
+    /// The same operations as `(range, rendered)` pairs. A pass that replaces a
+    /// whole statement subsumes any fold inside it — skipping is not enough, the
+    /// rendered text has to be spliced into the replacement or the operation is
+    /// re-emitted from source and reaches the runtime
+    pub(crate) symbolic_substitutions: Vec<(TextRange, String)>,
 }
 
 /// A single AST-level rewrite pass.
@@ -387,6 +392,7 @@ pub(crate) fn run_against_source<'a>(
     let symbolic_needs_literal_import = symbolic_folds.needs_literal_import;
     let symbolic_needs_any_import = symbolic_folds.needs_any_import;
     ctx.claimed_type_op_ranges = symbolic_folds.claimed_ranges();
+    ctx.symbolic_substitutions = symbolic_folds.substitutions();
     let symbolic_pass = symbolic_type_op::SymbolicTypeOp::new(symbolic_folds);
 
     // a `typeof` nested under a structural type-form (`&` / `or` / `not` / an

--- a/crates/by_transforms/src/transforms/callable.rs
+++ b/crates/by_transforms/src/transforms/callable.rs
@@ -780,14 +780,30 @@ fn is_named(expr: &Expr, ident: &str) -> bool {
 /// any synthesized `Protocol` class are emitted by the `callable` pass's own
 /// visit of the same expression — keyed by the same shape hash, so a callable
 /// arrow here resolves to the same hoisted class name — and so are not returned.
+///
+/// `substitutions` are ranges another transform has already lowered — a symbolic
+/// fold (`T.a` → `int`), a typevar rename (`T` → `_T`). They are honoured on every
+/// rendering path, which is what lets one wide edit carry rewrites it subsumes.
 pub(crate) fn lower_type_expr_full(
     source: &str,
     types: &dyn TypeInfo,
     expr: &Expr,
+    substitutions: &[(TextRange, String)],
 ) -> Option<String> {
     let mut inner = CallableSyntax::new(source).with_types(types);
+    for (range, name) in substitutions {
+        inner.add_substitution(*range, name.clone());
+    }
     if let Some(text) = inner.rewrite(expr) {
         return Some(text);
+    }
+    if substitutions
+        .iter()
+        .any(|(range, _)| expr.range().contains_range(*range))
+    {
+        // nothing structural to lower, but a subsumed rewrite still has to reach the
+        // output, so render the expression through the substitution sweep
+        return Some(inner.lower_type_expr(expr));
     }
     // no structural type-form — fall back to the per-leaf composer
     // (`float` → `JustFloat`, a literal → `Literal[…]`, `dynamic` → `Any`)

--- a/crates/by_transforms/src/transforms/generics.rs
+++ b/crates/by_transforms/src/transforms/generics.rs
@@ -52,6 +52,9 @@ pub(crate) struct GenericPolyfill<'src> {
     /// alias value is subsumed by this pass's whole-statement replacement, so
     /// the rename has to be reapplied there
     private_aliases: HashMap<String, String>,
+    /// `(range, rendered)` for every symbolic fold in the module. A fold inside a
+    /// statement this pass replaces wholesale is dropped unless spliced in here
+    symbolic_substitutions: Vec<(TextRange, String)>,
 }
 
 #[derive(Default)]
@@ -112,7 +115,12 @@ impl ImportNeeds {
 }
 
 impl<'src> GenericPolyfill<'src> {
-    pub(crate) fn new(source: &'src str, types: &'src dyn TypeInfo, config: Config) -> Self {
+    pub(crate) fn new(
+        source: &'src str,
+        types: &'src dyn TypeInfo,
+        config: Config,
+        symbolic_substitutions: Vec<(TextRange, String)>,
+    ) -> Self {
         Self {
             source,
             types,
@@ -126,7 +134,18 @@ impl<'src> GenericPolyfill<'src> {
             needed_imports_any: false,
             generic_class_renames: HashMap::new(),
             private_aliases: HashMap::new(),
+            symbolic_substitutions,
         }
+    }
+
+    /// the symbolic folds that fall inside `range`, ready to splice into a
+    /// replacement that subsumes them
+    fn substitutions_within(&self, range: TextRange) -> Vec<(TextRange, String)> {
+        self.symbolic_substitutions
+            .iter()
+            .filter(|(folded, _)| range.contains_range(*folded))
+            .cloned()
+            .collect()
     }
 
     /// pre-scan for `private type` aliases so a reference inside a later
@@ -325,16 +344,26 @@ impl<'src> GenericPolyfill<'src> {
                                     format!("tuple[{inner}]")
                                 }
                             } else {
-                                lower_type_expr_full(self.source, self.types, bound)
-                                    .unwrap_or_else(|| self.src(bound.range()).to_owned())
+                                lower_type_expr_full(
+                                    self.source,
+                                    self.types,
+                                    bound,
+                                    &self.substitutions_within(bound.range()),
+                                )
+                                .unwrap_or_else(|| self.src(bound.range()).to_owned())
                             };
                             extra_args.push(format!("bound={bound_src}"));
                         }
                     }
 
                     if let Some(default) = &tv.default {
-                        let default_src = lower_type_expr_full(self.source, self.types, default)
-                            .unwrap_or_else(|| self.src(default.range()).to_owned());
+                        let default_src = lower_type_expr_full(
+                            self.source,
+                            self.types,
+                            default,
+                            &self.substitutions_within(default.range()),
+                        )
+                        .unwrap_or_else(|| self.src(default.range()).to_owned());
                         if self.config.min_version < PythonVersion::PY313 {
                             self.needed_imports.typevar_needs_ext = true;
                         }
@@ -677,10 +706,6 @@ impl<'src> GenericPolyfill<'src> {
             self.src(alias.name.range()).to_owned()
         };
         let raw_value_src = self.src(alias.value.range()).to_owned();
-        // Pull in the literal-types + just-float rewrite for the RHS — our
-        // `alias.range()` edit subsumes anything those emitted on the value
-        // alone, so we have to splice the rewrite into our output.
-        let literal_rewrite = lower_type_expr_full(self.source, self.types, &alias.value);
 
         // references to a `private type` alias declared elsewhere in the module
         // also sit inside the subsumed value, so they are renamed here too
@@ -704,26 +729,31 @@ impl<'src> GenericPolyfill<'src> {
             (String::new(), Vec::new())
         };
 
-        // Apply renames inside the value expression inline (value is subsumed
-        // by the alias.range() edit so can't be emitted globally).
-        //
-        // Combining renames with the literal rewrite needs care: the literal
-        // rewrite emits a single replacement covering the whole value, so any
-        // rename edits inside its range would overlap and be lost. For now we
-        // use the literal rewrite when one exists (typical case: the value has
-        // no type-param or private-alias references), and fall back to
-        // renames-only otherwise.
-        let value_src = if let Some(rewrite) = literal_rewrite {
-            rewrite
-        } else {
-            let mut value_renames: Vec<Fix> = Vec::new();
-            rename_in_expr(&alias.value, &rename_map, &mut value_renames);
-            if value_renames.is_empty() {
-                raw_value_src
-            } else {
-                apply_renames_in_slice(&raw_value_src, alias.value.range().start(), &value_renames)
-            }
-        };
+        // Everything that rewrites part of the value has to be spliced here: our
+        // `alias.range()` edit subsumes the value, so an edit another pass emitted
+        // on it alone is dropped. Symbolic folds (`T.a` → `int`, `Dim + 1` → `int`)
+        // and typevar / private-alias renames are collected into one substitution
+        // set so the lowering below honours both, rather than picking one and
+        // silently losing the other.
+        let folded = self.substitutions_within(alias.value.range());
+        let mut value_renames: Vec<Fix> = Vec::new();
+        rename_in_expr(&alias.value, &rename_map, &mut value_renames);
+        let renames = value_renames
+            .iter()
+            .flat_map(ruff_diagnostics::Fix::edits)
+            // a rename inside a folded operation went with the operand it renamed —
+            // `type X[T: A] = T.a` folds to `int`, which mentions no `T` to rename
+            .filter(|edit| {
+                !folded
+                    .iter()
+                    .any(|(range, _)| range.contains_range(edit.range()))
+            })
+            .map(|edit| (edit.range(), edit.content().unwrap_or_default().to_owned()));
+        let substitutions: Vec<(TextRange, String)> =
+            folded.iter().cloned().chain(renames).collect();
+
+        let value_src = lower_type_expr_full(self.source, self.types, &alias.value, &substitutions)
+            .unwrap_or(raw_value_src);
 
         self.needed_imports.typealias_type = true;
 
@@ -1002,25 +1032,6 @@ fn rename_in_stmt(stmt: &Stmt, renames: &HashMap<String, String>, edits: &mut Ve
     }
 }
 
-fn apply_renames_in_slice(text: &str, text_start: TextSize, renames: &[Fix]) -> String {
-    let base = usize::from(text_start);
-    let mut local: Vec<(usize, usize, &str)> = renames
-        .iter()
-        .flat_map(Fix::edits)
-        .filter_map(|e| {
-            let lo = usize::from(e.start()).checked_sub(base)?;
-            let hi = usize::from(e.end()).checked_sub(base)?;
-            (hi <= text.len()).then_some((lo, hi, e.content().unwrap_or_default()))
-        })
-        .collect();
-    local.sort_by_key(|&(lo, ..)| std::cmp::Reverse(lo));
-    let mut result = text.to_owned();
-    for (lo, hi, new) in local {
-        result.replace_range(lo..hi, new);
-    }
-    result
-}
-
 pub(crate) fn mangle(name: &str) -> String {
     if name.starts_with('_') {
         name.to_owned()
@@ -1047,7 +1058,12 @@ impl super::ast_driver::TypeAwarePass for GenericPolyfillPass<'_> {
         types: &dyn TypeInfo,
         ctx: &mut super::ast_driver::PassContext,
     ) {
-        let mut inner = GenericPolyfill::new(self.source, types, self.config.clone());
+        let mut inner = GenericPolyfill::new(
+            self.source,
+            types,
+            self.config.clone(),
+            ctx.symbolic_substitutions.clone(),
+        );
         inner.collect_private_aliases(stmts);
         for stmt in stmts {
             inner.visit_stmt(stmt);

--- a/crates/by_transforms/src/transforms/init_method.rs
+++ b/crates/by_transforms/src/transforms/init_method.rs
@@ -45,6 +45,7 @@ impl TypeAwarePass for InitMethod<'_> {
         let mut state = State {
             source: self.source,
             types,
+            symbolic_substitutions: ctx.symbolic_substitutions.clone(),
             edits: RefCell::new(Vec::new()),
             errors: RefCell::new(Vec::new()),
         };
@@ -79,6 +80,10 @@ fn is_init_owned_modifier(word: &str) -> bool {
 struct State<'src> {
     source: &'src str,
     types: &'src dyn TypeInfo,
+    /// `(range, rendered)` for every symbolic fold in the module. the `__init__`
+    /// line is fresh output, so a fold inside a parameter annotation is dropped
+    /// unless it is spliced in here
+    symbolic_substitutions: Vec<(TextRange, String)>,
     edits: RefCell<Vec<(TextRange, String)>>,
     errors: RefCell<Vec<String>>,
 }
@@ -126,7 +131,13 @@ impl State<'_> {
     /// needs to reproduce the lowered text. falls back to the source verbatim
     /// when nothing lowers
     fn lower_annotation(&self, ann: &Expr) -> String {
-        lower_type_expr_full(self.source, self.types, ann).unwrap_or_else(|| {
+        let substitutions: Vec<(TextRange, String)> = self
+            .symbolic_substitutions
+            .iter()
+            .filter(|(range, _)| ann.range().contains_range(*range))
+            .cloned()
+            .collect();
+        lower_type_expr_full(self.source, self.types, ann, &substitutions).unwrap_or_else(|| {
             self.source[usize::from(ann.range().start())..usize::from(ann.range().end())].to_owned()
         })
     }

--- a/crates/by_transforms/src/transforms/symbolic_type_op.rs
+++ b/crates/by_transforms/src/transforms/symbolic_type_op.rs
@@ -58,6 +58,18 @@ impl SymbolicFolds {
     pub(crate) fn claimed_ranges(&self) -> Vec<TextRange> {
         self.folds.keys().copied().collect()
     }
+
+    /// each fold as a `(range, rendered)` substitution. a pass whose own edit
+    /// *subsumes* a folded operation — the `TypeAliasType` polyfill rewrites the
+    /// whole `type X = …` statement — would otherwise re-emit the operand from
+    /// source and drop the fold, leaving `_T.a` / `_Dim + 1` to be evaluated at
+    /// runtime. such a pass splices these in instead
+    pub(crate) fn substitutions(&self) -> Vec<(TextRange, String)> {
+        self.folds
+            .iter()
+            .map(|(range, fold)| (*range, fold.rendered.clone()))
+            .collect()
+    }
 }
 
 /// Walk every type position and resolve each non-union/non-intersection binary
@@ -124,6 +136,10 @@ impl TypeExprVisitor for FoldCollector<'_> {
             // the type function returned, so the emitted python names a real type
             // and carries no trace of the type function
             Expr::Subscript(_) => self.types.is_type_fn_application(expr),
+            // basedpython: an attribute type (`T.a`) folds to the member's type on the
+            // type parameter's bound — python cannot express the dependency on `T`, and
+            // the bound's member type is the guarantee every specialization satisfies
+            Expr::Attribute(_) => self.types.is_attribute_type(expr),
             _ => false,
         };
         if !foldable {
@@ -131,19 +147,6 @@ impl TypeExprVisitor for FoldCollector<'_> {
         }
         let Some(rendered) = self.types.symbolic_type_fold(expr) else {
             return Recurse::Descend;
-        };
-        // a `type def` application must always be replaced: its declaration is
-        // erased, so leaving the source alone would emit a dangling name. an
-        // application that stayed deferred (a non-ground argument, or a type
-        // function with no declared return) resolves to `Unknown`, which is not a
-        // runtime name — `Any` is the honest spelling of it
-        let rendered = if rendered == "Unknown" {
-            if !self.types.is_type_fn_application(expr) {
-                return Recurse::Descend;
-            }
-            "Any".to_string()
-        } else {
-            rendered
         };
         // the special float-literal types render as the bare names `inf` /
         // `-inf` / `nan`, which have no python literal syntax — leave them for
@@ -153,11 +156,34 @@ impl TypeExprVisitor for FoldCollector<'_> {
         if matches!(rendered.as_str(), "inf" | "-inf" | "nan") {
             return Recurse::Descend;
         }
-        // the rendered type must itself parse as a type expression; if ty
-        // produced something we can't splice back (unexpected for arithmetic),
-        // leave the source untouched
-        let Ok(parsed) = parse_expression(&rendered) else {
-            return Recurse::Descend;
+        // the rendered type must itself parse as a type expression, and `Unknown`
+        // is not a runtime name either
+        let (rendered, parsed) = match parse_expression(&rendered) {
+            Ok(parsed) if rendered != "Unknown" => (rendered, parsed),
+            // some forms *must* be replaced, because their source spelling names
+            // nothing at runtime: a `type def` application (its declaration is
+            // erased, so the name would dangle) and an attribute type (`T.a` is an
+            // attribute access on a `TypeVar` object). `Any` is the honest
+            // spelling when the resolved type has none — a deferred application,
+            // or a member python cannot write down such as a bound method or a
+            // callable, which ty renders in arrow form. anything else keeps its
+            // source so ty's own diagnostic stands.
+            //
+            // the widening is deliberately silent: it is the same trade every
+            // deferred operation already makes when it lowers to its reduced form
+            // (`Array[Dim + 1]` → `Array[int]`), the `.by` file keeps the precise
+            // type either way, and the transpiler has no warning channel — only
+            // hard errors, which would reject perfectly good source
+            _ => {
+                if !(self.types.is_type_fn_application(expr) || self.types.is_attribute_type(expr))
+                {
+                    return Recurse::Descend;
+                }
+                let Ok(parsed) = parse_expression("Any") else {
+                    return Recurse::Descend;
+                };
+                ("Any".to_string(), parsed)
+            }
         };
         if rendered.contains("Literal[") {
             self.needs_literal_import = true;
@@ -538,6 +564,246 @@ mod tests {
     fn value_position_unchanged() {
         // a binary operation in value position is ordinary arithmetic
         check("x = 1 + 1\n", "x = 1 + 1\n");
+    }
+
+    #[test]
+    fn attribute_type_folds_to_the_bound_member() {
+        check_py312(
+            indoc! {"
+                class A:
+                    a: int
+
+                class B[T: A]:
+                    x: T.a
+            "},
+            indoc! {"
+                class A:
+                    a: int
+
+                class B[T: A]:
+                    x: int
+            "},
+        );
+    }
+
+    #[test]
+    fn attribute_type_in_signature_and_subscript() {
+        check_py312(
+            indoc! {"
+                class A:
+                    a: int
+
+                def f[T: A](t: T, v: T.a) -> list[T.a]:
+                    return [v]
+            "},
+            indoc! {"
+                class A:
+                    a: int
+
+                def f[T: A](t: T, v: int) -> list[int]:
+                    return [v]
+            "},
+        );
+    }
+
+    #[test]
+    fn ordinary_dotted_annotation_unchanged() {
+        // a dotted name that already denotes a type is not an attribute type —
+        // folding it would emit a name that is not in scope
+        check_py312(
+            indoc! {"
+                class Outer:
+                    class Inner:
+                        pass
+
+                x: Outer.Inner
+            "},
+            indoc! {"
+                class Outer:
+                    class Inner:
+                        pass
+
+                x: Outer.Inner
+            "},
+        );
+    }
+
+    #[test]
+    fn attribute_type_at_the_typevar_lowering() {
+        // the default target polyfills the type parameter to `_T = TypeVar(...)`;
+        // an unfolded `T.a` would emit `_T.a`, an `AttributeError` on the `TypeVar`
+        // object when the class body runs
+        check(
+            indoc! {"
+                class A:
+                    a: int
+
+                class B[T: A]:
+                    x: T.a
+
+                def f[T: A](v: T.a) -> T.a:
+                    return v
+            "},
+            indoc! {"
+                from typing import TypeVar, Generic
+                class A:
+                    a: int
+
+                _T = TypeVar(\"_T\", bound=A)
+                class B(Generic[_T]):
+                    x: int
+
+                def f(v: int) -> int:
+                    return v
+            "},
+        );
+    }
+
+    #[test]
+    fn attribute_type_over_a_specialized_receiver() {
+        // a ground receiver folds in ty the moment it is written, so there is no
+        // `Deferred` left for the type-driven test — the shape is what marks it. an
+        // unfolded `X[A].x` is an `AttributeError` on the generic alias at runtime
+        check_py312(
+            indoc! {"
+                class A:
+                    a: int
+
+                class X[T: A]:
+                    x: T
+                    y: T.a
+
+                class Z:
+                    plain: X[A].x
+                    composed: X[A].y
+                    chained: X[A].x.a
+                    nested: list[X[A].y]
+            "},
+            indoc! {"
+                class A:
+                    a: int
+
+                class X[T: A]:
+                    x: T
+                    y: int
+
+                class Z:
+                    plain: A
+                    composed: int
+                    chained: int
+                    nested: list[int]
+            "},
+        );
+    }
+
+    #[test]
+    fn attribute_type_in_a_generic_type_alias() {
+        // the `TypeAliasType` polyfill replaces the whole statement, so it has to
+        // splice the fold in — otherwise `_T.a` is evaluated at import
+        check(
+            indoc! {"
+                class A:
+                    a: int
+
+                type Alias[T: A] = T.a
+            "},
+            indoc! {"
+                from typing import TypeVar
+                from typing_extensions import TypeAliasType
+                class A:
+                    a: int
+
+                _T = TypeVar(\"_T\", bound=A)
+                Alias = TypeAliasType(\"Alias\", int, type_params=(_T,))
+            "},
+        );
+    }
+
+    #[test]
+    fn type_alias_composes_a_fold_with_a_typevar_rename() {
+        // the alias polyfill renames `T` to `_T` *and* splices the `T.a` fold; before
+        // these shared one substitution set it could only apply one of the two
+        check(
+            indoc! {"
+                class A:
+                    a: int
+
+                type Alias[T: A] = dict[T, T.a]
+            "},
+            indoc! {"
+                from typing import TypeVar
+                from typing_extensions import TypeAliasType
+                class A:
+                    a: int
+
+                _T = TypeVar(\"_T\", bound=A)
+                Alias = TypeAliasType(\"Alias\", dict[_T, int], type_params=(_T,))
+            "},
+        );
+    }
+
+    #[test]
+    fn arithmetic_type_alias_is_folded_too() {
+        // the same subsumption applied to the sibling deferred-operation feature:
+        // `_D + 1` would be a `TypeError` at import
+        check(
+            indoc! {"
+                type Arith[D: int] = D + 1
+            "},
+            indoc! {"
+                from typing import TypeVar
+                from typing_extensions import TypeAliasType
+                _D = TypeVar(\"_D\", bound=int)
+                Arith = TypeAliasType(\"Arith\", int, type_params=(_D,))
+            "},
+        );
+    }
+
+    #[test]
+    fn attribute_type_without_a_python_spelling_degrades_to_any() {
+        // a method member's type is a bound method, which python cannot write
+        // down. leaving `T.m` in place would evaluate an attribute access on a
+        // `TypeVar` object when the class body runs
+        check_py312(
+            indoc! {"
+                class A:
+                    def m(self) -> str:
+                        return \"\"
+
+                class B[T: A]:
+                    z: T.m
+            "},
+            indoc! {"
+                from typing import Any
+                class A:
+                    def m(self) -> str:
+                        return \"\"
+
+                class B[T: A]:
+                    z: Any
+            "},
+        );
+    }
+
+    #[test]
+    fn attribute_type_value_position_unchanged() {
+        // outside a type position `T.a` is an ordinary attribute access
+        check_py312(
+            indoc! {"
+                class A:
+                    a: int
+
+                def f[T: A](t: T):
+                    return t.a
+            "},
+            indoc! {"
+                class A:
+                    a: int
+
+                def f[T: A](t: T):
+                    return t.a
+            "},
+        );
     }
 
     #[test]

--- a/crates/by_transforms/src/type_info.rs
+++ b/crates/by_transforms/src/type_info.rs
@@ -1,5 +1,6 @@
 //! Abstraction over type/binding information consumed by transforms.
 
+use ruff_python_ast::helpers::is_dotted_name;
 use ruff_python_ast::{Expr, ExprCall, ExprName, Stmt, StmtClassDef};
 use ruff_text_size::TextRange;
 use ty_python_core::scope::ScopeKind;
@@ -215,6 +216,12 @@ pub(crate) trait TypeInfo {
     /// [`symbolic_type_fold`](TypeInfo::symbolic_type_fold)
     fn is_type_fn_application(&self, expr: &Expr) -> bool;
 
+    /// whether `expr` is an attribute type — `T.a`, the type of member `a` on a type
+    /// parameter. python cannot express the dependency on `T`, so such an annotation
+    /// lowers to the member's type on the parameter's bound, read back through
+    /// [`symbolic_type_fold`](TypeInfo::symbolic_type_fold)
+    fn is_attribute_type(&self, expr: &Expr) -> bool;
+
     /// rendered exact (non-promoted) type of `expr` in a type position. used to
     /// fold symbolic operations such as `1 + 1` → `Literal[2]` or `A + B` →
     /// `Literal[3]`: ty already evaluates these in `infer_type_expression`, so
@@ -398,6 +405,23 @@ impl TypeInfo for SemanticModel<'_> {
             .value
             .inferred_type(self)
             .is_some_and(|ty| ty.is_type_fn(self.db()))
+    }
+
+    fn is_attribute_type(&self, expr: &Expr) -> bool {
+        let Expr::Attribute(attribute) = expr else {
+            return false;
+        };
+        // mirrors ty's rule: in a type position, an attribute on a receiver that is
+        // not a plain dotted name is an attribute type — `X[A].x` — because nothing
+        // else can be written that way. the type-driven test below covers the bare
+        // type-parameter form (`T.a`), whose receiver *is* a dotted name and which
+        // therefore always stays symbolic; a specialized receiver folds in ty the
+        // moment it is ground, so by then there is no `Deferred` left to recognise
+        if !is_dotted_name(&attribute.value) {
+            return true;
+        }
+        expr.inferred_type(self)
+            .is_some_and(|ty| ty.is_attribute_type(self.db()))
     }
 
     fn subscript_is_type_context(&self, name: &ExprName) -> bool {

--- a/crates/ty_python_semantic/resources/mdtest/basedpython_attribute_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/basedpython_attribute_types.md
@@ -1,0 +1,330 @@
+# basedpython: attribute types
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+`T.a`, where `T` is a type parameter, is an *attribute type*: the type of the member `a` on whatever
+`T` turns out to be. it cannot be resolved where it is written — `T` is unknown until the class or
+function is specialized — so it is kept symbolic and re-resolved against each specialization, in the
+same way an [arithmetic operation on a type parameter](basedpython_deferred_type_ops.md) is.
+
+the receiver may be any type expression. a *dotted name* is the one shape that keeps its ordinary
+meaning — `mod.Class` and `Outer.Inner` still name the type they resolve to — so only a type
+parameter is read as an attribute type there.
+
+## a member of a class type parameter
+
+```by
+class A1:
+    a: int
+
+class A2(A1):
+    a: bool
+
+class B[T: A1]:
+    x: T.a
+
+def check(b1: B[A1], b2: B[A2]):
+    reveal_type(b1.x)  # revealed: int
+    reveal_type(b2.x)  # revealed: bool
+```
+
+## a member of a function type parameter
+
+```by
+class A1:
+    a: int = 0
+
+class A2(A1):
+    a: bool = True
+
+def get[T: A1](t: T) -> T.a:
+    return t.a
+
+reveal_type(get(A1()))  # revealed: int
+reveal_type(get(A2()))  # revealed: bool
+```
+
+## an attribute type in a parameter position
+
+```by
+class A1:
+    a: int
+
+class A2(A1):
+    a: bool
+
+def store[T: A1](t: T, value: T.a) -> None: ...
+
+store(A2(), True)
+
+# error: [invalid-argument-type] "Argument to function `store` is incorrect: Expected `bool`, found `1`"
+store(A2(), 1)
+```
+
+## nested inside another type
+
+```by
+class A1:
+    a: int
+
+class A2(A1):
+    a: bool
+
+class B[T: A1]:
+    xs: list[T.a]
+
+def check(b1: B[A1], b2: B[A2]):
+    reveal_type(b1.xs)  # revealed: list[int]
+    reveal_type(b2.xs)  # revealed: list[bool]
+```
+
+## before specialization it is the bound's member
+
+an unspecialized attribute type behaves as the member's type on the parameter's bound — that is the
+guarantee every specialization satisfies.
+
+```by
+class A1:
+    a: int
+
+class B[T: A1]:
+    x: T.a
+
+def f[T: A1](b: B[T]):
+    reveal_type(b.x)  # revealed: int
+```
+
+## methods and nested classes are members too
+
+```by
+class Inner:
+    n: int
+
+class A1:
+    inner: Inner
+    def describe(self) -> str:
+        return ""
+
+class B[T: A1]:
+    d: T.describe
+    m: T.inner
+
+def check(b: B[A1]):
+    reveal_type(b.d)  # revealed: bound method A1.describe() -> str
+    reveal_type(b.m)  # revealed: Inner
+```
+
+## an inherited member
+
+the lookup is an ordinary member lookup, so it reaches the bound's bases.
+
+```by
+class Base:
+    inherited: str
+
+class A1(Base):
+    a: int
+
+class B[T: A1]:
+    x: T.inherited
+
+def check(b: B[A1]):
+    reveal_type(b.x)  # revealed: str
+```
+
+## in a generic type alias
+
+```by
+class A1:
+    a: int
+
+class A2(A1):
+    a: bool
+
+type Alias[T: A1] = T.a
+
+def check(x: Alias[A1], y: Alias[A2]):
+    reveal_type(x)  # revealed: int
+    reveal_type(y)  # revealed: bool
+```
+
+## a specialized receiver
+
+the receiver may be any type expression, not only a bare type parameter. `X[A].x` is the type of
+`X`'s member `x` once `T` is `A` — the lookup runs against an instance of the receiver, just as it
+does for the bare form.
+
+```by
+class A:
+    a: int
+
+class B(A):
+    a: bool
+
+class X[T: A]:
+    x: T
+    y: T.a
+
+class Z:
+    plain1: X[A].x
+    plain2: X[B].x
+    composed1: X[A].y
+    composed2: X[B].y
+
+def check(z: Z):
+    reveal_type(z.plain1)  # revealed: A
+    reveal_type(z.plain2)  # revealed: B
+    reveal_type(z.composed1)  # revealed: int
+    reveal_type(z.composed2)  # revealed: bool
+```
+
+## a specialized receiver composes and nests
+
+```by
+class A:
+    a: int
+
+class B(A):
+    a: bool
+
+class X[T: A]:
+    x: T
+    y: T.a
+
+class Z:
+    chained: X[B].x.a
+    nested: list[X[B].y]
+
+def check(z: Z):
+    reveal_type(z.chained)  # revealed: bool
+    reveal_type(z.nested)  # revealed: list[bool]
+```
+
+## a specialized receiver that is still symbolic
+
+a receiver that mentions a type parameter keeps the whole attribute type symbolic, so it re-resolves
+against each specialization exactly as the bare form does.
+
+```by
+class A:
+    a: int
+
+class B(A):
+    a: bool
+
+class X[T: A]:
+    y: T.a
+
+class W[T: A]:
+    w: X[T].y
+
+def check(wa: W[A], wb: W[B]):
+    reveal_type(wa.w)  # revealed: int
+    reveal_type(wb.w)  # revealed: bool
+```
+
+## a member the specialized receiver does not have
+
+```by
+class A:
+    a: int
+
+class X[T: A]:
+    x: T
+
+class Z:
+    # error: [unresolved-attribute] "Object of type `X[A]` has no attribute `nope`"
+    q: X[A].nope
+```
+
+## `Annotated` metadata is a value position, not a type
+
+metadata is arbitrary runtime data, so the type-expression reading must not reach into it — `T.a`
+there is an attribute access on the `TypeVar` object, exactly as it is outside an annotation.
+
+```by
+from typing import Annotated
+
+class A1:
+    a: int
+
+class B[T: A1]:
+    # error: [unresolved-attribute] "Object of type `TypeVar` has no attribute `a`"
+    v: Annotated[int, T.a]
+
+# error: [unresolved-attribute] "Object of type `TypeVar` has no attribute `a`"
+def fn[T: A1](v: Annotated[int, T.a]) -> None: ...
+```
+
+## a constrained type parameter has no members
+
+member lookup on a constrained type parameter does not union over the constraints — the same limit
+applies to `t.a` in a value position — so an attribute type over one is an error rather than the
+union of each constraint's member.
+
+```by
+class A1:
+    a: int
+
+class A2:
+    a: bool
+
+class B[T: (A1, A2)]:
+    # error: [unresolved-attribute] "Object of type `T@B` has no attribute `a`"
+    x: T.a
+```
+
+## no other dotted-name annotation changes meaning
+
+for a dotted name the attribute-type reading is confined to a type-parameter receiver, so every
+other dotted name in an annotation resolves exactly as it did before — including which diagnostic it
+earns.
+
+```by
+type def F[X]:
+    return int
+
+# error: [invalid-type-form] "`F` is a `type def`; it can only be applied in a type expression, not used as a value"
+x: F.nope
+```
+
+## a member the bound does not have is an error
+
+```by
+class A1:
+    a: int
+
+class B[T: A1]:
+    # error: [unresolved-attribute] "Object of type `T@B` has no attribute `nope`"
+    x: T.nope
+```
+
+## an unbounded type parameter only has `object`'s members
+
+```by
+class B[T]:
+    # error: [unresolved-attribute] "Object of type `T@B` has no attribute `a`"
+    x: T.a
+```
+
+## a parameter pack is not a receiver
+
+`P.args` and `P.kwargs` name the components of a parameter pack, not a member of it.
+
+```by
+def f[**P](*args: P.args, **kwargs: P.kwargs) -> None: ...
+```
+
+## attribute types are `.by` only
+
+```py
+class A1:
+    a: int
+
+class B[T: A1]:
+    # error: [unresolved-attribute] "Object of type `TypeVar` has no attribute `a`"
+    x: T.a
+```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2310,6 +2310,13 @@ impl<'db> Type<'db> {
             if function.has_known_decorator(db, crate::types::function::FunctionDecorators::TYPE_FN))
     }
 
+    /// basedpython: whether this is an *attribute type* — the member lookup `T.a` on a
+    /// type parameter, kept symbolic until the parameter is substituted. Python has no
+    /// way to spell the dependency, so the transpiler folds these to their reduced form.
+    pub fn is_attribute_type(self, db: &'db dyn Db) -> bool {
+        matches!(self, Type::Deferred(deferred) if deferred.is_attribute(db))
+    }
+
     pub(crate) fn literal_fallback_instance(self, db: &'db dyn Db) -> Option<Type<'db>> {
         // There are other literal types that could conceivable be included here: class literals
         // falling back to `type[X]`, for instance. For now, there is not much rigorous thought put

--- a/crates/ty_python_semantic/src/types/deferred.rs
+++ b/crates/ty_python_semantic/src/types/deferred.rs
@@ -20,11 +20,23 @@
 //! is re-run against the substituted operands with the very same fold the value-level
 //! inferrer uses, so `Dim + 1` with `Dim = 5` folds to `Literal[6]`.
 //!
+//! the same reasoning covers an *attribute type* — `T.a`, the type of member `a` on
+//! whatever `T` turns out to be:
+//!
+//! ```by
+//! class B[T: A1]:
+//!     x: T.a
+//! ```
+//!
+//! reducing it eagerly to `A1`'s `a` would make `B[A2]().x` read as `A1.a`'s type even
+//! when `A2` redeclares `a`.
+//!
 //! this is one mechanism spanning every foldable operation kind (see
 //! [`DeferredOperation`]); the fold for each kind is shared with value inference
 //! rather than reimplemented here.
 
 use ruff_python_ast as ast;
+use ruff_python_ast::name::Name;
 
 use super::Type;
 use super::infer::{deferred_comparison, literal_binary_op, literal_unary_op};
@@ -38,7 +50,10 @@ use crate::types::{KnownClass, TypeContext};
 
 /// The kind of a [`DeferredType`]'s pending operation. Each variant fixes how many
 /// operands the deferral carries and which value-level fold re-evaluates it.
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+// Unlike the Salsa handles in this module, this is a plain payload stored *inside*
+// the interned struct, so its heap (an attribute type's member name) is the interned
+// value's own and is derived rather than tracked separately.
+#[derive(Clone, PartialEq, Eq, Hash, Debug, get_size2::GetSize)]
 pub enum DeferredOperation {
     /// `left op right`; operands are `[left, right]`.
     Binary(ast::Operator),
@@ -46,6 +61,11 @@ pub enum DeferredOperation {
     Unary(ast::UnaryOp),
     /// `left op right`; operands are `[left, right]`.
     Compare(ast::CmpOp),
+    /// basedpython: `receiver.name` in a type expression — an *attribute type*;
+    /// operands are `[receiver]`. Unlike the arithmetic kinds this one is only ever
+    /// built for a type-parameter receiver, because that is the only receiver whose
+    /// members cannot be resolved at definition time.
+    Attribute(Name),
     /// `callee(arg0, arg1, ...)`; operands are `[callee, arg0, arg1, ...]`. Covers
     /// method calls too — the callee is the (typevar-receiver) bound method.
     Call,
@@ -57,12 +77,9 @@ pub enum DeferredOperation {
     TypeFn,
 }
 
-// The Salsa heap is tracked separately.
-impl get_size2::GetSize for DeferredOperation {}
-
 #[salsa::interned(debug, heap_size = ruff_memory_usage::heap_size)]
 pub struct DeferredType<'db> {
-    #[returns(copy)]
+    #[returns(ref)]
     pub(crate) operation: DeferredOperation,
     #[returns(deref)]
     pub(crate) operands: Box<[Type<'db>]>,
@@ -90,14 +107,14 @@ impl<'db> DeferredType<'db> {
     /// (non-literal) result (`int + Literal[1]` → `int`).
     pub(crate) fn build(
         db: &'db dyn Db,
-        operation: DeferredOperation,
+        operation: &DeferredOperation,
         operands: Box<[Type<'db>]>,
     ) -> Type<'db> {
         if operands
             .iter()
             .any(|operand| operand_is_symbolic(db, *operand))
         {
-            return Type::Deferred(Self::new(db, operation, operands));
+            return Type::Deferred(Self::new(db, operation.clone(), operands));
         }
         evaluate(db, operation, &operands).unwrap_or_else(Type::unknown)
     }
@@ -121,7 +138,7 @@ impl<'db> DeferredType<'db> {
         // answer a question nobody asked. its declared return type is the reduced
         // form, which is why annotating a type function is what makes generic code
         // using it checkable
-        if self.operation(db) == DeferredOperation::TypeFn {
+        if matches!(self.operation(db), DeferredOperation::TypeFn) {
             let [Type::FunctionLiteral(function), ..] = self.operands(db) else {
                 return Type::unknown();
             };
@@ -142,6 +159,11 @@ impl<'db> DeferredType<'db> {
     pub(crate) fn re_evaluate(self, db: &'db dyn Db, operands: Box<[Type<'db>]>) -> Type<'db> {
         Self::build(db, self.operation(db), operands)
     }
+
+    /// basedpython: whether this deferral is an attribute type (`T.a`).
+    pub(crate) fn is_attribute(self, db: &'db dyn Db) -> bool {
+        matches!(self.operation(db), DeferredOperation::Attribute(_))
+    }
 }
 
 impl<'db> Type<'db> {
@@ -160,14 +182,18 @@ impl<'db> Type<'db> {
 /// is genuinely unsupported between the operands.
 fn evaluate<'db>(
     db: &'db dyn Db,
-    operation: DeferredOperation,
+    operation: &DeferredOperation,
     operands: &[Type<'db>],
 ) -> Option<Type<'db>> {
-    match operation {
+    match *operation {
         DeferredOperation::Binary(op) => {
             let [left, right] = operands else { return None };
             literal_binary_op(db, *left, *right, op, true)
                 .or_else(|| Type::try_call_bin_op_return_type(db, *left, op, *right))
+        }
+        DeferredOperation::Attribute(ref name) => {
+            let [receiver] = operands else { return None };
+            receiver.member(db, name).ignore_possibly_undefined()
         }
         DeferredOperation::Unary(op) => {
             let [operand] = operands else { return None };

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -2109,6 +2109,17 @@ bitflags::bitflags! {
         /// The bare `TypedDict` special form is only a type expression here, where it denotes
         /// the top of the `TypedDict` lattice
         const IN_TYPE_VARIABLE_BOUND = 1 << 16;
+
+        /// basedpython: set while resolving a dotted name that *is* a type expression,
+        /// which is what makes `T.a` an attribute type there.
+        ///
+        /// [`IN_TYPE_EXPRESSION`](Self::IN_TYPE_EXPRESSION) cannot answer that question:
+        /// it stays set across the nested *value* inference a type expression performs —
+        /// `Annotated`'s metadata elements, most of all — so reading it would give a
+        /// runtime value the meaning of a type. This is set around exactly one dotted
+        /// name's inference instead, and a dotted name contains no arbitrary values to
+        /// leak into.
+        const RESOLVING_DOTTED_TYPE_EXPRESSION = 1 << 17;
     }
 }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -127,10 +127,10 @@ use crate::types::typevar::{BoundTypeVarIdentity, TypeVarConstraints, TypeVarIde
 use crate::types::unpacker::UnpackResult;
 use crate::types::{
     BoundTypeVarInstance, CallDunderError, CallableBinding, CallableType, CallableTypes, ClassType,
-    DynamicType, InferenceFlags, InternedConstraintSet, InternedType, IntersectionBuilder,
-    IntersectionType, KnownClass, KnownInstanceType, KnownUnion, LiteralValueType,
-    LiteralValueTypeKind, MemberLookupPolicy, ParamSpecAttrKind, Parameter, Parameters,
-    SentinelInstance, Signature, SpecialFormType, SubclassOfType, Type, TypeAliasType,
+    DeferredOperation, DeferredType, DynamicType, InferenceFlags, InternedConstraintSet,
+    InternedType, IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType, KnownUnion,
+    LiteralValueType, LiteralValueTypeKind, MemberLookupPolicy, ParamSpecAttrKind, Parameter,
+    Parameters, SentinelInstance, Signature, SpecialFormType, SubclassOfType, Type, TypeAliasType,
     TypeAndQualifiers, TypeContext, TypeQualifiers, TypeVarBoundOrConstraints, TypeVarKind,
     TypeVarVariance, TypedDictModule, TypedDictType, UnionAccumulator, UnionBuilder, UnionType,
     any_over_type, binding_type, extract_fixed_length_iterable_element_types,
@@ -12010,17 +12010,35 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return self.basedpython_chain_result(attribute, element_ty, none_chain_was_optional);
         }
 
-        if let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) = value_type
-            && typevar.is_paramspec(db)
-            && let Some(bound_typevar) = bind_typevar(
-                db,
-                self.index,
-                self.scope().file_scope_id(db),
-                self.typevar_binding_context,
-                typevar,
-            )
-        {
-            value_type = Type::TypeVar(bound_typevar);
+        // basedpython: `T.a` in a type expression is an *attribute type* — the type of
+        // member `a` on whatever `T` is specialized to. only a dotted name that *is* the
+        // type expression qualifies, never one reached through nested value inference
+        // (`Annotated`'s metadata). a parameter pack is excluded too: `P.args` /
+        // `**Kwargs` name a pack's components rather than a member of it
+        let mut attribute_type_receiver = None;
+        if let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) = value_type {
+            let is_attribute_type = self.is_basedpython_file()
+                && self
+                    .inference_flags()
+                    .contains(InferenceFlags::RESOLVING_DOTTED_TYPE_EXPRESSION)
+                && !typevar.is_parameter_pack(db)
+                && !typevar.is_typevartuple(db);
+            // binding the type parameter runs the lookup below — and any diagnostic for
+            // a member the parameter cannot have — against its bound
+            if (typevar.is_paramspec(db) || is_attribute_type)
+                && let Some(bound_typevar) = bind_typevar(
+                    db,
+                    self.index,
+                    self.scope().file_scope_id(db),
+                    self.typevar_binding_context,
+                    typevar,
+                )
+            {
+                value_type = Type::TypeVar(bound_typevar);
+                if is_attribute_type {
+                    attribute_type_receiver = Some(value_type);
+                }
+            }
         }
 
         let mut assigned_type = None;
@@ -12328,6 +12346,23 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let resolved_type = resolved_type.inner_type();
 
         self.check_deprecated(attr, resolved_type);
+
+        // basedpython: an attribute type stays symbolic until the type parameter is
+        // substituted, so `B[A2]().x` reads `a` off `A2` rather than off the bound the
+        // lookup above resolved it against. it still goes through the chain result, so
+        // a `?.` access composes here exactly as it does for every other receiver
+        if let Some(receiver) = attribute_type_receiver {
+            let attribute_type = DeferredType::build(
+                db,
+                &DeferredOperation::Attribute(attr.id.clone()),
+                Box::from([receiver]),
+            );
+            return self.basedpython_chain_result(
+                attribute,
+                attribute_type,
+                none_chain_was_optional,
+            );
+        }
 
         // Even if we can obtain the attribute type based on the assignments, we still perform default type inference
         // (to report errors).

--- a/crates/ty_python_semantic/src/types/infer/builder/annotation_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/annotation_expression.rs
@@ -207,12 +207,14 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     return TypeAndQualifiers::declared(self.infer_type_expression(annotation));
                 }
                 match attribute.ctx {
-                    ast::ExprContext::Load => infer_name_or_attribute(
-                        self.infer_attribute_expression(attribute),
-                        annotation,
-                        self,
-                        pep_613_policy,
-                    ),
+                    ast::ExprContext::Load => {
+                        // resolve the dotted name as the type expression it is, as the
+                        // bare-name arm below does, so the basedpython forms that only
+                        // exist in a type position — `T.a` attribute types — read the
+                        // same here as they do in a nested type expression
+                        let attribute_ty = self.infer_dotted_type_expression(attribute);
+                        infer_name_or_attribute(attribute_ty, annotation, self, pep_613_policy)
+                    }
                     ast::ExprContext::Invalid => AnnotationExpressionInference::new(
                         TypeAndQualifiers::declared(Type::unknown()),
                     ),

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -12,7 +12,7 @@ use crate::types::ClassType;
 use crate::types::call::CallArguments;
 use crate::types::diagnostic::{
     self, EXPERIMENTAL_SYNTAX, INVALID_TYPE_FORM, NOT_SUBSCRIPTABLE, UNBOUND_TYPE_VARIABLE,
-    UNSUPPORTED_OPERATOR, report_invalid_argument_number_to_special_form,
+    UNRESOLVED_ATTRIBUTE, UNSUPPORTED_OPERATOR, report_invalid_argument_number_to_special_form,
     report_invalid_arguments_to_callable, report_invalid_concatenate_last_arg,
     report_missing_type_arguments, report_unsupported_binary_operation,
 };
@@ -115,14 +115,67 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             })
     }
 
+    /// basedpython: an [attribute type](crate::types::deferred) whose receiver is
+    /// itself a type expression — `X[A].x` is the type of `X`'s member `x` when `T`
+    /// is `A`. The receiver is resolved as a type rather than as a value, so the
+    /// lookup runs against an instance of it, exactly as it does for the bare
+    /// type-parameter form.
+    ///
+    /// A receiver that still mentions a type parameter (`X[T].x`) keeps the whole
+    /// thing symbolic; a ground one folds here and now.
+    fn infer_attribute_type_expression(&mut self, attribute: &ast::ExprAttribute) -> Type<'db> {
+        let receiver = self.infer_type_expression(&attribute.value);
+        let db = self.db();
+        let member = &attribute.attr.id;
+        if receiver.member(db, member).place.is_undefined() {
+            if let Some(builder) = self.context.report_lint(&UNRESOLVED_ATTRIBUTE, attribute) {
+                builder.into_diagnostic(format_args!(
+                    "Object of type `{}` has no attribute `{member}`",
+                    receiver.display(db),
+                ));
+            }
+            return Type::unknown();
+        }
+        DeferredType::build(
+            db,
+            &DeferredOperation::Attribute(member.clone()),
+            Box::from([receiver]),
+        )
+    }
+
+    /// Infer a dotted name that *is* a type expression, as opposed to one reached
+    /// through a type expression's nested value inference. Only here does basedpython
+    /// read `T.a` as an [attribute type](crate::types::deferred).
+    pub(super) fn infer_dotted_type_expression(
+        &mut self,
+        attribute: &ast::ExprAttribute,
+    ) -> Type<'db> {
+        let previously_resolving = self
+            .context
+            .inference_flags
+            .replace(InferenceFlags::RESOLVING_DOTTED_TYPE_EXPRESSION, true);
+        let ty = self.infer_attribute_expression(attribute);
+        self.context.inference_flags.set(
+            InferenceFlags::RESOLVING_DOTTED_TYPE_EXPRESSION,
+            previously_resolving,
+        );
+        ty
+    }
+
     pub(super) fn infer_name_or_attribute_type_expression(
         &self,
         ty: Type<'db>,
         annotation: &ast::Expr,
     ) -> Type<'db> {
+        // a dotted name whose lookup already produced a type names that type directly;
+        // there is no value whose type-expression meaning still has to be taken. that
+        // covers `P.args` / `P.kwargs` and basedpython's `T.a` attribute types
         if annotation.is_attribute_expr()
-            && let Type::TypeVar(tvar) = ty
-            && tvar.paramspec_attr(self.db()).is_some()
+            && match ty {
+                Type::TypeVar(tvar) => tvar.paramspec_attr(self.db()).is_some(),
+                Type::Deferred(deferred) => deferred.is_attribute(self.db()),
+                _ => false,
+            }
         {
             return ty;
         }
@@ -202,6 +255,17 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             },
 
             ast::Expr::Attribute(attribute_expression) => {
+                // basedpython: an attribute type over a receiver that is not a plain
+                // dotted name — `X[A].x`, and the chains built on it. a dotted name
+                // has an established meaning (`mod.Class`, `Outer.Inner`) that the
+                // attribute-type reading must not take over, but nothing else here
+                // has any meaning at all: this is otherwise the error path below
+                if self.is_basedpython_file()
+                    && matches!(attribute_expression.ctx, ast::ExprContext::Load)
+                    && !is_dotted_name(&attribute_expression.value)
+                {
+                    return self.infer_attribute_type_expression(attribute_expression);
+                }
                 if is_dotted_name(expression) {
                     match attribute_expression.ctx {
                         ast::ExprContext::Load => {
@@ -227,7 +291,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                                 // already inferred, so it isn't inferred twice
                                 self.infer_attribute_load_impl(attribute_expression, receiver)
                             } else {
-                                self.infer_attribute_expression(attribute_expression)
+                                self.infer_dotted_type_expression(attribute_expression)
                             };
                             if let Some(materialized) = self.intercept_nested_top_bottom(ty) {
                                 return materialized;
@@ -598,7 +662,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             if DeferredType::is_deferred(db, &operands) {
                                 return DeferredType::build(
                                     db,
-                                    DeferredOperation::Binary(op),
+                                    &DeferredOperation::Binary(op),
                                     Box::new(operands),
                                 );
                             }
@@ -1069,7 +1133,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     if DeferredType::is_deferred(db, &operands) {
                         return DeferredType::build(
                             db,
-                            DeferredOperation::Unary(unary.op),
+                            &DeferredOperation::Unary(unary.op),
                             Box::new(operands),
                         );
                     }
@@ -1330,7 +1394,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     let right_ty = self.infer_type_expression(comparator);
                     return DeferredType::build(
                         db,
-                        DeferredOperation::Compare(compare.ops[0]),
+                        &DeferredOperation::Compare(compare.ops[0]),
                         Box::new([left_ty, right_ty]),
                     );
                 }
@@ -1382,7 +1446,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     }
                     return DeferredType::build(
                         db,
-                        DeferredOperation::Call,
+                        &DeferredOperation::Call,
                         operands.into_boxed_slice(),
                     );
                 }
@@ -2068,7 +2132,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             let mut operands = Vec::with_capacity(arguments.len() + 1);
             operands.push(Type::FunctionLiteral(function));
             operands.extend_from_slice(&arguments);
-            return DeferredType::build(db, DeferredOperation::TypeFn, operands.into_boxed_slice());
+            return DeferredType::build(
+                db,
+                &DeferredOperation::TypeFn,
+                operands.into_boxed_slice(),
+            );
         }
 
         let interned = TypeFnArguments::new(db, arguments.into_boxed_slice());

--- a/docs/basedpython/features/attribute-types.md
+++ b/docs/basedpython/features/attribute-types.md
@@ -1,0 +1,142 @@
+# attribute types
+
+a type parameter's members can be named in a type position. `T.a` is the type of
+the member `a` on whatever `T` turns out to be:
+
+```by
+class A1:
+    a: int
+
+class A2(A1):
+    a: bool
+
+class B[T: A1]:
+    x: T.a
+
+def check(b1: B[A1], b2: B[A2]):
+    reveal_type(b1.x)   # int
+    reveal_type(b2.x)   # bool
+```
+
+`T` is unknown where the annotation is written, so the lookup cannot be
+performed there. it is instead kept symbolic — like an
+[arithmetic operation on a type parameter](symbolic-type-ops.md) — and
+re-resolved against each specialization, so a subclass that redeclares the
+member is honoured rather than flattened to the bound's declaration.
+
+the same works for a function's type parameters:
+
+```by
+def get[T: A1](t: T) -> T.a:
+    return t.a
+
+reveal_type(get(A1()))  # int
+reveal_type(get(A2()))  # bool
+```
+
+## a specialized receiver
+
+the receiver does not have to be a bare type parameter. any type expression works,
+so a generic can be asked what a member of it becomes at a given specialization:
+
+```by
+class X[T: A1]:
+    x: T
+    y: T.a
+
+class Z:
+    p: X[A1].x      # A1
+    q: X[A2].y      # bool
+    r: X[A2].x.a    # bool — receivers chain
+```
+
+a receiver that still mentions a type parameter stays symbolic, so it re-resolves
+at each specialization just as the bare form does:
+
+```by
+class W[T: A1]:
+    w: X[T].y       # `int` for `W[A1]`, `bool` for `W[A2]`
+```
+
+## scope
+
+a *dotted name* is the one receiver shape that keeps its ordinary meaning: it
+names the type it resolves to, so `mod.Class` and `Outer.Inner` are unaffected
+and only a type parameter is read as an attribute type there.
+
+```by
+class Outer:
+    class Inner: ...
+
+x: Outer.Inner      # an `Inner` instance, not the type of the member `Inner`
+```
+
+every other receiver shape — a subscript, a chain built on one — has no other
+meaning in a type position, so there is nothing to collide with.
+
+a parameter pack is not a receiver either: `P.args` and `P.kwargs` name the
+components of the pack rather than a member of it. nor is an `Annotated`
+metadata element a type position — `Annotated[int, T.a]` is an attribute access
+on the type parameter itself, not an attribute type.
+
+the receiver may be a class or a function type parameter, and the attribute type
+may appear anywhere a type may: an annotation, a signature, inside another type,
+or as the value of a generic type alias.
+
+```by
+type Alias[T: A1] = T.a
+```
+
+any member works — a field, a method, a property, a nested class, or one
+inherited from a base of the bound. a member the bound does not have is reported
+as an unresolved attribute, so an attribute type is checked where it is written
+and not only where it is specialized:
+
+```by
+class B[T: A1]:
+    x: T.nope       # error: `T@B` has no attribute `nope`
+```
+
+a *constrained* type parameter is the one case with no members to look up:
+member access on one does not union over the constraints (the same limit applies
+to `t.a` in a value position), so `T.a` over `T: (A1, A2)` is an unresolved
+attribute even when both constraints declare `a`.
+
+before it is specialized, an attribute type behaves as the member's type on the
+parameter's bound — the guarantee every specialization satisfies:
+
+```by
+def f[T: A1](b: B[T]):
+    reveal_type(b.x)    # int
+```
+
+## polyfill
+
+there is no runtime construct. python cannot express a member type that depends
+on a type parameter, so the annotation is resolved at transpile time and written
+out as the member's type on the parameter's bound:
+
+```by
+class B[T: A1]:
+    x: T.a
+    xs: list[T.a]
+
+type Alias[T: A1] = T.a
+```
+
+transpiles to:
+
+```python
+class B[T: A1]:
+    x: int
+    xs: list[int]
+
+type Alias[T: A1] = int
+```
+
+a member whose type has no python spelling at all — a method, whose type is a
+bound method — is written out as `Any`. the precise type is still enforced
+inside the `.by` file; only the emitted annotation widens. this is the same
+trade every [symbolic operation](symbolic-type-ops.md) makes when it lowers to
+its reduced form, and it is not reported: the source is valid, and only the
+runtime artifact is less precise than the `.by` file it came from.

--- a/docs/basedpython/features/index.md
+++ b/docs/basedpython/features/index.md
@@ -50,6 +50,7 @@ type-checking improvements with no new syntax — they work in `.by` and `.py` f
 - [generics](generics.md)
 - [explicit typevar constraints](constraints.md)
 - [type parameter bound ranges](bound-ranges.md)
+- [attribute types (`T.a`)](attribute-types.md)
 - [`TypedDict` and `Self` in type parameters](typeddict-self-bounds.md)
 - [keyword-variadic packs](keyword-variadic.md)
 - [type parameter separators](type-param-separators.md)

--- a/zensical.toml
+++ b/zensical.toml
@@ -59,6 +59,7 @@ features = [
   { "generics" = "features/generics.md" },
   { "explicit typevar constraints" = "features/constraints.md" },
   { "type parameter bound ranges" = "features/bound-ranges.md" },
+  { "attribute types" = "features/attribute-types.md" },
   { "`TypedDict` and `Self` in type parameters" = "features/typeddict-self-bounds.md" },
   { "keyword-variadic packs" = "features/keyword-variadic.md" },
   { "type parameter separators" = "features/type-param-separators.md" },


### PR DESCRIPTION
`T.a` in a type expression is the type of member `a` on whatever the type parameter `T` is specialized to, kept symbolic via the existing deferred type-operation mechanism and re-resolved on each specialization