### PR TITLE
a receiver block binds `self` and `it` separately

### DIFF
--- a/crates/by_transforms/src/transforms/ast_driver.rs
+++ b/crates/by_transforms/src/transforms/ast_driver.rs
@@ -640,9 +640,9 @@ pub(crate) fn run_against_source<'a>(
         &implementation_block_pass,
         &conversion_pass,
         // implicit receivers: `x.fn()` → `fn(x)` for a receiver callable in
-        // scope, and a trailing lambda block's unqualified receiver members →
-        // `it.<name>`. same shape as the extension rewrite above, which wins
-        // when both could apply
+        // scope, and a trailing lambda block's `self` / unqualified receiver
+        // members → its receiver parameter. same shape as the extension rewrite
+        // above, which wins when both could apply
         &implicit_receiver_pass,
         &dynamic_keyword_pass,
         // import-only companion to the ty-side implicit `Character` resolution;

--- a/crates/by_transforms/src/transforms/implicit_receiver.rs
+++ b/crates/by_transforms/src/transforms/implicit_receiver.rs
@@ -9,21 +9,23 @@
 //!   in scope rather than to a member of `x`. An unapplied `x.fn` becomes a
 //!   `functools.partial`, matching how a bound method would have carried the
 //!   receiver
-//! - a bare name in a trailing lambda block that resolves to a member of the
-//!   block's receiver → `it.<name>`, where `it` is the block's implicit
-//!   parameter (the receiver itself)
+//! - a bare name in a trailing lambda block that resolves through the block's
+//!   receiver → the block's receiver parameter, either on its own (`self`) or
+//!   as the object a member is read off (`<receiver>.<name>`)
 //!
 //! Both are narrow edits nested inside the trailing-lambda template's `Src`
 //! spans, so they compose with the block lowering.
 //!
 //! [`callable`]: super::callable
 
-use ruff_python_ast::visitor::{Visitor, walk_expr, walk_stmt};
-use ruff_python_ast::{Expr, ExprAttribute, ExprContext, Stmt};
+use ruff_python_ast::visitor::{Visitor, walk_expr};
+use ruff_python_ast::{Expr, ExprAttribute, Stmt};
 use ruff_text_size::{Ranged, TextRange};
+use ty_python_semantic::ImplicitReceiverReference;
 
 use super::ast_driver::{Fragment, PassContext, TypeAwarePass};
 use super::extension::{arguments_span, spine_has_optional};
+use super::trailing_lambda::RECEIVER_PARAMETER;
 use crate::type_info::TypeInfo;
 
 struct ImplicitReceiverLower<'a> {
@@ -33,62 +35,10 @@ struct ImplicitReceiverLower<'a> {
     /// attribute ranges already rewritten as part of an enclosing call, so the
     /// bare-access arm doesn't rewrite them a second time
     handled: Vec<TextRange>,
-    /// the enclosing trailing lambda blocks, innermost last, and whether each
-    /// rebinds `it` — the name the receiver members are read from
-    blocks: Vec<Block>,
     needs_functools: bool,
 }
 
-/// An enclosing trailing lambda block, for the `it`-rebinding check
-struct Block {
-    rebinds_it: bool,
-    reported: bool,
-}
-
-/// Whether a block assigns `it` anywhere in its body. The lowering reads the
-/// receiver's members off that parameter, so a rebinding would silently redirect
-/// them to the new value. Nested scopes count too: this only decides whether to
-/// reject, and over-rejecting is the safe direction.
-fn rebinds_it(body: &[Stmt]) -> bool {
-    struct RebindsIt {
-        found: bool,
-    }
-
-    impl<'ast> Visitor<'ast> for RebindsIt {
-        fn visit_expr(&mut self, expr: &'ast Expr) {
-            if let Expr::Name(name) = expr
-                && name.id.as_str() == "it"
-                && matches!(name.ctx, ExprContext::Store | ExprContext::Del)
-            {
-                self.found = true;
-            }
-            walk_expr(self, expr);
-        }
-    }
-
-    let mut visitor = RebindsIt { found: false };
-    for stmt in body {
-        visitor.visit_stmt(stmt);
-    }
-    visitor.found
-}
-
 impl<'ast> Visitor<'ast> for ImplicitReceiverLower<'_> {
-    fn visit_stmt(&mut self, stmt: &'ast Stmt) {
-        if let Stmt::FunctionDef(function) = stmt
-            && function.is_trailing_lambda
-        {
-            self.blocks.push(Block {
-                rebinds_it: rebinds_it(&function.body),
-                reported: false,
-            });
-            walk_stmt(self, stmt);
-            self.blocks.pop();
-            return;
-        }
-        walk_stmt(self, stmt);
-    }
-
     fn visit_expr(&mut self, expr: &'ast Expr) {
         match expr {
             // `x.fn(a)` → `fn(x, a)`
@@ -127,15 +77,20 @@ impl<'ast> Visitor<'ast> for ImplicitReceiverLower<'_> {
                     }
                 }
             }
-            // a receiver member used unqualified inside a trailing lambda block
+            // the receiver of a trailing lambda block, or one of its members,
+            // used unqualified inside the block
             Expr::Name(name) => {
-                if name.ctx.is_load() && self.types.is_implicit_receiver_name(name) {
-                    if self.block_rebinds_it() {
-                        self.report_rebound_it();
-                    } else {
-                        self.edits
-                            .push((name.range(), vec![Fragment::Lit(format!("it.{}", name.id))]));
-                    }
+                if name.ctx.is_load()
+                    && let Some(reference) = self.types.implicit_receiver_name(name)
+                {
+                    let lowered = match reference {
+                        ImplicitReceiverReference::Receiver => RECEIVER_PARAMETER.to_owned(),
+                        ImplicitReceiverReference::Member => {
+                            format!("{RECEIVER_PARAMETER}.{}", name.id)
+                        }
+                    };
+                    self.edits
+                        .push((name.range(), vec![Fragment::Lit(lowered)]));
                 }
             }
             _ => {}
@@ -159,28 +114,6 @@ impl ImplicitReceiverLower<'_> {
         fragments.push(Fragment::Lit(")".to_owned()));
         self.edits.push((call.range(), fragments));
     }
-
-    /// whether the innermost enclosing block rebinds `it`, which the member
-    /// rewrite reads the receiver from
-    fn block_rebinds_it(&self) -> bool {
-        self.blocks.last().is_some_and(|block| block.rebinds_it)
-    }
-
-    /// report the rebinding once per block, however many members it uses
-    fn report_rebound_it(&mut self) {
-        let Some(block) = self.blocks.last_mut() else {
-            return;
-        };
-        if block.reported {
-            return;
-        }
-        block.reported = true;
-        self.errors.push(
-            "a trailing lambda block that rebinds `it` cannot use its receiver's members \
-             unqualified yet — the lowering reads them from `it`"
-                .to_owned(),
-        );
-    }
 }
 
 /// whether the access is a link of a `?.` chain, which the receiver rewrite
@@ -202,7 +135,6 @@ impl TypeAwarePass for ImplicitReceiverPass {
             edits: Vec::new(),
             handled: Vec::new(),
             errors: Vec::new(),
-            blocks: Vec::new(),
             needs_functools: false,
         };
         for stmt in stmts {
@@ -270,7 +202,7 @@ mod tests {
     }
 
     #[test]
-    fn trailing_block_members_bind_to_it() {
+    fn trailing_block_members_bind_to_the_receiver_parameter() {
         let out = check(indoc! {"
             def f(fn: int.() -> None) -> None:
                 fn(1)
@@ -278,7 +210,43 @@ mod tests {
             f:
                 print(imag)
         "});
-        assert!(out.contains("print(it.imag)"), "got:\n{out}");
+        assert!(out.contains("print(_by_self.imag)"), "got:\n{out}");
+        assert!(
+            out.contains("def _trailing_lambda_0(_by_self=None, it=None):"),
+            "got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn a_trailing_block_spells_its_receiver_self() {
+        let out = check(indoc! {"
+            def f(fn: str.(int) -> None) -> None:
+                fn(\"a\", 1)
+
+            f:
+                print(upper(), it, self)
+        "});
+        assert!(
+            out.contains("print(_by_self.upper(), it, _by_self)"),
+            "got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn an_enclosing_self_keeps_its_meaning() {
+        // the receiver is the *last* fallback, so a method's own `self` still
+        // wins — and the block's receiver parameter is a name the source cannot
+        // spell, so it cannot be shadowed either
+        let out = check(indoc! {"
+            def f(fn: str.() -> None) -> None:
+                fn(\"a\")
+
+            class C:
+                def m(self) -> None:
+                    f:
+                        print(self, upper())
+        "});
+        assert!(out.contains("print(self, _by_self.upper())"), "got:\n{out}");
     }
 
     #[test]
@@ -295,20 +263,18 @@ mod tests {
     }
 
     #[test]
-    fn rebinding_it_is_rejected() {
-        let error = transpile(
-            indoc! {"
-                def f(fn: str.() -> None) -> None:
-                    fn(\"abc\")
+    fn a_block_local_shadows_the_receiver_spelling() {
+        // a block that binds `self` itself keeps that binding — the receiver's
+        // members are read off the block's own parameter, so they are unaffected
+        let out = check(indoc! {"
+            def f(fn: str.() -> None) -> None:
+                fn(\"abc\")
 
-                f:
-                    it = 5
-                    print(upper())
-            "},
-            &Config::test_default(),
-        )
-        .expect_err("a block that rebinds `it` should be rejected");
-        assert!(error.contains("rebinds `it`"), "got:\n{error}");
+            f:
+                self = 5
+                print(self, upper())
+        "});
+        assert!(out.contains("print(self, _by_self.upper())"), "got:\n{out}");
     }
 
     #[test]

--- a/crates/by_transforms/src/transforms/trailing_lambda.rs
+++ b/crates/by_transforms/src/transforms/trailing_lambda.rs
@@ -37,6 +37,13 @@ use super::ast_driver::{Fragment, PassContext, TypeAwarePass};
 use super::source_util::line_indent;
 use crate::type_info::{CaptureKind, TypeInfo};
 
+/// The parameter a block binds its callback's implicit receiver to. The body
+/// spells it `self`, which [`implicit_receiver`] rewrites to this name — a name
+/// the source cannot produce, so a method's own `self` is never shadowed
+///
+/// [`implicit_receiver`]: super::implicit_receiver
+pub(crate) const RECEIVER_PARAMETER: &str = "_by_self";
+
 struct TrailingLambdaLower<'a, 'src> {
     source: &'src str,
     types: &'a dyn TypeInfo,
@@ -247,9 +254,18 @@ impl TrailingLambdaLower<'_, '_> {
         // surviving bindings to pre-init before it
         let (declarations, preinits) = self.capture_declarations(function);
 
-        // `it` defaults to `None` so a callback whose type takes no argument
-        // (`() -> None`, invoked as `fn()`) can still call the block, which
-        // always declares the single implicit `it` parameter
+        // a receiver callback is called with its receiver first, so the block
+        // declares a parameter for it ahead of `it`. both default to `None` so a
+        // callback whose type takes fewer arguments (`() -> None`, invoked as
+        // `fn()`) can still call the block, which always declares them
+        let parameters = if self
+            .types
+            .trailing_lambda_callback_has_receiver(signature_callee)
+        {
+            format!("{RECEIVER_PARAMETER}=None, it=None")
+        } else {
+            "it=None".to_owned()
+        };
         let mut fragments = Vec::new();
         if !returns.is_empty() {
             fragments.push(Fragment::Lit(format!("{ret_cell} = []\n{indent}")));
@@ -259,7 +275,7 @@ impl TrailingLambdaLower<'_, '_> {
         for preinit in &preinits {
             fragments.push(Fragment::Lit(format!("{preinit} = None\n{indent}")));
         }
-        fragments.push(Fragment::Lit(format!("def {name}(it=None):")));
+        fragments.push(Fragment::Lit(format!("def {name}({parameters}):")));
         // write-through declarations so block assignments update enclosing
         // bindings; spliced ahead of the suite so they precede every use
         if let Some(declarations) = declarations {

--- a/crates/by_transforms/src/type_info.rs
+++ b/crates/by_transforms/src/type_info.rs
@@ -8,7 +8,7 @@ use ty_python_core::{global_scope, place_table, semantic_index};
 use ty_python_semantic::types::{
     DynamicType, KnownClass, KnownInstanceType, Type, UnpackedKwargs, character,
 };
-use ty_python_semantic::{HasType, SemanticModel};
+use ty_python_semantic::{HasType, ImplicitReceiverReference, SemanticModel};
 
 /// How the postfix `^` / `!` operators test the "absent" arm of an operand's
 /// wrapped type. `T?` lowers to `T | None`, so its absent arm is `None`; a
@@ -170,9 +170,10 @@ pub(crate) trait TypeInfo {
     /// rather than a member of `x`. lowered to `fn(x)`
     fn is_implicit_receiver_attribute(&self, attribute: &ruff_python_ast::ExprAttribute) -> bool;
 
-    /// whether `name` is a member of the enclosing trailing lambda block's
-    /// receiver, used unqualified. lowered to `it.<name>`
-    fn is_implicit_receiver_name(&self, name: &ExprName) -> bool;
+    /// how `name` resolves through the enclosing trailing lambda block's
+    /// receiver: `self` is the receiver itself, any other name is a member of
+    /// it used unqualified. both lower to the block's receiver parameter
+    fn implicit_receiver_name(&self, name: &ExprName) -> Option<ImplicitReceiverReference>;
 
     /// the enum a *context-sensitively* resolved name must be qualified with —
     /// `Red` in a `Color` context lowers to `Color.Red`. `None` for every name
@@ -330,6 +331,11 @@ pub(crate) trait TypeInfo {
     /// as a positional argument instead (unknown callee signature, or a
     /// variadic / positional-only last parameter)
     fn trailing_lambda_keyword(&self, callee: &Expr) -> Option<String>;
+
+    /// whether the trailing-lambda callee's callback declares an implicit
+    /// receiver, which the block binds as a leading parameter — the body reads
+    /// the receiver's members off it unqualified, and spells it `self`
+    fn trailing_lambda_callback_has_receiver(&self, callee: &Expr) -> bool;
 
     /// whether the trailing-lambda callee's callback parameter is `once` — the
     /// block runs exactly once, so its `return` propagates to the enclosing
@@ -546,7 +552,7 @@ impl TypeInfo for SemanticModel<'_> {
         SemanticModel::implicit_receiver_attribute(self, attribute)
     }
 
-    fn is_implicit_receiver_name(&self, name: &ExprName) -> bool {
+    fn implicit_receiver_name(&self, name: &ExprName) -> Option<ImplicitReceiverReference> {
         SemanticModel::implicit_receiver_name(self, name)
     }
 
@@ -828,6 +834,10 @@ impl TypeInfo for SemanticModel<'_> {
 
     fn trailing_lambda_keyword(&self, callee: &Expr) -> Option<String> {
         SemanticModel::trailing_lambda_keyword(self, callee)
+    }
+
+    fn trailing_lambda_callback_has_receiver(&self, callee: &Expr) -> bool {
+        SemanticModel::trailing_lambda_callback_has_receiver(self, callee)
     }
 
     fn trailing_lambda_callee_is_once(&self, callee: &Expr) -> bool {

--- a/crates/by_transforms/tests/implicit_receiver_runtime.rs
+++ b/crates/by_transforms/tests/implicit_receiver_runtime.rs
@@ -6,8 +6,9 @@
 //! plain function, `x.fn()` called through the receiver, an unapplied `x.fn`
 //! bound as a `functools.partial`, and a trailing lambda block using the
 //! receiver's members unqualified — and runs them on a real interpreter. A
-//! misplaced receiver argument or a member bound to the wrong object would fail
-//! here even though the type-level tests pass.
+//! misplaced receiver argument, a member bound to the wrong object, or a block
+//! whose parameters don't line up with the call would fail here even though the
+//! type-level tests pass.
 //!
 //! No third-party packages are needed, so any `python3` will do; if none is
 //! found the test skips rather than fails.
@@ -50,15 +51,16 @@ def suffixed(value: int, mark: str) -> str:
 
 assert unapplied(suffixed) == "5!", "an unapplied reference binds the receiver"
 
-# a trailing lambda block sees the receiver's members unqualified
-def apply(fn: str.() -> None) -> None:
-    fn("abc")
+# a trailing lambda block sees the receiver's members unqualified, spells the
+# receiver itself `self`, and binds the callback's own argument as `it`
+def apply(fn: str.(int) -> None) -> None:
+    fn("abc", 3)
 
 seen: str = ""
 apply:
-    seen = upper() + str(len(it))
+    seen = upper() + str(it) + self
 
-assert seen == "ABC3", "block members resolve against the receiver"
+assert seen == "ABC3abc", "a block's receiver, its members and `it` all bind"
 
 print("ok")
 "##;

--- a/crates/ty/docs/rules.md
+++ b/crates/ty/docs/rules.md
@@ -8,7 +8,7 @@
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.13">0.0.13</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22abstract-method-in-final-class%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2061" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2090" target="_blank">View source</a>
 </small>
 
 
@@ -54,7 +54,7 @@ class Derived(Base):  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.61">0.0.61</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22ambiguous-context-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1818" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1847" target="_blank">View source</a>
 </small>
 
 
@@ -87,7 +87,7 @@ f(1, b=s1)    # ok — explicit
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.39">0.0.1-alpha.39</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22ambiguous-conversion%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1134" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1135" target="_blank">View source</a>
 </small>
 
 
@@ -123,7 +123,7 @@ report(Celsius())  # error: two conversions apply
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.3">0.0.1-alpha.3</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22ambiguous-extension-member%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1046" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1047" target="_blank">View source</a>
 </small>
 
 
@@ -158,7 +158,7 @@ extension list:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.20">0.0.1-alpha.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22ambiguous-protocol-member%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L373" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L374" target="_blank">View source</a>
 </small>
 
 
@@ -222,7 +222,7 @@ class SubProto(BaseProto, Protocol):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22assert-type-unspellable-subtype%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2106" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2135" target="_blank">View source</a>
 </small>
 
 
@@ -305,7 +305,7 @@ value = unknown  # ty: ignore[unresolved-reference]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.16">0.0.16</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22call-abstract-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2070" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2099" target="_blank">View source</a>
 </small>
 
 
@@ -360,7 +360,7 @@ Foo.method()  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22call-non-callable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L227" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L228" target="_blank">View source</a>
 </small>
 
 
@@ -388,7 +388,7 @@ Calling a non-callable object will raise a `TypeError` at runtime.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.7">0.0.7</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22call-top-callable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L236" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L237" target="_blank">View source</a>
 </small>
 
 
@@ -423,7 +423,7 @@ def f(x: object):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22conflicting-declarations%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L254" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L255" target="_blank">View source</a>
 </small>
 
 
@@ -457,7 +457,7 @@ a = 1  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22conflicting-metaclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L263" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L264" target="_blank">View source</a>
 </small>
 
 
@@ -492,7 +492,7 @@ class C(A, B): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22cyclic-class-definition%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L272" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L273" target="_blank">View source</a>
 </small>
 
 
@@ -528,7 +528,7 @@ class B(A): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.29">0.0.1-alpha.29</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22cyclic-type-alias-definition%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L281" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L282" target="_blank">View source</a>
 </small>
 
 
@@ -564,7 +564,7 @@ type B = A  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22dataclass-field-order%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L326" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L327" target="_blank">View source</a>
 </small>
 
 
@@ -601,7 +601,7 @@ class Example:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.16">0.0.1-alpha.16</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22deprecated%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L299" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L300" target="_blank">View source</a>
 </small>
 
 
@@ -640,7 +640,7 @@ old_func()  # error: [deprecated]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22division-by-zero%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L290" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L291" target="_blank">View source</a>
 </small>
 
 
@@ -673,7 +673,7 @@ false positives it can produce.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22duplicate-base%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L308" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L309" target="_blank">View source</a>
 </small>
 
 
@@ -704,7 +704,7 @@ class B(A, A): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.12">0.0.1-alpha.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22duplicate-kw-only%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L317" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L318" target="_blank">View source</a>
 </small>
 
 
@@ -747,7 +747,7 @@ class A:  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22empty-body%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L473" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L474" target="_blank">View source</a>
 </small>
 
 
@@ -797,7 +797,7 @@ def bar() -> str:  # error: [empty-body]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.61">0.0.61</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22erased-cast-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1683" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1712" target="_blank">View source</a>
 </small>
 
 
@@ -858,7 +858,7 @@ def h(x: object):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.3">0.0.1-alpha.3</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22erased-type-check%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1908" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1937" target="_blank">View source</a>
 </small>
 
 
@@ -936,7 +936,7 @@ def foo() -> "intt\b": ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22escaping-local%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1187" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1188" target="_blank">View source</a>
 </small>
 
 
@@ -975,7 +975,7 @@ def f(local fn: () -> None):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22escaping-loop-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1648" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1677" target="_blank">View source</a>
 </small>
 
 
@@ -1016,7 +1016,7 @@ for x in [1, 2, 3]:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.50">0.0.50</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22experimental-syntax%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L218" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L219" target="_blank">View source</a>
 </small>
 
 
@@ -1056,7 +1056,7 @@ def g(value: ~A) -> None: ...  # error: [experimental-syntax]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22final-on-non-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2014" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2043" target="_blank">View source</a>
 </small>
 
 
@@ -1091,7 +1091,7 @@ def my_function() -> int:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.40">0.0.40</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22final-on-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2023" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2052" target="_blank">View source</a>
 </small>
 
 
@@ -1126,7 +1126,7 @@ let a = 1
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22final-without-value%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2052" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2081" target="_blank">View source</a>
 </small>
 
 
@@ -1242,7 +1242,7 @@ def test() -> "Literal[5]":
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22inconsistent-mro%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L400" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L401" target="_blank">View source</a>
 </small>
 
 
@@ -1278,7 +1278,7 @@ class C(A, B): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22index-out-of-bounds%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L409" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L410" target="_blank">View source</a>
 </small>
 
 
@@ -1308,7 +1308,7 @@ t[3]  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.33">0.0.1-alpha.33</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22ineffective-final%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2005" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2034" target="_blank">View source</a>
 </small>
 
 
@@ -1345,7 +1345,7 @@ class MyClass: ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.12">0.0.1-alpha.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22instance-layout-conflict%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L354" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L355" target="_blank">View source</a>
 </small>
 
 
@@ -1446,7 +1446,7 @@ an atypical memory layout.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-argument-type%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L446" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L447" target="_blank">View source</a>
 </small>
 
 
@@ -1478,7 +1478,7 @@ func("foo")  # error: [invalid-argument-type]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-assignment%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L482" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L483" target="_blank">View source</a>
 </small>
 
 
@@ -1509,7 +1509,7 @@ a: int = ""  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-attribute-access%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2245" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2274" target="_blank">View source</a>
 </small>
 
 
@@ -1567,7 +1567,7 @@ C.instance_only_var = 56  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.33">0.0.33</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-attribute-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2326" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2355" target="_blank">View source</a>
 </small>
 
 
@@ -1613,7 +1613,7 @@ class Sub(Base):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.19">0.0.1-alpha.19</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-await%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L491" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L492" target="_blank">View source</a>
 </small>
 
 
@@ -1655,7 +1655,7 @@ asyncio.run(main())
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-base%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L500" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L501" target="_blank">View source</a>
 </small>
 
 
@@ -1682,7 +1682,7 @@ class A(42): ...  # error: [invalid-base]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-context-manager%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L527" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L528" target="_blank">View source</a>
 </small>
 
 
@@ -1712,7 +1712,7 @@ with 1:  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.39">0.0.1-alpha.39</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-conversion%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1107" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1108" target="_blank">View source</a>
 </small>
 
 
@@ -1745,7 +1745,7 @@ class Fahrenheit:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.12">0.0.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-dataclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L344" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L345" target="_blank">View source</a>
 </small>
 
 
@@ -1798,7 +1798,7 @@ See: <https://docs.python.org/3/library/dataclasses.html#dataclasses.dataclass>
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.13">0.0.13</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-dataclass-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L335" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L336" target="_blank">View source</a>
 </small>
 
 
@@ -1834,7 +1834,7 @@ class A:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-declaration%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L536" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L537" target="_blank">View source</a>
 </small>
 
 
@@ -1866,7 +1866,7 @@ a: str  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-enum-member-annotation%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L554" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L555" target="_blank">View source</a>
 </small>
 
 
@@ -1923,7 +1923,7 @@ class Pet(Enum):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-exception-caught%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L545" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L546" target="_blank">View source</a>
 </small>
 
 
@@ -1987,7 +1987,7 @@ This rule corresponds to Ruff's [`except-with-non-exception-classes` (`B030`)](h
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.28">0.0.1-alpha.28</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-explicit-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2079" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2108" target="_blank">View source</a>
 </small>
 
 
@@ -2040,7 +2040,7 @@ class D(A):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.3">0.0.1-alpha.3</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-extension%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L997" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L998" target="_blank">View source</a>
 </small>
 
 
@@ -2073,7 +2073,7 @@ extension list[T: int]:  # error: `list` declares no type parameter `T`
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.4">0.0.1-alpha.4</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-field-lookup%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1164" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1165" target="_blank">View source</a>
 </small>
 
 
@@ -2102,7 +2102,7 @@ Author.objects.filter(name__startswith=1) # error: lookup wants `str`
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.36">0.0.1-alpha.36</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-fixture-type%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1398" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1399" target="_blank">View source</a>
 </small>
 
 
@@ -2138,7 +2138,7 @@ def test_user(user: int) -> None:  # error: fixture provides `str`
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.35">0.0.1-alpha.35</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-frozen-dataclass-subclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2345" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2374" target="_blank">View source</a>
 </small>
 
 
@@ -2189,7 +2189,7 @@ class NonFrozenChild(FrozenBase):  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-generic-class%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L572" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L573" target="_blank">View source</a>
 </small>
 
 
@@ -2238,7 +2238,7 @@ class D(Generic[U, T]): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.12">0.0.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-generic-enum%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L563" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L564" target="_blank">View source</a>
 </small>
 
 
@@ -2334,7 +2334,7 @@ a = 20 / 0  # type: ignore
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.5">0.0.1-alpha.5</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-implementation%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1075" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1076" target="_blank">View source</a>
 </small>
 
 
@@ -2372,7 +2372,7 @@ implementation Concrete for B:  # error: not an abstract class or protocol
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.17">0.0.1-alpha.17</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-key%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L419" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L420" target="_blank">View source</a>
 </small>
 
 
@@ -2420,7 +2420,7 @@ carol = Person(name="Carol", aeg=25)  # typo!
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-legacy-positional-parameter%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2363" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2392" target="_blank">View source</a>
 </small>
 
 
@@ -2482,7 +2482,7 @@ def f(x, y, /):  # Python 3.8+ syntax
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-legacy-type-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L590" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L591" target="_blank">View source</a>
 </small>
 
 
@@ -2522,7 +2522,7 @@ def f(t: TypeVar("U")): ...  # ty: ignore[invalid-type-form]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.18">0.0.18</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-match-pattern%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L707" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L708" target="_blank">View source</a>
 </small>
 
 
@@ -2572,7 +2572,7 @@ match object():
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-metaclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L635" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L636" target="_blank">View source</a>
 </small>
 
 
@@ -2607,7 +2607,7 @@ class B(metaclass=42): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.20">0.0.1-alpha.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-method-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2335" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2364" target="_blank">View source</a>
 </small>
 
 
@@ -2725,7 +2725,7 @@ Correct use of `@override` is enforced by ty's [`invalid-explicit-override`](#in
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.19">0.0.1-alpha.19</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-named-tuple%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L382" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L383" target="_blank">View source</a>
 </small>
 
 
@@ -2782,7 +2782,7 @@ AttributeError: Cannot overwrite NamedTuple attribute _asdict
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.31">0.0.31</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-named-tuple-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L391" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L392" target="_blank">View source</a>
 </small>
 
 
@@ -2830,7 +2830,7 @@ admin[0]  # "Alice"
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.27">0.0.1-alpha.27</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-newtype%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L617" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L618" target="_blank">View source</a>
 </small>
 
 
@@ -2868,7 +2868,7 @@ Baz = NewType("Baz", int | str)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-overload%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L644" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L645" target="_blank">View source</a>
 </small>
 
 
@@ -2925,7 +2925,7 @@ def foo(x: int) -> int: ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-parameter-default%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L662" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L663" target="_blank">View source</a>
 </small>
 
 
@@ -2954,7 +2954,7 @@ def f(a: int = ""): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.36">0.0.1-alpha.36</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-parametrize%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1484" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1485" target="_blank">View source</a>
 </small>
 
 
@@ -2987,7 +2987,7 @@ def test_add(a: int, b: int) -> None:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-paramspec%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L599" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L600" target="_blank">View source</a>
 </small>
 
 
@@ -3023,7 +3023,7 @@ P2 = ParamSpec()  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-protocol%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L363" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L364" target="_blank">View source</a>
 </small>
 
 
@@ -3059,7 +3059,7 @@ TypeError: Protocols can only inherit from other protocols, got <class 'int'>
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-raise%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L671" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L672" target="_blank">View source</a>
 </small>
 
 
@@ -3130,7 +3130,7 @@ def g():
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.37">0.0.1-alpha.37</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-raises-clause%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1354" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1355" target="_blank">View source</a>
 </small>
 
 
@@ -3158,7 +3158,7 @@ def f() raises int:  # error: `int` is not an exception
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.36">0.0.1-alpha.36</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-regex%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1428" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1429" target="_blank">View source</a>
 </small>
 
 
@@ -3191,7 +3191,7 @@ if m := re.match("(a)(b)", "ab"):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-return-type%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L455" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L456" target="_blank">View source</a>
 </small>
 
 
@@ -3223,7 +3223,7 @@ def func() -> int:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-super-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L680" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L681" target="_blank">View source</a>
 </small>
 
 
@@ -3334,7 +3334,7 @@ class C: ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.10">0.0.10</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-total-ordering%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2354" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2383" target="_blank">View source</a>
 </small>
 
 
@@ -3385,7 +3385,7 @@ class MyClass:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.6">0.0.1-alpha.6</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-alias-type%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L608" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L609" target="_blank">View source</a>
 </small>
 
 
@@ -3426,7 +3426,7 @@ NewAlias = TypeAliasType(get_name(), int)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.29">0.0.1-alpha.29</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-arguments%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L864" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L865" target="_blank">View source</a>
 </small>
 
 
@@ -3493,7 +3493,7 @@ Bar[int]  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-checking-constant%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L689" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L690" target="_blank">View source</a>
 </small>
 
 
@@ -3526,7 +3526,7 @@ TYPE_CHECKING = ""  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-form%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L698" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L699" target="_blank">View source</a>
 </small>
 
 
@@ -3562,7 +3562,7 @@ b: Annotated[int]  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.11">0.0.1-alpha.11</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-guard-definition%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L716" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L717" target="_blank">View source</a>
 </small>
 
 
@@ -3619,7 +3619,7 @@ class C:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-variable-bound%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L746" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L747" target="_blank">View source</a>
 </small>
 
 
@@ -3663,7 +3663,7 @@ def g[U, T: U](): ...  # error: [invalid-type-variable-bound]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-variable-constraints%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L737" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L738" target="_blank">View source</a>
 </small>
 
 
@@ -3720,7 +3720,7 @@ V = TypeVar("V", list[int], int)  # valid constrained Type
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.16">0.0.16</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-variable-default%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L755" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L756" target="_blank">View source</a>
 </small>
 
 
@@ -3762,7 +3762,7 @@ U = TypeVar("U", int, str, default=bytes)  # error: [invalid-type-variable-defau
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.28">0.0.28</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-typed-dict-field%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2308" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2337" target="_blank">View source</a>
 </small>
 
 
@@ -3798,7 +3798,7 @@ class Child(Base):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-typed-dict-header%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2317" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2346" target="_blank">View source</a>
 </small>
 
 
@@ -3841,7 +3841,7 @@ def f(options: dict[str, object]):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.9">0.0.9</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-typed-dict-statement%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2299" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2328" target="_blank">View source</a>
 </small>
 
 
@@ -3876,7 +3876,7 @@ class Foo(TypedDict):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.25">0.0.25</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-yield%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L464" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L465" target="_blank">View source</a>
 </small>
 
 
@@ -3911,7 +3911,7 @@ def gen() -> Iterator[int]:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22isinstance-against-protocol%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L428" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L429" target="_blank">View source</a>
 </small>
 
 
@@ -3978,7 +3978,7 @@ def h(arg2: type):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22isinstance-against-typed-dict%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L437" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L438" target="_blank">View source</a>
 </small>
 
 
@@ -4028,7 +4028,7 @@ def g(arg: object):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.36">0.0.1-alpha.36</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22iteration-over-character%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1953" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1982" target="_blank">View source</a>
 </small>
 
 
@@ -4059,7 +4059,7 @@ def f(s: str):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.30">0.0.30</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22mismatched-type-name%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L626" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L627" target="_blank">View source</a>
 </small>
 
 
@@ -4102,7 +4102,7 @@ Movie = TypedDict("Film", {"title": str})  # error: [mismatched-type-name]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22missing-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L773" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L774" target="_blank">View source</a>
 </small>
 
 
@@ -4133,7 +4133,7 @@ func()  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.61">0.0.61</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22missing-context-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1793" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1822" target="_blank">View source</a>
 </small>
 
 
@@ -4164,7 +4164,7 @@ f(1)                  # ok — `s` is passed implicitly
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.4">0.0.1-alpha.4</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22missing-framework-stubs%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1024" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1025" target="_blank">View source</a>
 </small>
 
 
@@ -4192,7 +4192,7 @@ from django.db import models  # warning: install `django-stubs` for precise type
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.41">0.0.41</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22missing-override-decorator%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2088" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2117" target="_blank">View source</a>
 </small>
 
 
@@ -4251,7 +4251,7 @@ class ExplicitChild(Parent):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.45">0.0.45</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22missing-type-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L782" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L783" target="_blank">View source</a>
 </small>
 
 
@@ -4290,7 +4290,7 @@ def handle(m: re.Match[str]) -> str:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.20">0.0.1-alpha.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22missing-typed-dict-key%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2290" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2319" target="_blank">View source</a>
 </small>
 
 
@@ -4329,7 +4329,7 @@ alice["age"]  # KeyError
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22narrowing-guard-as-value%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1591" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1592" target="_blank">View source</a>
 </small>
 
 
@@ -4363,7 +4363,7 @@ def f(a: int | None):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22no-matching-overload%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L846" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L847" target="_blank">View source</a>
 </small>
 
 
@@ -4401,7 +4401,7 @@ func("string")  # error: [no-matching-overload]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.30">0.0.30</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22non-callable-init-subclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L581" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L582" target="_blank">View source</a>
 </small>
 
 
@@ -4439,7 +4439,7 @@ class Sub(Super): ...  # error: [non-callable-init-subclass]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.39">0.0.1-alpha.39</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22non-exhaustive-statement-expression%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1305" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1306" target="_blank">View source</a>
 </small>
 
 
@@ -4470,7 +4470,7 @@ def f(x: int | str) -> int:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.61">0.0.61</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22non-overlapping-cast%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1738" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1767" target="_blank">View source</a>
 </small>
 
 
@@ -4499,7 +4499,7 @@ def f(a: object):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22not-iterable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L873" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L874" target="_blank">View source</a>
 </small>
 
 
@@ -4528,7 +4528,7 @@ for i in 34:  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22not-subscriptable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L855" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L856" target="_blank">View source</a>
 </small>
 
 
@@ -4556,7 +4556,7 @@ Subscripting an object that does not support it will raise a `TypeError` at runt
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22once-called-twice%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1511" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1512" target="_blank">View source</a>
 </small>
 
 
@@ -4585,7 +4585,7 @@ def f(once done: () -> None):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22once-not-called%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1376" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1377" target="_blank">View source</a>
 </small>
 
 
@@ -4613,7 +4613,7 @@ def f(once done: () -> None):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.61">0.0.61</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22optional-object-conversion%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1761" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1790" target="_blank">View source</a>
 </small>
 
 
@@ -4651,7 +4651,7 @@ def f(x: int?):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.29">0.0.1-alpha.29</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22override-of-final-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1987" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2016" target="_blank">View source</a>
 </small>
 
 
@@ -4688,7 +4688,7 @@ class B(A):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.16">0.0.16</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22override-of-final-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1996" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2025" target="_blank">View source</a>
 </small>
 
 
@@ -4725,7 +4725,7 @@ class B(A):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.38">0.0.1-alpha.38</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22override-raise%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1245" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1246" target="_blank">View source</a>
 </small>
 
 
@@ -4768,7 +4768,7 @@ def main():
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22parameter-already-assigned%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L891" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L892" target="_blank">View source</a>
 </small>
 
 
@@ -4799,7 +4799,7 @@ f(1, x=2)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22positional-only-parameter-as-kwarg%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2173" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2202" target="_blank">View source</a>
 </small>
 
 
@@ -4830,7 +4830,7 @@ f(x=1)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-missing-attribute%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L900" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L901" target="_blank">View source</a>
 </small>
 
 
@@ -4869,7 +4869,7 @@ A.c  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-missing-implicit-call%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L245" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L246" target="_blank">View source</a>
 </small>
 
 
@@ -4908,7 +4908,7 @@ A()[0]  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-missing-import%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L918" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L919" target="_blank">View source</a>
 </small>
 
 
@@ -4954,7 +4954,7 @@ from module import a  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.23">0.0.23</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-missing-submodule%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L909" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L910" target="_blank">View source</a>
 </small>
 
 
@@ -4986,7 +4986,7 @@ html.parser  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-unresolved-reference%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L927" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L928" target="_blank">View source</a>
 </small>
 
 
@@ -5023,7 +5023,7 @@ print(x)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22private-import%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L971" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L972" target="_blank">View source</a>
 </small>
 
 
@@ -5055,7 +5055,7 @@ from helpers import Key  # error: `Key` is private to `helpers`
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.60">0.0.60</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22pydantic-discarded-extra-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2160" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2189" target="_blank">View source</a>
 </small>
 
 
@@ -5130,7 +5130,7 @@ def test() -> "int":
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22redundant-cast%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2254" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2283" target="_blank">View source</a>
 </small>
 
 
@@ -5165,7 +5165,7 @@ cast(int, f())  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.18">0.0.18</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22redundant-final-classvar%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2263" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2292" target="_blank">View source</a>
 </small>
 
 
@@ -5203,7 +5203,7 @@ class C:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.3">0.0.1-alpha.3</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22reified-classmethod%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1881" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1910" target="_blank">View source</a>
 </small>
 
 
@@ -5236,7 +5236,7 @@ class C:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22shadowed-type-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2272" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2301" target="_blank">View source</a>
 </small>
 
 
@@ -5280,7 +5280,7 @@ class Outer[T]:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22static-assert-error%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2236" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2265" target="_blank">View source</a>
 </small>
 
 
@@ -5315,7 +5315,7 @@ static_assert(int(2.0 * 3.0) == 6)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.39">0.0.39</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22subclass-of-dataclass-with-order%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1978" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2007" target="_blank">View source</a>
 </small>
 
 
@@ -5366,7 +5366,7 @@ Consider using [`functools.total_ordering`][total_ordering] instead, which does 
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22subclass-of-final-class%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L936" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L937" target="_blank">View source</a>
 </small>
 
 
@@ -5400,7 +5400,7 @@ class B(A): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22subclass-of-sealed-class%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L945" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L946" target="_blank">View source</a>
 </small>
 
 
@@ -5432,7 +5432,7 @@ class Circle(Shape): ...  # error: `Shape` is sealed in another workspace
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.30">0.0.1-alpha.30</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22super-call-in-named-tuple-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2133" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2162" target="_blank">View source</a>
 </small>
 
 
@@ -5472,7 +5472,7 @@ class F(NamedTuple):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22too-many-positional-arguments%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2115" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2144" target="_blank">View source</a>
 </small>
 
 
@@ -5502,7 +5502,7 @@ f("foo")  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22trailing-lambda-control-flow%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1534" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1535" target="_blank">View source</a>
 </small>
 
 
@@ -5535,13 +5535,47 @@ def find(items: list[int]) -> int:
     return -1
 ```
 
+## `trailing-lambda-parameters`
+
+<small>
+Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
+Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
+<a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22trailing-lambda-parameters%22" target="_blank">Related issues</a> ·
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1649" target="_blank">View source</a>
+</small>
+
+
+**What it does**
+
+Checks for a trailing-lambda block whose callback takes arguments the
+block has no parameter for.
+
+**Why is this bad?**
+
+A block binds one argument, as `it` — plus its callback's implicit
+receiver, which the body spells `self` and reads members off
+unqualified. A callback that takes more than that, or takes a variadic
+parameter, passes arguments the block cannot name, and would be called
+with more arguments than it declares.
+
+**Example**
+
+
+```by
+def f(a: (int, str) -> None):
+    a(1, "two")
+
+f:  # error: the block binds only `it`, so `"two"` has nowhere to go
+    print(it)
+```
+
 ## `trailing-lambda-return-type`
 
 <small>
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22trailing-lambda-return-type%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1619" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1620" target="_blank">View source</a>
 </small>
 
 
@@ -5576,7 +5610,7 @@ f:  # error: the block returns `None`, not `str`
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22type-assertion-failure%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2097" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2126" target="_blank">View source</a>
 </small>
 
 
@@ -5615,7 +5649,7 @@ def _(x: int):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.4">0.0.1-alpha.4</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unannotated-model-field%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1220" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1221" target="_blank">View source</a>
 </small>
 
 
@@ -5646,7 +5680,7 @@ class User(BaseModel):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unavailable-implicit-super-arguments%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2124" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2153" target="_blank">View source</a>
 </small>
 
 
@@ -5704,7 +5738,7 @@ class A:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unbound-type-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L764" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L765" target="_blank">View source</a>
 </small>
 
 
@@ -5748,7 +5782,7 @@ class C(Generic[T]):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.37">0.0.1-alpha.37</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22undeclared-raise%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1282" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1283" target="_blank">View source</a>
 </small>
 
 
@@ -5777,7 +5811,7 @@ def f() raises TypeError:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22undefined-reveal%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2142" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2171" target="_blank">View source</a>
 </small>
 
 
@@ -5806,7 +5840,7 @@ reveal_type(1)  # revealed: Literal[1]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.37">0.0.1-alpha.37</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unhandled-exception%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1330" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1331" target="_blank">View source</a>
 </small>
 
 
@@ -5836,7 +5870,7 @@ def main():
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unknown-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2151" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2180" target="_blank">View source</a>
 </small>
 
 
@@ -5867,7 +5901,7 @@ f(x=1, y=2)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.36">0.0.1-alpha.36</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unknown-fixture%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1455" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1456" target="_blank">View source</a>
 </small>
 
 
@@ -5903,7 +5937,7 @@ def test_thing(no_such_fixture) -> None:  # requests an unknown fixture
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-attribute%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2182" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2211" target="_blank">View source</a>
 </small>
 
 
@@ -5936,7 +5970,7 @@ A().foo  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.15">0.0.1-alpha.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-global%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2281" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2310" target="_blank">View source</a>
 </small>
 
 
@@ -6011,7 +6045,7 @@ def g():
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-import%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2191" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2220" target="_blank">View source</a>
 </small>
 
 
@@ -6040,7 +6074,7 @@ import foo  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-narrowing-guard%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1567" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1568" target="_blank">View source</a>
 </small>
 
 
@@ -6070,7 +6104,7 @@ def check(value: int | None) -> asserts values:  # error: `values` is nothing
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-reference%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2200" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2229" target="_blank">View source</a>
 </small>
 
 
@@ -6098,7 +6132,7 @@ print(x)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.3">0.0.1-alpha.3</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unspecialized-reified-generic%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1845" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1874" target="_blank">View source</a>
 </small>
 
 
@@ -6140,7 +6174,7 @@ g(1)       # ok — transpiles to g[int](1)
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.7">0.0.1-alpha.7</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsupported-base%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L509" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L510" target="_blank">View source</a>
 </small>
 
 
@@ -6187,7 +6221,7 @@ class D(C): ...  # error: [unsupported-base]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsupported-bool-conversion%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L882" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L883" target="_blank">View source</a>
 </small>
 
 
@@ -6236,7 +6270,7 @@ b1 < b2 < b1  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.12">0.0.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsupported-dynamic-base%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L518" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L519" target="_blank">View source</a>
 </small>
 
 
@@ -6283,7 +6317,7 @@ def factory(base: type[Base]) -> type:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsupported-operator%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2209" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2238" target="_blank">View source</a>
 </small>
 
 
@@ -6316,7 +6350,7 @@ A() + A()  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.21">0.0.21</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unused-awaitable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2218" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2247" target="_blank">View source</a>
 </small>
 
 
@@ -6436,7 +6470,7 @@ to `false`.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22useless-overload-body%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L653" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L654" target="_blank">View source</a>
 </small>
 
 
@@ -6515,7 +6549,7 @@ def foo(x: int | str) -> int | str:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22zero-stepsize-in-slice%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2227" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2256" target="_blank">View source</a>
 </small>
 
 

--- a/crates/ty_ide/src/inlay_hints.rs
+++ b/crates/ty_ide/src/inlay_hints.rs
@@ -19,7 +19,7 @@ use ty_python_semantic::types::context_params::implicit_context_arguments;
 use ty_python_semantic::types::ide_support::{
     InlayHintCallArgumentDetails, hintable_parameter_type, inferred_override, inferred_raises,
     inferred_type_param_variance, inlay_hint_call_argument_details, is_reveal_type_function,
-    numeric_promotion, trailing_lambda_implicit_parameter, type_parameter_names,
+    numeric_promotion, trailing_lambda_implicit_parameters, type_parameter_names,
 };
 use ty_python_semantic::types::{Type, TypeDetail};
 use ty_python_semantic::{HasType, SemanticModel, with_display_for_file};
@@ -331,18 +331,23 @@ impl InlayHint {
         }
     }
 
-    /// A parameter the source never spells, shown where it would be written.
-    fn implicit_parameter(
+    /// The parameters a source never spells, shown where they would be written.
+    fn implicit_parameters(
         db: &dyn Db,
         position: TextSize,
-        name: &str,
-        ty: Option<Type>,
+        parameters: &[(&str, Option<Type>)],
         parameter_follows: bool,
     ) -> Self {
-        let mut parts = vec![InlayHintLabelPart::new(name)];
+        let mut parts = Vec::new();
 
-        if let Some(ty) = ty {
-            parts.push(format!(": {}", ty.display(db)).into());
+        for (index, (name, ty)) in parameters.iter().enumerate() {
+            if index > 0 {
+                parts.push(", ".into());
+            }
+            parts.push(InlayHintLabelPart::new(*name));
+            if let Some(ty) = ty {
+                parts.push(format!(": {}", ty.display(db)).into());
+            }
         }
 
         if parameter_follows {
@@ -1018,17 +1023,16 @@ impl<'a, 'db> InlayHintVisitor<'a, 'db> {
         let position = parameter.range().start();
         let ty = hintable_parameter_type(&self.model, parameter);
 
-        self.hints.push(InlayHint::implicit_parameter(
+        self.hints.push(InlayHint::implicit_parameters(
             self.db,
             position,
-            parameter.name.as_str(),
-            ty,
+            &[(parameter.name.as_str(), ty)],
             self.parameter_follows(position),
         ));
     }
 
-    /// basedpython: hint the parameter a trailing lambda block binds — `it`, or
-    /// the receiver spelled `self` when the callback declares one.
+    /// basedpython: hint the parameters a trailing lambda block binds — `it`,
+    /// preceded by the receiver spelled `self` when the callback declares one.
     ///
     /// The parser anchors the synthetic parameter *on* the block's `:`, but the
     /// binding belongs to the suite that opens after it, so the hint sits past
@@ -1047,15 +1051,15 @@ impl<'a, 'db> InlayHintVisitor<'a, 'db> {
             return;
         }
 
-        let Some((name, ty)) = trailing_lambda_implicit_parameter(&self.model, function) else {
+        let parameters = trailing_lambda_implicit_parameters(&self.model, function);
+        if parameters.is_empty() {
             return;
-        };
+        }
 
-        self.hints.push(InlayHint::implicit_parameter(
+        self.hints.push(InlayHint::implicit_parameters(
             self.db,
             colon + TextSize::from(1),
-            name,
-            ty,
+            &parameters,
             false,
         ));
     }
@@ -9739,6 +9743,9 @@ Source with applied edits:
             def against(fn: str.() -> None) -> None:
                 'a'.fn()
 
+            def against_with(fn: str.(int) -> None) -> None:
+                'a'.fn(1)
+
             class C:
                 init(a: int)
 
@@ -9749,7 +9756,10 @@ Source with applied edits:
                 print(it)
 
             against:
-                print(it)
+                print(upper())
+
+            against_with:
+                print(upper(), it)
             ",
         );
 

--- a/crates/ty_ide/src/snapshots/ty_ide__inlay_hints__tests__basedpython_implicit_parameters.snap
+++ b/crates/ty_ide/src/snapshots/ty_ide__inlay_hints__tests__basedpython_implicit_parameters.snap
@@ -9,6 +9,9 @@ def apply(fn: (int) -> None) -> None:
 def against(fn: str.() -> None) -> None:
     'a'.fn()
 
+def against_with(fn: str.(int) -> None) -> None:
+    'a'.fn(1)
+
 class C:
     init([self, ]a: int)
 
@@ -19,4 +22,7 @@ apply:[it: int]
     print(it)
 
 against:[self: str]
-    print(it)
+    print(upper())
+
+against_with:[self: str, it: int]
+    print(upper(), it)

--- a/crates/ty_python_semantic/resources/mdtest/basedpython_escaping_local.md
+++ b/crates/ty_python_semantic/resources/mdtest/basedpython_escaping_local.md
@@ -196,6 +196,25 @@ f:
     sink(it)
 ```
 
+## a receiver callback's `local` argument is still `it`
+
+A block binds its callback's [receiver](basedpython_implicit_receiver.md) implicitly, as `self`, so
+the parameter *after* the receiver is the one `it` binds — and the one whose `local` constrains the
+block.
+
+```by
+class Resource: ...
+
+def sink(r: Resource): ...
+
+def f(fn: str.(local Resource) -> None):
+    fn("a", Resource())
+
+f:
+    # error: [escaping-local] "local `it` cannot escape the call: it is passed as a non-`local` argument"
+    sink(it)
+```
+
 ## a borrowed `it` may be used freely within the block
 
 ```by

--- a/crates/ty_python_semantic/resources/mdtest/basedpython_implicit_receiver.md
+++ b/crates/ty_python_semantic/resources/mdtest/basedpython_implicit_receiver.md
@@ -4,7 +4,7 @@ a callable type may declare a *receiver* — `int.() -> str` is a callable whose
 receiver it runs against. the receiver is an ordinary leading positional parameter, so any function
 of the same shape satisfies it, and it additionally unlocks two forms: calling the callable as a
 method of the receiver (`x.fn()`), and a trailing lambda block whose body sees the receiver's
-members unqualified
+members unqualified and spells the receiver itself `self`
 
 ```toml
 [environment]
@@ -103,8 +103,9 @@ def apply(fn: (int) -> str) -> None:
 
 ## trailing lambda blocks
 
-a trailing lambda block bound to a receiver callable sees the receiver's members unqualified — the
-block's implicit `it` parameter *is* the receiver
+a trailing lambda block bound to a receiver callable sees the receiver's members unqualified, and
+spells the receiver itself `self`. the block's implicit `it` parameter is the callback's *own*
+argument — the one after the receiver
 
 ### the receiver's members are in scope
 
@@ -113,9 +114,37 @@ def apply(fn: int.() -> None) -> None:
     fn(1)
 
 apply:
-    reveal_type(it)  # revealed: int
+    reveal_type(self)  # revealed: int
     reveal_type(imag)  # revealed: 0
     reveal_type(bit_length())  # revealed: int
+```
+
+### a receiver callback's argument is `it`
+
+```by
+def apply(fn: int.(str) -> None) -> None:
+    fn(1, "a")
+
+apply:
+    reveal_type(self)  # revealed: int
+    reveal_type(it)  # revealed: str
+    reveal_type(bit_length())  # revealed: int
+```
+
+### an enclosing `self` keeps its meaning
+
+the receiver is the last fallback, so a method's own `self` still wins — its members are the ones in
+scope unqualified either way
+
+```by
+def apply(fn: int.() -> None) -> None:
+    fn(1)
+
+class C:
+    def m(self) -> None:
+        apply:
+            reveal_type(self)  # revealed: Self@m
+            reveal_type(imag)  # revealed: 0
 ```
 
 ## an enclosing binding wins

--- a/crates/ty_python_semantic/resources/mdtest/basedpython_trailing_lambda.md
+++ b/crates/ty_python_semantic/resources/mdtest/basedpython_trailing_lambda.md
@@ -42,6 +42,61 @@ g:
     print(it)
 ```
 
+## the callback may not take more than the block binds
+
+A block binds one argument, as `it`. A callback that takes more would be called with arguments the
+block has no parameter for, and that the body cannot name.
+
+```by
+def f(a: (int, str) -> None):
+    a(1, "two")
+
+f:  # error: [trailing-lambda-parameters] "a trailing-lambda block binds one argument, but this callback takes 2"
+    print(it)
+```
+
+A keyword-only parameter counts too — the block declares no name for it either.
+
+```by
+def g(a: (int, *, flag: bool) -> None):
+    a(1, flag=True)
+
+g:  # error: [trailing-lambda-parameters] "a trailing-lambda block binds one argument, but this callback takes 2"
+    print(it)
+```
+
+A variadic parameter stands for any number of arguments, so a block can never fill it.
+
+```by
+def h(a: (*: int) -> None):
+    a(1)
+
+h:  # error: [trailing-lambda-parameters] "a trailing-lambda block binds one argument, so it cannot fill a callback with a variadic parameter"
+    print(it)
+```
+
+The gradual form is the deliberately unchecked one, and is left alone.
+
+```by
+def gradual(a: (...) -> None):
+    a(1)
+
+gradual:
+    print(it)
+```
+
+The receiver of an [implicit receiver](basedpython_implicit_receiver.md) callback is bound by the
+block itself, so it does not count against the one argument `it` binds.
+
+```by
+def against(a: str.(int) -> None):
+    a("a", 1)
+
+against:
+    reveal_type(self)  # revealed: str
+    reveal_type(it)  # revealed: int
+```
+
 ## earlier defaulted parameters keep their defaults
 
 A required parameter may follow a defaulted one in a `def` — the trailing block binds the last

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -21,7 +21,7 @@ use ruff_db::source::{SourceTextError, source_text};
 use rustc_hash::FxHasher;
 pub use semantic_model::{
     Completion, ExpectedStringLiteralCompletion, HasDefinition, HasOptionalDefinition, HasType,
-    MemberDefinition, NameKind, SemanticModel,
+    ImplicitReceiverReference, MemberDefinition, NameKind, SemanticModel,
 };
 use std::hash::BuildHasherDefault;
 pub use suppression::{

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -411,21 +411,29 @@ impl<'db> SemanticModel<'db> {
         .is_some()
     }
 
-    /// basedpython: whether a bare name resolves to a member of the enclosing
-    /// trailing lambda block's receiver, which the transpiler rewrites to
-    /// `it.<name>`. `false` for every name that resolves any other way — the
-    /// receiver's members are the last fallback
-    pub fn implicit_receiver_name(&self, name: &ast::ExprName) -> bool {
-        let Some(scope) = self.scope(ast::AnyNodeRef::from(name)) else {
-            return false;
-        };
-        crate::types::receivers::implicit_receiver_member(
+    /// basedpython: how a bare name resolves through the enclosing trailing
+    /// lambda block's receiver, which the transpiler rewrites to the block's
+    /// receiver parameter. `None` for every name that resolves any other way —
+    /// the receiver and its members are the last fallback
+    pub fn implicit_receiver_name(
+        &self,
+        name: &ast::ExprName,
+    ) -> Option<ImplicitReceiverReference> {
+        let scope = self.scope(ast::AnyNodeRef::from(name))?;
+        let resolved = crate::types::receivers::implicit_receiver_name(
             self.db,
             self.file,
             scope.to_scope_id(self.db, self.file),
             name.id.as_str(),
-        )
-        .is_some()
+        )?;
+        Some(match resolved {
+            crate::types::receivers::ImplicitReceiverName::Receiver(_) => {
+                ImplicitReceiverReference::Receiver
+            }
+            crate::types::receivers::ImplicitReceiverName::Member(_) => {
+                ImplicitReceiverReference::Member
+            }
+        })
     }
 
     /// basedpython: the enum a *context-sensitively* resolved name must be
@@ -469,6 +477,15 @@ impl<'db> SemanticModel<'db> {
         let callee_ty = callee.inferred_type(self)?;
         crate::types::trailing_lambda::trailing_lambda_keyword(self.db, callee_ty)
             .map(|name| name.to_string())
+    }
+
+    /// basedpython: whether the trailing-lambda callee's callback declares an
+    /// implicit receiver — the block then binds it as a leading parameter, which
+    /// its body reads members off unqualified and spells `self`
+    pub fn trailing_lambda_callback_has_receiver(&self, callee: &ast::Expr) -> bool {
+        callee.inferred_type(self).is_some_and(|ty| {
+            crate::types::trailing_lambda::trailing_lambda_receiver_type(self.db, ty).is_some()
+        })
     }
 
     /// basedpython: whether the trailing-lambda callee's callback parameter is
@@ -1101,6 +1118,16 @@ fn strip_none<'db>(db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
 pub struct MemberDefinition<'db> {
     pub ty: Type<'db>,
     pub first_reachable_definition: Definition<'db>,
+}
+
+/// basedpython: what a bare name inside a trailing lambda block resolves to
+/// through the block's callback receiver
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ImplicitReceiverReference {
+    /// `self` — the receiver itself
+    Receiver,
+    /// a member read off the receiver
+    Member,
 }
 
 /// A classification of symbol names.

--- a/crates/ty_python_semantic/src/types/context_sensitive.rs
+++ b/crates/ty_python_semantic/src/types/context_sensitive.rs
@@ -261,8 +261,8 @@ pub(crate) fn qualifier_for_unbound_name<'db>(
     }
     // a trailing lambda block's receiver member answers *before* this fallback
     // does, so a receiver whose member happens to be an enum value keeps the
-    // `it.<name>` lowering the checker resolved it to
-    if receivers::implicit_receiver_member(db, file, scope, name).is_some() {
+    // receiver-parameter lowering the checker resolved it to
+    if receivers::implicit_receiver_name(db, file, scope, name).is_some() {
         return None;
     }
     let enum_class = enum_class_of(db, resolved_type()?)?;

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -153,6 +153,7 @@ pub(crate) fn register_lints(registry: &mut LintRegistryBuilder) {
     registry.register_lint(&ONCE_NOT_CALLED);
     registry.register_lint(&ONCE_CALLED_TWICE);
     registry.register_lint(&TRAILING_LAMBDA_CONTROL_FLOW);
+    registry.register_lint(&TRAILING_LAMBDA_PARAMETERS);
     registry.register_lint(&TRAILING_LAMBDA_RETURN_TYPE);
     registry.register_lint(&UNRESOLVED_NARROWING_GUARD);
     registry.register_lint(&NARROWING_GUARD_AS_VALUE);
@@ -1640,6 +1641,34 @@ declare_lint! {
     /// ```
     pub(crate) static TRAILING_LAMBDA_RETURN_TYPE = {
         summary: "detects a trailing-lambda callback whose return type does not accept `None`",
+        status: LintStatus::stable("0.0.1-alpha.1"),
+        default_level: Level::Error,
+    }
+}
+
+declare_lint! {
+    /// ## What it does
+    /// Checks for a trailing-lambda block whose callback takes arguments the
+    /// block has no parameter for.
+    ///
+    /// ## Why is this bad?
+    /// A block binds one argument, as `it` — plus its callback's implicit
+    /// receiver, which the body spells `self` and reads members off
+    /// unqualified. A callback that takes more than that, or takes a variadic
+    /// parameter, passes arguments the block cannot name, and would be called
+    /// with more arguments than it declares.
+    ///
+    /// ## Example
+    ///
+    /// ```by
+    /// def f(a: (int, str) -> None):
+    ///     a(1, "two")
+    ///
+    /// f:  # error: the block binds only `it`, so `"two"` has nowhere to go
+    ///     print(it)
+    /// ```
+    pub(crate) static TRAILING_LAMBDA_PARAMETERS = {
+        summary: "detects a trailing-lambda callback taking arguments the block cannot bind",
         status: LintStatus::stable("0.0.1-alpha.1"),
         default_level: Level::Error,
     }

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -2343,28 +2343,34 @@ pub fn inferred_override<'db>(
         .map(Type::from)
 }
 
-/// basedpython: the parameter a trailing lambda block binds implicitly, as its
-/// name and the type the callee gives it.
+/// basedpython: the parameters a trailing lambda block binds implicitly, each as
+/// its name and the type the callee gives it.
 ///
 /// A callback that declares an implicit receiver (`int.() -> str`) runs
-/// *against* a value, so the block binds that receiver, spelled `self`. An
-/// ordinary callback binds the argument it is passed, spelled `it`.
-pub fn trailing_lambda_implicit_parameter<'db>(
+/// *against* a value, so the block binds that receiver, spelled `self`. The
+/// argument the callback is passed is bound as `it` — the only binding of an
+/// ordinary callback, and the one after the receiver of a receiver callback,
+/// which is left out when there is none.
+pub fn trailing_lambda_implicit_parameters<'db>(
     model: &SemanticModel<'db>,
     function: &ast::StmtFunctionDef,
-) -> Option<(&'static str, Option<Type<'db>>)> {
+) -> Vec<(&'static str, Option<Type<'db>>)> {
     let db = model.db();
-    let callee = function.trailing_lambda_callee()?.inferred_type(model)?;
+    let Some(callee) = function
+        .trailing_lambda_callee()
+        .and_then(|callee| callee.inferred_type(model))
+    else {
+        return Vec::new();
+    };
+    let it = crate::types::trailing_lambda::trailing_lambda_it_type(db, callee);
 
-    if let Some(receiver) = crate::types::trailing_lambda::trailing_lambda_receiver_type(db, callee)
-    {
-        return Some(("self", Some(receiver)));
-    }
-
-    Some((
-        "it",
-        crate::types::trailing_lambda::trailing_lambda_it_type(db, callee),
-    ))
+    let Some(receiver) = crate::types::trailing_lambda::trailing_lambda_receiver_type(db, callee)
+    else {
+        return vec![("it", it)];
+    };
+    let mut parameters = vec![("self", Some(receiver))];
+    parameters.extend(it.map(|it| ("it", Some(it))));
+    parameters
 }
 
 /// The type worth showing for a parameter the source leaves unannotated.

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -11447,19 +11447,20 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             })
             // basedpython only: inside a trailing lambda block whose callback
-            // declares a receiver (`int.() -> None`), the receiver's members are
-            // in scope unqualified. reached last, so a name bound anywhere in the
-            // lexical chain — or a builtin — keeps its ordinary meaning
+            // declares a receiver (`int.() -> None`), the receiver is spelled
+            // `self` and its members are in scope unqualified. reached last, so a
+            // name bound anywhere in the lexical chain — or a builtin — keeps its
+            // ordinary meaning
             .or_fall_back_to(db, || {
                 if self.is_basedpython_file()
-                    && let Some(member) = receivers::implicit_receiver_member(
+                    && let Some(resolved) = receivers::implicit_receiver_name(
                         db,
                         self.file(),
                         self.scope(),
                         symbol_name,
                     )
                 {
-                    Place::bound(member).into()
+                    Place::bound(resolved.ty()).into()
                 } else {
                     Place::Undefined.into()
                 }

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -10,10 +10,11 @@ use crate::{
         diagnostic::{
             FINAL_ON_NON_METHOD, INVALID_FIXTURE_TYPE, INVALID_PARAMETER_DEFAULT,
             INVALID_PARAMETRIZE, INVALID_PARAMSPEC, INVALID_TYPE_FORM, REIFIED_CLASSMETHOD,
-            TRAILING_LAMBDA_RETURN_TYPE, UNKNOWN_FIXTURE, USELESS_OVERLOAD_BODY,
-            add_type_expression_reference_link, is_invalid_typed_dict_literal,
-            report_implicit_return_type, report_invalid_generator_function_return_type,
-            report_invalid_return_type, report_shadowed_type_variable,
+            TRAILING_LAMBDA_PARAMETERS, TRAILING_LAMBDA_RETURN_TYPE, UNKNOWN_FIXTURE,
+            USELESS_OVERLOAD_BODY, add_type_expression_reference_link,
+            is_invalid_typed_dict_literal, report_implicit_return_type,
+            report_invalid_generator_function_return_type, report_invalid_return_type,
+            report_shadowed_type_variable,
         },
         extensions,
         function::{
@@ -35,7 +36,9 @@ use crate::{
         infer_definition_types, infer_expression_types, infer_scope_types,
         lifetimes::InheritedBorrow,
         signatures::ReturnCallableTypeVarScope,
-        trailing_lambda::{trailing_lambda_it_borrow, trailing_lambda_it_type},
+        trailing_lambda::{
+            UnbindableParameters, trailing_lambda_it_borrow, trailing_lambda_it_type,
+        },
         tuple::{TupleSpecBuilder, TupleType},
         typed_dict::extract_unpacked_typed_dict_keys_from_kwargs_annotation,
     },
@@ -162,9 +165,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         crate::types::lifetimes::check_local_lifetimes(&self.context, function, inherited_borrow);
 
         // basedpython: a trailing-lambda block always returns `None`, so its
-        // callback must be declared to return `None`
+        // callback must be declared to return `None`, and it binds one argument,
+        // so its callback may not take more
         if function.is_trailing_lambda {
             self.check_trailing_lambda_callback_returns_none(function);
+            self.check_trailing_lambda_bindable_parameters(function);
         }
 
         // basedpython: a non-`once` trailing-lambda block is an ordinary closure
@@ -1517,21 +1522,25 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         function.is_trailing_lambda.then_some(function)
     }
 
-    /// basedpython: the type of a trailing lambda's implicit `it` parameter,
-    /// read from the callee's standalone-expression inference (registered by
+    /// basedpython: the type of the expression a trailing lambda block is
+    /// attached to, read from its standalone-expression inference (registered by
     /// the semantic index builder — independent of the enclosing definition's
-    /// inference, so no cycle). `None` when the callee's signature or its
-    /// last parameter's callable shape is not inspectable
+    /// inference, so no cycle)
+    fn trailing_lambda_callee_type(&self, function: &ast::StmtFunctionDef) -> Option<Type<'db>> {
+        let callee = function.trailing_lambda_callee()?;
+        let expression = self.index.try_expression(callee)?;
+        infer_expression_types(self.db(), expression, TypeContext::default())
+            .try_expression_type(callee)
+    }
+
+    /// basedpython: the type of a trailing lambda's implicit `it` parameter.
+    /// `None` when the callee's signature or its last parameter's callable shape
+    /// is not inspectable
     fn trailing_lambda_it_parameter_type(
         &self,
         function: &ast::StmtFunctionDef,
     ) -> Option<Type<'db>> {
-        let db = self.db();
-        let callee = function.trailing_lambda_callee()?;
-        let expression = self.index.try_expression(callee)?;
-        let callee_ty = infer_expression_types(db, expression, TypeContext::default())
-            .try_expression_type(callee)?;
-        trailing_lambda_it_type(db, callee_ty)
+        trailing_lambda_it_type(self.db(), self.trailing_lambda_callee_type(function)?)
     }
 
     /// basedpython: the borrow a trailing-lambda block's implicit `it` inherits
@@ -1574,19 +1583,45 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     /// parameter `once` — the block then runs exactly once (`with`-like). Anything
     /// unresolvable is treated as not-`once` (the restricted default).
     fn trailing_lambda_callee_is_once(&self, function: &ast::StmtFunctionDef) -> bool {
+        self.trailing_lambda_callee_type(function)
+            .is_some_and(|callee_ty| {
+                crate::types::trailing_lambda::callee_callback_is_once(self.db(), callee_ty)
+            })
+    }
+
+    /// basedpython: a trailing-lambda block binds one argument, as `it`, plus the
+    /// receiver its callback declares. Report a callback that takes more than
+    /// that: the extra arguments have no parameter to land in, and no spelling
+    /// in the body.
+    fn check_trailing_lambda_bindable_parameters(&self, function: &ast::StmtFunctionDef) {
         let db = self.db();
         let Some(callee) = function.trailing_lambda_callee() else {
-            return false;
+            return;
         };
-        let Some(expression) = self.index.try_expression(callee) else {
-            return false;
+        let Some(callee_ty) = self.trailing_lambda_callee_type(function) else {
+            return;
         };
-        let Some(callee_ty) = infer_expression_types(db, expression, TypeContext::default())
-            .try_expression_type(callee)
+        let Some(unbindable) =
+            crate::types::trailing_lambda::trailing_lambda_unbindable_parameters(db, callee_ty)
         else {
-            return false;
+            return;
         };
-        crate::types::trailing_lambda::callee_callback_is_once(db, callee_ty)
+        let Some(builder) = self
+            .context
+            .report_lint(&TRAILING_LAMBDA_PARAMETERS, callee)
+        else {
+            return;
+        };
+        let message = match unbindable {
+            UnbindableParameters::TooMany(count) => format!(
+                "a trailing-lambda block binds one argument, but this callback takes {count}"
+            ),
+            UnbindableParameters::Variadic => "a trailing-lambda block binds one argument, so it \
+                 cannot fill a callback with a variadic parameter"
+                .to_owned(),
+        };
+        let mut diagnostic = builder.into_diagnostic(message);
+        diagnostic.info("the block's suite takes the implicit parameter `it`");
     }
 
     /// basedpython: a trailing-lambda block lowers to a function returning `None`
@@ -1598,12 +1633,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let Some(callee) = function.trailing_lambda_callee() else {
             return;
         };
-        let Some(expression) = self.index.try_expression(callee) else {
-            return;
-        };
-        let Some(callee_ty) = infer_expression_types(db, expression, TypeContext::default())
-            .try_expression_type(callee)
-        else {
+        let Some(callee_ty) = self.trailing_lambda_callee_type(function) else {
             return;
         };
         let Some(return_ty) =

--- a/crates/ty_python_semantic/src/types/receivers.rs
+++ b/crates/ty_python_semantic/src/types/receivers.rs
@@ -10,6 +10,7 @@
 //!   accepts `x`. only reached when `x` has no member `fn` of its own
 //! - the body of a [trailing lambda] block bound to a receiver callback, where the
 //!   receiver's members are in scope unqualified (`imag` for an `int` receiver)
+//!   and the receiver itself is spelled `self`
 //!
 //! both are *last* fallbacks: a declared member, and any name bound anywhere in
 //! the lexical chain, keeps its ordinary meaning. that is what makes the forms
@@ -117,21 +118,46 @@ pub(crate) fn resolve_receiver_attribute<'db>(
     None
 }
 
-/// basedpython: the receiver member a bare `name` in a trailing lambda block
-/// resolves to, when the block's callback declares a receiver. `None` for a name
-/// that resolves anywhere else — the receiver's members are the last fallback, so
-/// no existing binding is ever captured
-pub(crate) fn implicit_receiver_member<'db>(
+/// basedpython: what a bare name in a trailing lambda block resolves to through
+/// the block's receiver
+pub(crate) enum ImplicitReceiverName<'db> {
+    /// `self` — the receiver itself
+    Receiver(Type<'db>),
+    /// a member of the receiver, read off it in the lowering
+    Member(Type<'db>),
+}
+
+impl<'db> ImplicitReceiverName<'db> {
+    pub(crate) fn ty(&self) -> Type<'db> {
+        match self {
+            Self::Receiver(ty) | Self::Member(ty) => *ty,
+        }
+    }
+}
+
+/// basedpython: what a bare `name` in a trailing lambda block resolves to when
+/// the block's callback declares a receiver: `self` is the receiver, and any
+/// other name is looked up as a member of it. `None` for a name that resolves
+/// anywhere else — both are the last fallback, so no existing binding is ever
+/// captured (a method's own `self` keeps its meaning)
+pub(crate) fn implicit_receiver_name<'db>(
     db: &'db dyn Db,
     file: File,
     scope: ScopeId<'db>,
     name: &str,
-) -> Option<Type<'db>> {
+) -> Option<ImplicitReceiverName<'db>> {
     let receiver = trailing_lambda_scope_receiver(db, file, scope)?;
     if resolves_elsewhere(db, file, scope, name) {
         return None;
     }
-    receiver.member(db, name).place.ignore_possibly_undefined()
+    if name == "self" {
+        return Some(ImplicitReceiverName::Receiver(receiver));
+    }
+    receiver
+        .member(db, name)
+        .place
+        .ignore_possibly_undefined()
+        .map(ImplicitReceiverName::Member)
 }
 
 /// the receiver of the trailing lambda block `scope` is the body of. Walks out

--- a/crates/ty_python_semantic/src/types/trailing_lambda.rs
+++ b/crates/ty_python_semantic/src/types/trailing_lambda.rs
@@ -12,7 +12,7 @@ use ruff_python_ast::name::Name;
 
 use crate::Db;
 use crate::types::Type;
-use crate::types::signatures::Parameter;
+use crate::types::signatures::{Parameter, Signature};
 use crate::types::soundness::single_signature;
 
 /// basedpython: whether the callee's callback — its last declared parameter, the
@@ -90,10 +90,10 @@ pub(crate) fn trailing_lambda_keyword<'db>(db: &'db dyn Db, callee: Type<'db>) -
     parameter.name().cloned()
 }
 
-/// the parameter the implicit `it` binds: the first positional parameter of the
-/// callable the callee's last parameter is declared as. `None` when that shape
-/// doesn't hold
-fn it_parameter<'db>(db: &'db dyn Db, callee: Type<'db>) -> Option<Parameter<'db>> {
+/// the single signature of the callback a trailing lambda block fills: the
+/// callable the callee's last declared parameter is annotated as. `None` for
+/// anything else — an unannotated, non-callable or overloaded parameter
+fn callback_signature<'db>(db: &'db dyn Db, callee: Type<'db>) -> Option<&'db Signature<'db>> {
     let parameter = last_parameter(db, callee)?;
     let Type::Callable(callable) = parameter.annotated_type() else {
         return None;
@@ -101,7 +101,27 @@ fn it_parameter<'db>(db: &'db dyn Db, callee: Type<'db>) -> Option<Parameter<'db
     let [signature] = callable.signatures(db).overloads.as_slice() else {
         return None;
     };
-    Some(signature.parameters().get_positional(0)?.clone())
+    Some(signature)
+}
+
+/// whether the callback's leading parameter is a receiver, which the block binds
+/// implicitly rather than as `it`
+fn declares_receiver(signature: &Signature<'_>) -> bool {
+    signature
+        .parameters()
+        .iter()
+        .next()
+        .is_some_and(Parameter::is_receiver)
+}
+
+/// the parameter the implicit `it` binds: the first parameter of the callback
+/// the block fills that the block does not bind implicitly — the leading one, or
+/// the one after the receiver when the callback declares one. `None` when that
+/// shape doesn't hold
+fn it_parameter<'db>(db: &'db dyn Db, callee: Type<'db>) -> Option<Parameter<'db>> {
+    let signature = callback_signature(db, callee)?;
+    let index = usize::from(declares_receiver(signature));
+    Some(signature.parameters().get_positional(index)?.clone())
 }
 
 /// the type of the implicit `it` parameter. `None` when the callee's callback
@@ -129,14 +149,52 @@ pub(crate) fn trailing_lambda_it_borrow<'db>(
 }
 
 /// the type the block's callback declares as its *receiver* — the block body then
-/// sees that type's members unqualified. `None` when the callback is an ordinary
-/// callable, which has no implicit member scope
+/// sees that type's members unqualified, and spells the receiver itself `self`.
+/// `None` when the callback is an ordinary callable, which has no implicit
+/// member scope
 pub(crate) fn trailing_lambda_receiver_type<'db>(
     db: &'db dyn Db,
     callee: Type<'db>,
 ) -> Option<Type<'db>> {
     let parameter = last_parameter(db, callee)?;
     crate::types::receivers::receiver_type(db, parameter.annotated_type())
+}
+
+/// a callback parameter a trailing lambda block has no way to bind
+pub(crate) enum UnbindableParameters {
+    /// more parameters than the single `it` a block binds
+    TooMany(usize),
+    /// a variadic parameter, which stands for any number of arguments
+    Variadic,
+}
+
+/// the parameters of the callee's callback that a trailing lambda block cannot
+/// bind. A block binds its callback's receiver implicitly and one further
+/// argument as `it`, so anything beyond that is unreachable from the body — and
+/// passed to a block that has no parameter for it at runtime.
+///
+/// `None` when the block covers the callback, when the callback is not an
+/// inspectable single-signature callable, or when its parameter list is gradual
+/// (`(...) -> None`, the deliberately unchecked form)
+pub(crate) fn trailing_lambda_unbindable_parameters<'db>(
+    db: &'db dyn Db,
+    callee: Type<'db>,
+) -> Option<UnbindableParameters> {
+    let signature = callback_signature(db, callee)?;
+    let parameters = signature.parameters();
+    if parameters.is_gradual() {
+        return None;
+    }
+    let bound_implicitly = usize::from(declares_receiver(signature));
+    let declared = parameters.iter().skip(bound_implicitly);
+    if declared
+        .clone()
+        .any(|parameter| parameter.is_variadic() || parameter.is_keyword_variadic())
+    {
+        return Some(UnbindableParameters::Variadic);
+    }
+    let count = declared.count();
+    (count > 1).then_some(UnbindableParameters::TooMany(count))
 }
 
 /// the declared return type of the callback the callee's last parameter is — the
@@ -147,12 +205,5 @@ pub(crate) fn trailing_lambda_callback_return_type<'db>(
     db: &'db dyn Db,
     callee: Type<'db>,
 ) -> Option<Type<'db>> {
-    let parameter = last_parameter(db, callee)?;
-    let Type::Callable(callable) = parameter.annotated_type() else {
-        return None;
-    };
-    let [signature] = callable.signatures(db).overloads.as_slice() else {
-        return None;
-    };
-    Some(signature.return_ty)
+    Some(callback_signature(db, callee)?.return_ty)
 }

--- a/docs/basedpython/features/implicit-receivers.md
+++ b/docs/basedpython/features/implicit-receivers.md
@@ -54,30 +54,32 @@ spliced into
 ## trailing lambda blocks
 
 when a [trailing lambda](trailing-lambdas.md) block fills a receiver callback,
-the block's body sees the receiver's members unqualified. the block's implicit
-`it` parameter *is* the receiver, so the two spellings are the same value:
+the block binds that receiver itself. the body sees the receiver's members
+unqualified, and spells the receiver `self`; the block's implicit `it` parameter
+is the callback's *own* argument, the one after the receiver:
 
 ```by
-def apply(fn: int.() -> None):
-    fn(1)
+def apply(fn: int.(str) -> None):
+    fn(1, "a")
 
 apply:
-    print(it)    # 1
-    print(imag)  # 0 — `it.imag`
+    print(self)  # 1
+    print(imag)  # 0 — a member of `self`
+    print(it)    # "a"
 ```
 
 →
 
 ```python
-def _trailing_lambda_0(it=None):
+def _trailing_lambda_0(_by_self=None, it=None):
+    print(_by_self)
+    print(_by_self.imag)
     print(it)
-    print(it.imag)
 apply(fn=_trailing_lambda_0)
 ```
 
-a block that assigns `it` cannot use its receiver's members unqualified — the
-lowering reads them from `it`, so a rebinding would silently redirect them. that
-combination is rejected
+the receiver lands in a parameter the source cannot spell, so nothing the block
+binds can redirect the members read off it
 
 as with `x.fn`, this is the last fallback. a name bound anywhere in the lexical
 chain — a block local, an enclosing function's local, a module global, a builtin —
@@ -88,15 +90,20 @@ the scope around it:
 imag: str = "shadow"
 
 apply:
-    print(imag)  # the module-level `imag`, not `it.imag`
+    print(imag)  # the module-level `imag`, not the receiver's
 ```
+
+`self` is no exception: inside a method, `self` is that method's own receiver,
+and the block's receiver is reachable only through its members
 
 a name that resolves nowhere and is not a member of the receiver stays an
 `unresolved-reference` error
 
 a block still returns `None`, so the callback must be declared to return a type
 that accepts it — `int.() -> None`, not `int.() -> str` (see
-[trailing lambdas](trailing-lambdas.md#binding))
+[trailing lambdas](trailing-lambdas.md#binding)) — and it binds one argument
+beyond the receiver, so `int.(str, str) -> None` is rejected with
+`trailing-lambda-parameters`
 
 ## syntax
 

--- a/docs/basedpython/features/trailing-lambdas.md
+++ b/docs/basedpython/features/trailing-lambdas.md
@@ -15,9 +15,21 @@ f(2):
     print(it)  # prints 2
 ```
 
-customising the lambda's parameters is not supported yet — the block always
-takes exactly one parameter named `it`, defaulted to `None` so a callback whose
-type takes no argument (`() -> None`, invoked as `fn()`) can still call it
+customising the lambda's parameters is not supported yet — the block takes
+exactly one parameter named `it` (plus the callback's
+[receiver](#implicit-receivers), where it declares one), defaulted to `None` so
+a callback whose type takes no argument (`() -> None`, invoked as `fn()`) can
+still call it. a callback that takes *more* than that one argument is rejected
+with `trailing-lambda-parameters`: the extra arguments have no parameter to land
+in, and no spelling in the body
+
+```by
+def f(a: (int, str) -> None):
+    a(1, "two")
+
+f:  # error: the block binds only `it`, so `"two"` has nowhere to go
+    print(it)
+```
 
 ## binding
 
@@ -66,9 +78,19 @@ preserved in place
 ## implicit receivers
 
 when the callback declares an [implicit receiver](implicit-receivers.md)
-(`int.() -> None`), the block body sees that type's members unqualified — `imag`
-means `it.imag`. a name bound anywhere in the lexical chain keeps its ordinary
-meaning, so only names that would otherwise be unresolved resolve this way
+(`str.(int) -> None`), the block binds that receiver itself, ahead of `it`: the
+body sees the receiver's members unqualified, spells the receiver `self`, and
+`it` is the callback's own argument — the one *after* the receiver. a name bound
+anywhere in the lexical chain keeps its ordinary meaning, so only names that
+would otherwise be unresolved resolve this way
+
+```by
+def against(fn: str.(int) -> None):
+    fn("asdf", 1)
+
+against:
+    print(upper(), it, self)  # ASDF 1 asdf
+```
 
 ## enclosing scope
 
@@ -201,8 +223,8 @@ the checker still treats the parameter as required. see
 
 ## inlay hints
 
-the parameter the block binds is shown as an inlay hint with the type the callee
-gives it, written just past the `:` that opens the suite:
+the parameters the block binds are shown as an inlay hint with the types the
+callee gives them, written just past the `:` that opens the suite:
 
 ```by
 def apply(fn: (int) -> None) -> None:
@@ -213,14 +235,22 @@ apply:⟨it: int⟩
 ```
 
 a callback that declares an [implicit receiver](implicit-receivers.md) runs
-*against* a value rather than being passed one, so the hint spells it `self`:
+*against* a value as well as being passed one, so the receiver is hinted first,
+spelled `self` — with `it` after it whenever the callback takes an argument of
+its own:
 
 ```by
 def against(fn: str.() -> None) -> None:
     "a".fn()
 
+def against_with(fn: str.(int) -> None) -> None:
+    "a".fn(1)
+
 against:⟨self: str⟩
     print(upper())
+
+against_with:⟨self: str, it: int⟩
+    print(upper(), it)
 ```
 
 the same hint covers the other parameters basedpython synthesizes rather than

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -1698,6 +1698,16 @@
             }
           ]
         },
+        "trailing-lambda-parameters": {
+          "title": "detects a trailing-lambda callback taking arguments the block cannot bind",
+          "description": "## What it does\nChecks for a trailing-lambda block whose callback takes arguments the\nblock has no parameter for.\n\n## Why is this bad?\nA block binds one argument, as `it` — plus its callback's implicit\nreceiver, which the body spells `self` and reads members off\nunqualified. A callback that takes more than that, or takes a variadic\nparameter, passes arguments the block cannot name, and would be called\nwith more arguments than it declares.\n\n## Example\n\n```by\ndef f(a: (int, str) -> None):\n    a(1, \"two\")\n\nf:  # error: the block binds only `it`, so `\"two\"` has nowhere to go\n    print(it)\n```",
+          "default": "error",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Level"
+            }
+          ]
+        },
         "trailing-lambda-return-type": {
           "title": "detects a trailing-lambda callback whose return type does not accept `None`",
           "description": "## What it does\nChecks for a trailing-lambda block whose callback's declared return type\ndoes not accept `None`.\n\n## Why is this bad?\nA trailing-lambda block lowers to a function that returns `None` (in a\n`once` block a `return` targets the *enclosing* function, not the block).\nA callback whose return type does not accept `None` — `int`, `str`, … —\ncan never be satisfied by the block. A return type that merely accepts\n`None` (`None` itself, `int | None`, `object`) is fine; other non-`None`\nreturn types are not yet supported.\n\n## Example\n\n```by\ndef f(a: (int) -> str):  # callback returns `str`\n    print(a(1))\n\nf:  # error: the block returns `None`, not `str`\n    print(it)\n```",


### PR DESCRIPTION
a trailing lambda block bound to a receiver callback now binds the receiver as a parameter of its own — spelled `self` in the body, alongside the members it already saw unqualified — and `it` is the callback argument after the receiver. the block was previously called with more arguments than it declared, which raised a TypeError at runtime

a callback that takes more arguments than the block binds is now rejected with the new `trailing-lambda-parameters` lint rather than crashing at runtime