### PR TITLE
added boolean condition warnings: overlap, redundancy, `== True`

### DIFF
--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -1009,6 +1009,27 @@ pub enum DiagnosticId {
     /// A glob pattern doesn't follow the expected syntax.
     InvalidGlob,
 
+    /// A class name in the configuration isn't spelled like one.
+    ///
+    /// ## Why is this bad?
+    /// An option that takes class names matches them literally, so a malformed entry silently
+    /// matches nothing. Whether a well-formed name resolves to a class that exists is not checked
+    /// — only that it *could* be one.
+    ///
+    /// ## Example
+    /// ```toml
+    /// [analysis]
+    /// overlapping-condition-exempt-types = ["list[int]"]
+    /// ```
+    ///
+    /// Use instead:
+    ///
+    /// ```toml
+    /// [analysis]
+    /// overlapping-condition-exempt-types = ["list"]
+    /// ```
+    InvalidClassName,
+
     /// An `include` glob without any patterns.
     ///
     /// ## Why is this bad?
@@ -1137,6 +1158,7 @@ impl DiagnosticId {
             DiagnosticId::RevealedType => "revealed-type",
             DiagnosticId::UnknownRule => "unknown-rule",
             DiagnosticId::InvalidGlob => "invalid-glob",
+            DiagnosticId::InvalidClassName => "invalid-class-name",
             DiagnosticId::EmptyInclude => "empty-include",
             DiagnosticId::UnnecessaryOverridesSection => "unnecessary-overrides-section",
             DiagnosticId::UselessOverridesSection => "useless-overrides-section",

--- a/crates/ty/docs/configuration.md
+++ b/crates/ty/docs/configuration.md
@@ -165,6 +165,78 @@ Defaults to `false`.
 
 ---
 
+### `overlapping-condition-assume-truthy-instances`
+
+Whether an instance with no `__bool__` and no `__len__` counts as always truthy when
+looking for an [`overlapping-condition`](rules.md#overlapping-condition).
+
+Such an instance is only *ambiguously* truthy — a subclass may define `__bool__` — so by
+default it is a falsy member of `if not x` just as `None` is. Enabling this assumes the
+class means what it looks like it means, which drops the reports for the very common
+`if not x` over an optional instance.
+
+Defaults to `false`.
+
+**Default value**: `false`
+
+**Type**: `bool`
+
+**Example usage**:
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.ty.analysis]
+    # `if not x` over a `Foo | None` only selects `None`
+    overlapping-condition-assume-truthy-instances = true
+    ```
+
+=== "ty.toml"
+
+    ```toml
+    [analysis]
+    # `if not x` over a `Foo | None` only selects `None`
+    overlapping-condition-assume-truthy-instances = true
+    ```
+
+---
+
+### `overlapping-condition-exempt-types`
+
+A list of classes whose values do not count as a distinct member of an
+[`overlapping-condition`](rules.md#overlapping-condition).
+
+`if not x` over an `int | None` selects both a falsy `int` and `None`, and is reported
+because the branch cannot tell them apart. Listing `int` here says that conflating a falsy
+`int` with anything else is fine, so only `None` is left and the condition is accepted.
+
+Entries are qualified class names (`decimal.Decimal`). A class in `builtins` may also be
+spelled bare (`int`), and `None` stands for the type of `None`.
+
+**Default value**: `[]`
+
+**Type**: `list[str]`
+
+**Example usage**:
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.ty.analysis]
+    # Accept a falsy `int` or `str` sharing a branch with another member
+    overlapping-condition-exempt-types = ["int", "str"]
+    ```
+
+=== "ty.toml"
+
+    ```toml
+    [analysis]
+    # Accept a falsy `int` or `str` sharing a branch with another member
+    overlapping-condition-exempt-types = ["int", "str"]
+    ```
+
+---
+
 ### `replace-imports-with-any`
 
 A list of module glob patterns whose imports should be replaced with `typing.Any`.
@@ -892,6 +964,78 @@ Defaults to `false`.
     [overrides.analysis]
     # Turn off fluid specializations
     disable-fluid-specializations = true
+    ```
+
+---
+
+#### `overlapping-condition-assume-truthy-instances`
+
+Whether an instance with no `__bool__` and no `__len__` counts as always truthy when
+looking for an [`overlapping-condition`](rules.md#overlapping-condition).
+
+Such an instance is only *ambiguously* truthy — a subclass may define `__bool__` — so by
+default it is a falsy member of `if not x` just as `None` is. Enabling this assumes the
+class means what it looks like it means, which drops the reports for the very common
+`if not x` over an optional instance.
+
+Defaults to `false`.
+
+**Default value**: `false`
+
+**Type**: `bool`
+
+**Example usage**:
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.ty.overrides.analysis]
+    # `if not x` over a `Foo | None` only selects `None`
+    overlapping-condition-assume-truthy-instances = true
+    ```
+
+=== "ty.toml"
+
+    ```toml
+    [overrides.analysis]
+    # `if not x` over a `Foo | None` only selects `None`
+    overlapping-condition-assume-truthy-instances = true
+    ```
+
+---
+
+#### `overlapping-condition-exempt-types`
+
+A list of classes whose values do not count as a distinct member of an
+[`overlapping-condition`](rules.md#overlapping-condition).
+
+`if not x` over an `int | None` selects both a falsy `int` and `None`, and is reported
+because the branch cannot tell them apart. Listing `int` here says that conflating a falsy
+`int` with anything else is fine, so only `None` is left and the condition is accepted.
+
+Entries are qualified class names (`decimal.Decimal`). A class in `builtins` may also be
+spelled bare (`int`), and `None` stands for the type of `None`.
+
+**Default value**: `[]`
+
+**Type**: `list[str]`
+
+**Example usage**:
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.ty.overrides.analysis]
+    # Accept a falsy `int` or `str` sharing a branch with another member
+    overlapping-condition-exempt-types = ["int", "str"]
+    ```
+
+=== "ty.toml"
+
+    ```toml
+    [overrides.analysis]
+    # Accept a falsy `int` or `str` sharing a branch with another member
+    overlapping-condition-exempt-types = ["int", "str"]
     ```
 
 ---

--- a/crates/ty/docs/rules.md
+++ b/crates/ty/docs/rules.md
@@ -8,7 +8,7 @@
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.13">0.0.13</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22abstract-method-in-final-class%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2131" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2134" target="_blank">View source</a>
 </small>
 
 
@@ -54,7 +54,7 @@ class Derived(Base):  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.61">0.0.61</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22ambiguous-context-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1888" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1891" target="_blank">View source</a>
 </small>
 
 
@@ -87,7 +87,7 @@ f(1, b=s1)    # ok — explicit
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.39">0.0.1-alpha.39</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22ambiguous-conversion%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1139" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1142" target="_blank">View source</a>
 </small>
 
 
@@ -123,7 +123,7 @@ report(Celsius())  # error: two conversions apply
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.3">0.0.1-alpha.3</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22ambiguous-extension-member%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1051" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1054" target="_blank">View source</a>
 </small>
 
 
@@ -158,7 +158,7 @@ extension list:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.20">0.0.1-alpha.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22ambiguous-protocol-member%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L378" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L381" target="_blank">View source</a>
 </small>
 
 
@@ -222,7 +222,7 @@ class SubProto(BaseProto, Protocol):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22assert-type-unspellable-subtype%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2176" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2179" target="_blank">View source</a>
 </small>
 
 
@@ -305,7 +305,7 @@ value = unknown  # ty: ignore[unresolved-reference]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.61">0.0.61</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22bool-as-int%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1826" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1829" target="_blank">View source</a>
 </small>
 
 
@@ -348,7 +348,7 @@ a4 = True + 1       # ok — a boolean used as a boolean
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.16">0.0.16</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22call-abstract-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2140" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2143" target="_blank">View source</a>
 </small>
 
 
@@ -403,7 +403,7 @@ Foo.method()  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22call-non-callable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L232" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L235" target="_blank">View source</a>
 </small>
 
 
@@ -431,7 +431,7 @@ Calling a non-callable object will raise a `TypeError` at runtime.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.7">0.0.7</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22call-top-callable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L241" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L244" target="_blank">View source</a>
 </small>
 
 
@@ -466,7 +466,7 @@ def f(x: object):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22conflicting-declarations%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L259" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L262" target="_blank">View source</a>
 </small>
 
 
@@ -500,7 +500,7 @@ a = 1  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22conflicting-metaclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L268" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L271" target="_blank">View source</a>
 </small>
 
 
@@ -535,7 +535,7 @@ class C(A, B): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22cyclic-class-definition%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L277" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L280" target="_blank">View source</a>
 </small>
 
 
@@ -571,7 +571,7 @@ class B(A): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.29">0.0.1-alpha.29</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22cyclic-type-alias-definition%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L286" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L289" target="_blank">View source</a>
 </small>
 
 
@@ -607,7 +607,7 @@ type B = A  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22dataclass-field-order%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L331" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L334" target="_blank">View source</a>
 </small>
 
 
@@ -644,7 +644,7 @@ class Example:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.16">0.0.1-alpha.16</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22deprecated%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L304" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L307" target="_blank">View source</a>
 </small>
 
 
@@ -683,7 +683,7 @@ old_func()  # error: [deprecated]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22division-by-zero%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L295" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L298" target="_blank">View source</a>
 </small>
 
 
@@ -716,7 +716,7 @@ false positives it can produce.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22duplicate-base%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L313" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L316" target="_blank">View source</a>
 </small>
 
 
@@ -747,7 +747,7 @@ class B(A, A): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.12">0.0.1-alpha.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22duplicate-kw-only%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L322" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L325" target="_blank">View source</a>
 </small>
 
 
@@ -790,7 +790,7 @@ class A:  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22empty-body%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L478" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L481" target="_blank">View source</a>
 </small>
 
 
@@ -840,7 +840,7 @@ def bar() -> str:  # error: [empty-body]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.61">0.0.61</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22erased-cast-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1716" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1719" target="_blank">View source</a>
 </small>
 
 
@@ -901,7 +901,7 @@ def h(x: object):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.3">0.0.1-alpha.3</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22erased-type-check%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1978" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1981" target="_blank">View source</a>
 </small>
 
 
@@ -979,7 +979,7 @@ def foo() -> "intt\b": ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22escaping-local%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1192" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1195" target="_blank">View source</a>
 </small>
 
 
@@ -1018,7 +1018,7 @@ def f(local fn: () -> None):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22escaping-loop-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1681" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1684" target="_blank">View source</a>
 </small>
 
 
@@ -1059,7 +1059,7 @@ for x in [1, 2, 3]:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.50">0.0.50</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22experimental-syntax%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L223" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L226" target="_blank">View source</a>
 </small>
 
 
@@ -1099,7 +1099,7 @@ def g(value: ~A) -> None: ...  # error: [experimental-syntax]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22final-on-non-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2084" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2087" target="_blank">View source</a>
 </small>
 
 
@@ -1134,7 +1134,7 @@ def my_function() -> int:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.40">0.0.40</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22final-on-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2093" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2096" target="_blank">View source</a>
 </small>
 
 
@@ -1169,7 +1169,7 @@ let a = 1
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22final-without-value%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2122" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2125" target="_blank">View source</a>
 </small>
 
 
@@ -1285,7 +1285,7 @@ def test() -> "Literal[5]":
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22inconsistent-mro%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L405" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L408" target="_blank">View source</a>
 </small>
 
 
@@ -1321,7 +1321,7 @@ class C(A, B): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22index-out-of-bounds%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L414" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L417" target="_blank">View source</a>
 </small>
 
 
@@ -1351,7 +1351,7 @@ t[3]  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.33">0.0.1-alpha.33</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22ineffective-final%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2075" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2078" target="_blank">View source</a>
 </small>
 
 
@@ -1388,7 +1388,7 @@ class MyClass: ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.12">0.0.1-alpha.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22instance-layout-conflict%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L359" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L362" target="_blank">View source</a>
 </small>
 
 
@@ -1489,7 +1489,7 @@ an atypical memory layout.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-argument-type%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L451" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L454" target="_blank">View source</a>
 </small>
 
 
@@ -1521,7 +1521,7 @@ func("foo")  # error: [invalid-argument-type]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-assignment%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L487" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L490" target="_blank">View source</a>
 </small>
 
 
@@ -1552,7 +1552,7 @@ a: int = ""  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-attribute-access%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2315" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2318" target="_blank">View source</a>
 </small>
 
 
@@ -1610,7 +1610,7 @@ C.instance_only_var = 56  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.33">0.0.33</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-attribute-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2396" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2399" target="_blank">View source</a>
 </small>
 
 
@@ -1656,7 +1656,7 @@ class Sub(Base):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.19">0.0.1-alpha.19</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-await%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L496" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L499" target="_blank">View source</a>
 </small>
 
 
@@ -1698,7 +1698,7 @@ asyncio.run(main())
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-base%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L505" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L508" target="_blank">View source</a>
 </small>
 
 
@@ -1725,7 +1725,7 @@ class A(42): ...  # error: [invalid-base]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-context-manager%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L532" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L535" target="_blank">View source</a>
 </small>
 
 
@@ -1755,7 +1755,7 @@ with 1:  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.39">0.0.1-alpha.39</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-conversion%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1112" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1115" target="_blank">View source</a>
 </small>
 
 
@@ -1788,7 +1788,7 @@ class Fahrenheit:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.12">0.0.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-dataclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L349" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L352" target="_blank">View source</a>
 </small>
 
 
@@ -1841,7 +1841,7 @@ See: <https://docs.python.org/3/library/dataclasses.html#dataclasses.dataclass>
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.13">0.0.13</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-dataclass-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L340" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L343" target="_blank">View source</a>
 </small>
 
 
@@ -1877,7 +1877,7 @@ class A:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-declaration%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L541" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L544" target="_blank">View source</a>
 </small>
 
 
@@ -1909,7 +1909,7 @@ a: str  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-enum-member-annotation%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L559" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L562" target="_blank">View source</a>
 </small>
 
 
@@ -1966,7 +1966,7 @@ class Pet(Enum):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-exception-caught%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L550" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L553" target="_blank">View source</a>
 </small>
 
 
@@ -2030,7 +2030,7 @@ This rule corresponds to Ruff's [`except-with-non-exception-classes` (`B030`)](h
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.28">0.0.1-alpha.28</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-explicit-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2149" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2152" target="_blank">View source</a>
 </small>
 
 
@@ -2083,7 +2083,7 @@ class D(A):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.3">0.0.1-alpha.3</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-extension%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1002" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1005" target="_blank">View source</a>
 </small>
 
 
@@ -2116,7 +2116,7 @@ extension list[T: int]:  # error: `list` declares no type parameter `T`
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.4">0.0.1-alpha.4</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-field-lookup%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1169" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1172" target="_blank">View source</a>
 </small>
 
 
@@ -2145,7 +2145,7 @@ Author.objects.filter(name__startswith=1) # error: lookup wants `str`
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.36">0.0.1-alpha.36</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-fixture-type%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1403" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1406" target="_blank">View source</a>
 </small>
 
 
@@ -2181,7 +2181,7 @@ def test_user(user: int) -> None:  # error: fixture provides `str`
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.35">0.0.1-alpha.35</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-frozen-dataclass-subclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2415" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2418" target="_blank">View source</a>
 </small>
 
 
@@ -2232,7 +2232,7 @@ class NonFrozenChild(FrozenBase):  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-generic-class%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L577" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L580" target="_blank">View source</a>
 </small>
 
 
@@ -2281,7 +2281,7 @@ class D(Generic[U, T]): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.12">0.0.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-generic-enum%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L568" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L571" target="_blank">View source</a>
 </small>
 
 
@@ -2377,7 +2377,7 @@ a = 20 / 0  # type: ignore
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.5">0.0.1-alpha.5</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-implementation%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1080" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1083" target="_blank">View source</a>
 </small>
 
 
@@ -2415,7 +2415,7 @@ implementation Concrete for B:  # error: not an abstract class or protocol
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.17">0.0.1-alpha.17</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-key%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L424" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L427" target="_blank">View source</a>
 </small>
 
 
@@ -2463,7 +2463,7 @@ carol = Person(name="Carol", aeg=25)  # typo!
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-legacy-positional-parameter%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2433" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2436" target="_blank">View source</a>
 </small>
 
 
@@ -2525,7 +2525,7 @@ def f(x, y, /):  # Python 3.8+ syntax
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-legacy-type-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L595" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L598" target="_blank">View source</a>
 </small>
 
 
@@ -2565,7 +2565,7 @@ def f(t: TypeVar("U")): ...  # ty: ignore[invalid-type-form]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.18">0.0.18</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-match-pattern%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L712" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L715" target="_blank">View source</a>
 </small>
 
 
@@ -2615,7 +2615,7 @@ match object():
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-metaclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L640" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L643" target="_blank">View source</a>
 </small>
 
 
@@ -2650,7 +2650,7 @@ class B(metaclass=42): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.20">0.0.1-alpha.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-method-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2405" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2408" target="_blank">View source</a>
 </small>
 
 
@@ -2768,7 +2768,7 @@ Correct use of `@override` is enforced by ty's [`invalid-explicit-override`](#in
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.19">0.0.1-alpha.19</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-named-tuple%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L387" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L390" target="_blank">View source</a>
 </small>
 
 
@@ -2825,7 +2825,7 @@ AttributeError: Cannot overwrite NamedTuple attribute _asdict
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.31">0.0.31</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-named-tuple-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L396" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L399" target="_blank">View source</a>
 </small>
 
 
@@ -2873,7 +2873,7 @@ admin[0]  # "Alice"
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.27">0.0.1-alpha.27</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-newtype%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L622" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L625" target="_blank">View source</a>
 </small>
 
 
@@ -2911,7 +2911,7 @@ Baz = NewType("Baz", int | str)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-overload%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L649" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L652" target="_blank">View source</a>
 </small>
 
 
@@ -2968,7 +2968,7 @@ def foo(x: int) -> int: ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-parameter-default%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L667" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L670" target="_blank">View source</a>
 </small>
 
 
@@ -2997,7 +2997,7 @@ def f(a: int = ""): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.36">0.0.1-alpha.36</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-parametrize%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1489" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1492" target="_blank">View source</a>
 </small>
 
 
@@ -3030,7 +3030,7 @@ def test_add(a: int, b: int) -> None:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-paramspec%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L604" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L607" target="_blank">View source</a>
 </small>
 
 
@@ -3066,7 +3066,7 @@ P2 = ParamSpec()  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-protocol%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L368" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L371" target="_blank">View source</a>
 </small>
 
 
@@ -3102,7 +3102,7 @@ TypeError: Protocols can only inherit from other protocols, got <class 'int'>
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-raise%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L676" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L679" target="_blank">View source</a>
 </small>
 
 
@@ -3173,7 +3173,7 @@ def g():
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.37">0.0.1-alpha.37</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-raises-clause%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1359" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1362" target="_blank">View source</a>
 </small>
 
 
@@ -3201,7 +3201,7 @@ def f() raises int:  # error: `int` is not an exception
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.36">0.0.1-alpha.36</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-regex%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1433" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1436" target="_blank">View source</a>
 </small>
 
 
@@ -3234,7 +3234,7 @@ if m := re.match("(a)(b)", "ab"):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-return-type%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L460" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L463" target="_blank">View source</a>
 </small>
 
 
@@ -3266,7 +3266,7 @@ def func() -> int:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-super-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L685" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L688" target="_blank">View source</a>
 </small>
 
 
@@ -3377,7 +3377,7 @@ class C: ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.10">0.0.10</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-total-ordering%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2424" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2427" target="_blank">View source</a>
 </small>
 
 
@@ -3428,7 +3428,7 @@ class MyClass:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.6">0.0.1-alpha.6</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-alias-type%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L613" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L616" target="_blank">View source</a>
 </small>
 
 
@@ -3469,7 +3469,7 @@ NewAlias = TypeAliasType(get_name(), int)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.29">0.0.1-alpha.29</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-arguments%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L869" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L872" target="_blank">View source</a>
 </small>
 
 
@@ -3536,7 +3536,7 @@ Bar[int]  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-checking-constant%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L694" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L697" target="_blank">View source</a>
 </small>
 
 
@@ -3569,7 +3569,7 @@ TYPE_CHECKING = ""  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-form%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L703" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L706" target="_blank">View source</a>
 </small>
 
 
@@ -3605,7 +3605,7 @@ b: Annotated[int]  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.11">0.0.1-alpha.11</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-guard-definition%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L721" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L724" target="_blank">View source</a>
 </small>
 
 
@@ -3662,7 +3662,7 @@ class C:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-variable-bound%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L751" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L754" target="_blank">View source</a>
 </small>
 
 
@@ -3706,7 +3706,7 @@ def g[U, T: U](): ...  # error: [invalid-type-variable-bound]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-variable-constraints%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L742" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L745" target="_blank">View source</a>
 </small>
 
 
@@ -3763,7 +3763,7 @@ V = TypeVar("V", list[int], int)  # valid constrained Type
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.16">0.0.16</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-variable-default%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L760" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L763" target="_blank">View source</a>
 </small>
 
 
@@ -3805,7 +3805,7 @@ U = TypeVar("U", int, str, default=bytes)  # error: [invalid-type-variable-defau
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.28">0.0.28</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-typed-dict-field%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2378" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2381" target="_blank">View source</a>
 </small>
 
 
@@ -3841,7 +3841,7 @@ class Child(Base):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-typed-dict-header%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2387" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2390" target="_blank">View source</a>
 </small>
 
 
@@ -3884,7 +3884,7 @@ def f(options: dict[str, object]):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.9">0.0.9</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-typed-dict-statement%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2369" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2372" target="_blank">View source</a>
 </small>
 
 
@@ -3919,7 +3919,7 @@ class Foo(TypedDict):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.25">0.0.25</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-yield%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L469" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L472" target="_blank">View source</a>
 </small>
 
 
@@ -3954,7 +3954,7 @@ def gen() -> Iterator[int]:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22isinstance-against-protocol%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L433" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L436" target="_blank">View source</a>
 </small>
 
 
@@ -4021,7 +4021,7 @@ def h(arg2: type):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22isinstance-against-typed-dict%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L442" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L445" target="_blank">View source</a>
 </small>
 
 
@@ -4071,7 +4071,7 @@ def g(arg: object):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.36">0.0.1-alpha.36</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22iteration-over-character%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2023" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2026" target="_blank">View source</a>
 </small>
 
 
@@ -4102,7 +4102,7 @@ def f(s: str):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.30">0.0.30</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22mismatched-type-name%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L631" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L634" target="_blank">View source</a>
 </small>
 
 
@@ -4145,7 +4145,7 @@ Movie = TypedDict("Film", {"title": str})  # error: [mismatched-type-name]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22missing-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L778" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L781" target="_blank">View source</a>
 </small>
 
 
@@ -4176,7 +4176,7 @@ func()  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.61">0.0.61</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22missing-context-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1863" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1866" target="_blank">View source</a>
 </small>
 
 
@@ -4207,7 +4207,7 @@ f(1)                  # ok — `s` is passed implicitly
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.4">0.0.1-alpha.4</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22missing-framework-stubs%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1029" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1032" target="_blank">View source</a>
 </small>
 
 
@@ -4235,7 +4235,7 @@ from django.db import models  # warning: install `django-stubs` for precise type
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.41">0.0.41</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22missing-override-decorator%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2158" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2161" target="_blank">View source</a>
 </small>
 
 
@@ -4294,7 +4294,7 @@ class ExplicitChild(Parent):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.45">0.0.45</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22missing-type-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L787" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L790" target="_blank">View source</a>
 </small>
 
 
@@ -4333,7 +4333,7 @@ def handle(m: re.Match[str]) -> str:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.20">0.0.1-alpha.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22missing-typed-dict-key%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2360" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2363" target="_blank">View source</a>
 </small>
 
 
@@ -4372,7 +4372,7 @@ alice["age"]  # KeyError
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22narrowing-guard-as-value%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1596" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1599" target="_blank">View source</a>
 </small>
 
 
@@ -4406,7 +4406,7 @@ def f(a: int | None):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22no-matching-overload%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L851" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L854" target="_blank">View source</a>
 </small>
 
 
@@ -4444,7 +4444,7 @@ func("string")  # error: [no-matching-overload]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.30">0.0.30</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22non-callable-init-subclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L586" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L589" target="_blank">View source</a>
 </small>
 
 
@@ -4482,7 +4482,7 @@ class Sub(Super): ...  # error: [non-callable-init-subclass]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.39">0.0.1-alpha.39</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22non-exhaustive-statement-expression%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1310" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1313" target="_blank">View source</a>
 </small>
 
 
@@ -4513,7 +4513,7 @@ def f(x: int | str) -> int:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.61">0.0.61</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22non-overlapping-cast%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1771" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1774" target="_blank">View source</a>
 </small>
 
 
@@ -4542,7 +4542,7 @@ def f(a: object):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22not-iterable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L878" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L881" target="_blank">View source</a>
 </small>
 
 
@@ -4571,7 +4571,7 @@ for i in 34:  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22not-subscriptable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L860" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L863" target="_blank">View source</a>
 </small>
 
 
@@ -4599,7 +4599,7 @@ Subscripting an object that does not support it will raise a `TypeError` at runt
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22once-called-twice%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1516" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1519" target="_blank">View source</a>
 </small>
 
 
@@ -4628,7 +4628,7 @@ def f(once done: () -> None):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22once-not-called%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1381" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1384" target="_blank">View source</a>
 </small>
 
 
@@ -4656,7 +4656,7 @@ def f(once done: () -> None):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.61">0.0.61</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22optional-object-conversion%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1794" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1797" target="_blank">View source</a>
 </small>
 
 
@@ -4688,13 +4688,68 @@ def f(x: int?):
     sink(x cast object) # ok — explicit
 ```
 
+## `overlapping-condition`
+
+<small>
+Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
+Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.62">0.0.62</a> ·
+<a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22overlapping-condition%22" target="_blank">Related issues</a> ·
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2445" target="_blank">View source</a>
+</small>
+
+
+**What it does**
+
+Checks for a truthiness test whose selected branch holds a value that is
+always there alongside one that is only sometimes there.
+
+**Why is this bad?**
+
+A condition collapses a value to a single bit, so two members that answer
+the test the same way become indistinguishable inside the branch. The case
+that bites is a sentinel meeting the falsy corner of a value that normally
+belongs to the other branch — `None` meeting `""` in `if not name:`.
+
+Only the branch the condition *selects* is analyzed: `if a` looks at the
+truthy members, `if not a` at the falsy ones. A boolean operator is one
+condition per operand rather than one over its value, since each operand's
+truthiness is tested on its own.
+
+Two members that are *each* only partly in the branch are not reported:
+`if x:` over a `str | bytes` conflates nothing the union did not already
+conflate. Neither are members of one class, or of two classes where one
+derives the other, which a condition was never going to tell apart:
+`Literal[1] | Literal[2]` and `list[A] | list[B]` are each one kind of
+value.
+
+**Examples**
+
+```python
+def f(a: bool | None):
+    if a:      # ok — only `True` is truthy
+        ...
+    if not a:  # warning: `False` and `None` are both falsy
+        ...
+
+def g(name: str | None):
+    if not name:  # warning: `""` and `None` are both falsy
+        ...
+    if name is None:  # ok — the members are told apart
+        ...
+```
+
+**Options**
+
+- `analysis.overlapping-condition-exempt-types`
+- `analysis.overlapping-condition-assume-truthy-instances`
+
 ## `override-of-final-method`
 
 <small>
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.29">0.0.1-alpha.29</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22override-of-final-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2057" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2060" target="_blank">View source</a>
 </small>
 
 
@@ -4731,7 +4786,7 @@ class B(A):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.16">0.0.16</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22override-of-final-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2066" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2069" target="_blank">View source</a>
 </small>
 
 
@@ -4768,7 +4823,7 @@ class B(A):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.38">0.0.1-alpha.38</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22override-raise%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1250" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1253" target="_blank">View source</a>
 </small>
 
 
@@ -4811,7 +4866,7 @@ def main():
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22parameter-already-assigned%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L896" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L899" target="_blank">View source</a>
 </small>
 
 
@@ -4842,7 +4897,7 @@ f(1, x=2)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22positional-only-parameter-as-kwarg%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2243" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2246" target="_blank">View source</a>
 </small>
 
 
@@ -4873,7 +4928,7 @@ f(x=1)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-missing-attribute%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L905" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L908" target="_blank">View source</a>
 </small>
 
 
@@ -4912,7 +4967,7 @@ A.c  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-missing-implicit-call%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L250" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L253" target="_blank">View source</a>
 </small>
 
 
@@ -4951,7 +5006,7 @@ A()[0]  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-missing-import%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L923" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L926" target="_blank">View source</a>
 </small>
 
 
@@ -4997,7 +5052,7 @@ from module import a  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.23">0.0.23</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-missing-submodule%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L914" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L917" target="_blank">View source</a>
 </small>
 
 
@@ -5029,7 +5084,7 @@ html.parser  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-unresolved-reference%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L932" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L935" target="_blank">View source</a>
 </small>
 
 
@@ -5066,7 +5121,7 @@ print(x)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22private-import%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L976" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L979" target="_blank">View source</a>
 </small>
 
 
@@ -5098,7 +5153,7 @@ from helpers import Key  # error: `Key` is private to `helpers`
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.60">0.0.60</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22pydantic-discarded-extra-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2230" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2233" target="_blank">View source</a>
 </small>
 
 
@@ -5167,13 +5222,55 @@ def test() -> "int":
     return 1
 ```
 
+## `redundant-boolean-comparison`
+
+<small>
+Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
+Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.62">0.0.62</a> ·
+<a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22redundant-boolean-comparison%22" target="_blank">Related issues</a> ·
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2541" target="_blank">View source</a>
+</small>
+
+
+**What it does**
+
+Checks for a comparison of a `bool` against `True` or `False`.
+
+**Why is this bad?**
+
+The operand is already the value the comparison produces, so the
+comparison only adds noise. Testing the operand — or its negation —
+says the same thing.
+
+An operand that is *not* a `bool` is left alone: `x == True` where
+`x: bool | None` really does tell `True` apart from `False` and `None`,
+and `x == True` where `x: int` is a value comparison. A chained comparison
+(`a == True == b`) is left alone too: it is two comparisons over one
+literal, and neither the operand nor its negation replaces the chain.
+
+**Examples**
+
+```python
+def f(a: bool):
+    if a == True:   # warning: redundant comparison
+        ...
+    if a is False:  # warning: redundant comparison
+        ...
+    if a:           # ok
+        ...
+
+def g(a: bool | None):
+    if a == True:  # ok — tells `True` apart from `False` and `None`
+        ...
+```
+
 ## `redundant-cast`
 
 <small>
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22redundant-cast%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2324" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2327" target="_blank">View source</a>
 </small>
 
 
@@ -5202,13 +5299,67 @@ def f() -> int:
 cast(int, f())  # error
 ```
 
+## `redundant-condition`
+
+<small>
+Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
+Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.62">0.0.62</a> ·
+<a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22redundant-condition%22" target="_blank">Related issues</a> ·
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2493" target="_blank">View source</a>
+</small>
+
+
+**What it does**
+
+Checks for a condition whose outcome is fixed by the tested type, so the
+branch is not conditional at all.
+
+**Why is this bad?**
+
+One of the two branches is dead. Either the annotation is wider than the
+author believed, or the test is left over from an earlier version of the
+code.
+
+Only a value *read* is reported — a name, an attribute, a subscript. A
+comparison or a call computes a fresh value, and ty folding that one is the
+statically-known-branch machinery doing its job: `elif isinstance(x, B):`
+closing an exhaustive chain is deliberate, and so is `while True:`, which
+is a literal rather than a read.
+
+A read whose constant outcome comes from the checker's model of the build
+environment (`TYPE_CHECKING`, `sys.version_info`, `sys.platform`, `os.name`)
+rather than from the program's own types is not reported either — those are
+*artificially* constant, and selecting a branch at check time is exactly
+what they are for.
+
+**Examples**
+
+```python
+import sys
+from typing import TYPE_CHECKING, Literal
+
+def f(a: Literal[True], x: int):
+    if a:  # warning: always true
+        ...
+    if x is not None:  # ok — a comparison, not a value read
+        ...
+
+while True:  # ok — a literal, not a value read
+    ...
+
+if TYPE_CHECKING:  # ok — artificially constant
+    ...
+if sys.version_info >= (3, 12):  # ok — artificially constant
+    ...
+```
+
 ## `redundant-final-classvar`
 
 <small>
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.18">0.0.18</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22redundant-final-classvar%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2333" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2336" target="_blank">View source</a>
 </small>
 
 
@@ -5246,7 +5397,7 @@ class C:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.3">0.0.1-alpha.3</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22reified-classmethod%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1951" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1954" target="_blank">View source</a>
 </small>
 
 
@@ -5279,7 +5430,7 @@ class C:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22shadowed-type-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2342" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2345" target="_blank">View source</a>
 </small>
 
 
@@ -5323,7 +5474,7 @@ class Outer[T]:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22static-assert-error%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2306" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2309" target="_blank">View source</a>
 </small>
 
 
@@ -5358,7 +5509,7 @@ static_assert(int(2.0 * 3.0) == 6)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.39">0.0.39</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22subclass-of-dataclass-with-order%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2048" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2051" target="_blank">View source</a>
 </small>
 
 
@@ -5409,7 +5560,7 @@ Consider using [`functools.total_ordering`][total_ordering] instead, which does 
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22subclass-of-final-class%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L941" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L944" target="_blank">View source</a>
 </small>
 
 
@@ -5443,7 +5594,7 @@ class B(A): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22subclass-of-sealed-class%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L950" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L953" target="_blank">View source</a>
 </small>
 
 
@@ -5475,7 +5626,7 @@ class Circle(Shape): ...  # error: `Shape` is sealed in another workspace
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.30">0.0.1-alpha.30</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22super-call-in-named-tuple-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2203" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2206" target="_blank">View source</a>
 </small>
 
 
@@ -5515,7 +5666,7 @@ class F(NamedTuple):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22too-many-positional-arguments%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2185" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2188" target="_blank">View source</a>
 </small>
 
 
@@ -5545,7 +5696,7 @@ f("foo")  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22trailing-lambda-control-flow%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1539" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1542" target="_blank">View source</a>
 </small>
 
 
@@ -5584,7 +5735,7 @@ def find(items: list[int]) -> int:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22trailing-lambda-parameters%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1653" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1656" target="_blank">View source</a>
 </small>
 
 
@@ -5618,7 +5769,7 @@ f:  # error: the block binds only `it`, so `"two"` has nowhere to go
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22trailing-lambda-return-type%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1624" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1627" target="_blank">View source</a>
 </small>
 
 
@@ -5653,7 +5804,7 @@ f:  # error: the block returns `None`, not `str`
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22type-assertion-failure%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2167" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2170" target="_blank">View source</a>
 </small>
 
 
@@ -5692,7 +5843,7 @@ def _(x: int):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.4">0.0.1-alpha.4</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unannotated-model-field%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1225" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1228" target="_blank">View source</a>
 </small>
 
 
@@ -5723,7 +5874,7 @@ class User(BaseModel):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unavailable-implicit-super-arguments%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2194" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2197" target="_blank">View source</a>
 </small>
 
 
@@ -5781,7 +5932,7 @@ class A:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unbound-type-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L769" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L772" target="_blank">View source</a>
 </small>
 
 
@@ -5825,7 +5976,7 @@ class C(Generic[T]):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.37">0.0.1-alpha.37</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22undeclared-raise%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1287" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1290" target="_blank">View source</a>
 </small>
 
 
@@ -5854,7 +6005,7 @@ def f() raises TypeError:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22undefined-reveal%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2212" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2215" target="_blank">View source</a>
 </small>
 
 
@@ -5883,7 +6034,7 @@ reveal_type(1)  # revealed: Literal[1]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.37">0.0.1-alpha.37</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unhandled-exception%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1335" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1338" target="_blank">View source</a>
 </small>
 
 
@@ -5913,7 +6064,7 @@ def main():
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unknown-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2221" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2224" target="_blank">View source</a>
 </small>
 
 
@@ -5944,7 +6095,7 @@ f(x=1, y=2)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.36">0.0.1-alpha.36</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unknown-fixture%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1460" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1463" target="_blank">View source</a>
 </small>
 
 
@@ -5980,7 +6131,7 @@ def test_thing(no_such_fixture) -> None:  # requests an unknown fixture
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-attribute%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2252" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2255" target="_blank">View source</a>
 </small>
 
 
@@ -6013,7 +6164,7 @@ A().foo  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.15">0.0.1-alpha.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-global%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2351" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2354" target="_blank">View source</a>
 </small>
 
 
@@ -6088,7 +6239,7 @@ def g():
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-import%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2261" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2264" target="_blank">View source</a>
 </small>
 
 
@@ -6117,7 +6268,7 @@ import foo  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-narrowing-guard%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1572" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1575" target="_blank">View source</a>
 </small>
 
 
@@ -6147,7 +6298,7 @@ def check(value: int | None) -> asserts values:  # error: `values` is nothing
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-reference%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2270" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2273" target="_blank">View source</a>
 </small>
 
 
@@ -6175,7 +6326,7 @@ print(x)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.3">0.0.1-alpha.3</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unspecialized-reified-generic%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1915" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1918" target="_blank">View source</a>
 </small>
 
 
@@ -6217,7 +6368,7 @@ g(1)       # ok — transpiles to g[int](1)
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.7">0.0.1-alpha.7</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsupported-base%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L514" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L517" target="_blank">View source</a>
 </small>
 
 
@@ -6264,7 +6415,7 @@ class D(C): ...  # error: [unsupported-base]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsupported-bool-conversion%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L887" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L890" target="_blank">View source</a>
 </small>
 
 
@@ -6313,7 +6464,7 @@ b1 < b2 < b1  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.12">0.0.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsupported-dynamic-base%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L523" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L526" target="_blank">View source</a>
 </small>
 
 
@@ -6360,7 +6511,7 @@ def factory(base: type[Base]) -> type:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsupported-operator%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2279" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2282" target="_blank">View source</a>
 </small>
 
 
@@ -6393,7 +6544,7 @@ A() + A()  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.21">0.0.21</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unused-awaitable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2288" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2291" target="_blank">View source</a>
 </small>
 
 
@@ -6513,7 +6664,7 @@ to `false`.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22useless-overload-body%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L658" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L661" target="_blank">View source</a>
 </small>
 
 
@@ -6592,7 +6743,7 @@ def foo(x: int | str) -> int | str:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22zero-stepsize-in-slice%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2297" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2300" target="_blank">View source</a>
 </small>
 
 

--- a/crates/ty/tests/cli/analysis_options.rs
+++ b/crates/ty/tests/cli/analysis_options.rs
@@ -365,3 +365,86 @@ fn bivariant_private_attributes_is_per_module() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+/// A class name that could not name a class is a configuration error, not a silent no-op.
+#[test]
+fn overlapping_condition_exempt_types_rejects_a_malformed_name() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        (
+            "ty.toml",
+            r#"
+            [analysis]
+            overlapping-condition-exempt-types = ["int", "list[int]"]
+            "#,
+        ),
+        (
+            "test.py",
+            r#"
+            def f(a: str | None):
+                if not a:
+                    ...
+            "#,
+        ),
+    ])?;
+
+    assert_cmd_snapshot!(case.command(), @r#"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    by failed
+      Cause: error[invalid-class-name]: Invalid class name
+     --> ty.toml:3:46
+      |
+    2 | [analysis]
+    3 | overlapping-condition-exempt-types = ["int", "list[int]"]
+      |                                              ^^^^^^^^^^^ Expected a bare or qualified class name, such as `int` or `decimal.Decimal`
+      |
+    "#);
+
+    Ok(())
+}
+
+/// A well-formed name that resolves to nothing is not an error; it just never matches — which the
+/// surviving `overlapping-condition` warning is the proof of.
+#[test]
+fn overlapping_condition_exempt_types_accepts_an_unresolvable_name() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        (
+            "ty.toml",
+            r#"
+            [analysis]
+            overlapping-condition-exempt-types = ["nowhere.Nothing"]
+            "#,
+        ),
+        (
+            "test.py",
+            r#"
+            def f(a: str | None):
+                if not a:
+                    ...
+            "#,
+        ),
+    ])?;
+
+    assert_cmd_snapshot!(case.command(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    warning[overlapping-condition]: This condition does not distinguish between `str & ~AlwaysTruthy` and `None`
+     --> test.py:3:8
+      |
+    3 |     if not a:
+      |        ^^^^^
+      |
+    info: `str | None` is tested for falsiness
+    help: Compare against the specific value instead of testing truthiness
+
+    Found 1 diagnostic
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -1666,6 +1666,46 @@ pub struct AnalysisOptions {
     )]
     pub bivariant_private_attributes: Option<bool>,
 
+    /// A list of classes whose values do not count as a distinct member of an
+    /// [`overlapping-condition`](rules.md#overlapping-condition).
+    ///
+    /// `if not x` over an `int | None` selects both a falsy `int` and `None`, and is reported
+    /// because the branch cannot tell them apart. Listing `int` here says that conflating a falsy
+    /// `int` with anything else is fine, so only `None` is left and the condition is accepted.
+    ///
+    /// Entries are qualified class names (`decimal.Decimal`). A class in `builtins` may also be
+    /// spelled bare (`int`), and `None` stands for the type of `None`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"[]"#,
+        value_type = "list[str]",
+        example = r#"
+            # Accept a falsy `int` or `str` sharing a branch with another member
+            overlapping-condition-exempt-types = ["int", "str"]
+        "#
+    )]
+    pub overlapping_condition_exempt_types: Option<Vec<RangedValue<String>>>,
+
+    /// Whether an instance with no `__bool__` and no `__len__` counts as always truthy when
+    /// looking for an [`overlapping-condition`](rules.md#overlapping-condition).
+    ///
+    /// Such an instance is only *ambiguously* truthy — a subclass may define `__bool__` — so by
+    /// default it is a falsy member of `if not x` just as `None` is. Enabling this assumes the
+    /// class means what it looks like it means, which drops the reports for the very common
+    /// `if not x` over an optional instance.
+    ///
+    /// Defaults to `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"false"#,
+        value_type = "bool",
+        example = r#"
+            # `if not x` over a `Foo | None` only selects `None`
+            overlapping-condition-assume-truthy-instances = true
+        "#
+    )]
+    pub overlapping_condition_assume_truthy_instances: Option<bool>,
+
     /// A list of module glob patterns for which `unresolved-import` diagnostics should be suppressed.
     ///
     /// Details on supported glob patterns:
@@ -1730,6 +1770,8 @@ impl AnalysisOptions {
             disable_fluid_specializations,
             sound_types,
             bivariant_private_attributes,
+            overlapping_condition_exempt_types,
+            overlapping_condition_assume_truthy_instances,
         } = self;
 
         let AnalysisSettings {
@@ -1740,6 +1782,9 @@ impl AnalysisOptions {
             disable_fluid_specializations: disable_fluid_specializations_default,
             sound_types: sound_types_default,
             bivariant_private_attributes: bivariant_private_attributes_default,
+            overlapping_condition_exempt_types: overlapping_condition_exempt_types_default,
+            overlapping_condition_assume_truthy_instances:
+                overlapping_condition_assume_truthy_instances_default,
         } = AnalysisSettings::default();
 
         let allowed_unresolved_imports =
@@ -1776,8 +1821,62 @@ impl AnalysisOptions {
             sound_types: sound_types.unwrap_or(sound_types_default),
             bivariant_private_attributes: bivariant_private_attributes
                 .unwrap_or(bivariant_private_attributes_default),
+            overlapping_condition_exempt_types: overlapping_condition_exempt_types
+                .as_ref()
+                .map(|types| build_class_name_list(db, types, diagnostics))
+                .unwrap_or(overlapping_condition_exempt_types_default),
+            overlapping_condition_assume_truthy_instances:
+                overlapping_condition_assume_truthy_instances
+                    .unwrap_or(overlapping_condition_assume_truthy_instances_default),
         }
     }
+}
+
+/// Collect a list of configured class names, rejecting entries that are not spelled like one.
+///
+/// Only the spelling is checked. Whether a well-formed name resolves to a class that exists is
+/// not — an entry that resolves to nothing simply never matches, the same way a well-formed glob
+/// that matches no module is not an error.
+fn build_class_name_list(
+    db: &dyn Db,
+    names: &[RangedValue<String>],
+    diagnostics: &mut Vec<OptionDiagnostic>,
+) -> Box<[Box<str>]> {
+    const OPTION_NAME: &str = "overlapping-condition-exempt-types";
+
+    let is_identifier = |segment: &str| {
+        let mut chars = segment.chars();
+        chars
+            .next()
+            .is_some_and(|first| first.is_alphabetic() || first == '_')
+            && chars.all(|char| char.is_alphanumeric() || char == '_')
+    };
+
+    let mut collected = Vec::with_capacity(names.len());
+    for name in names {
+        if name.split('.').all(is_identifier) {
+            collected.push(Box::from(&***name));
+        } else {
+            // Fatal, like every other diagnostic in this vec — `Options::to_settings` turns the
+            // first analysis diagnostic into a `ToSettingsError` regardless of its severity, and
+            // that is the same treatment a malformed `allowed-unresolved-imports` glob gets.
+            diagnostics.push(
+                OptionDiagnostic::new(
+                    DiagnosticId::InvalidClassName,
+                    format!("`{}` is not a class name", &***name),
+                    Severity::Error,
+                )
+                .with_source_sub(
+                    db,
+                    name,
+                    "class name",
+                    OPTION_NAME,
+                    "Expected a bare or qualified class name, such as `int` or `decimal.Decimal`",
+                ),
+            );
+        }
+    }
+    collected.into_boxed_slice()
 }
 
 fn build_module_glob_set(

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1041,6 +1041,7 @@ def add_replacement(self: Foo, x: int, y: int, /) -> int:
 original_add = Foo.add
 
 def requires_true(value: Literal[True]) -> None:
+    # error: [redundant-condition]
     assert value
 
 Foo.add = add_replacement

--- a/crates/ty_python_semantic/resources/mdtest/basedpython_sqlalchemy.md
+++ b/crates/ty_python_semantic/resources/mdtest/basedpython_sqlalchemy.md
@@ -112,7 +112,7 @@ with Session(engine) as session:
     session.add(Flag())
     session.commit()
     row = session.query(Flag).one()
-    assert row.enabled is True
+    assert row.enabled
 ```
 
 ## soundness guards inside a model method

--- a/crates/ty_python_semantic/resources/mdtest/basedpython_type_guards.md
+++ b/crates/ty_python_semantic/resources/mdtest/basedpython_type_guards.md
@@ -433,6 +433,7 @@ reveal_type(h.data)  # revealed: str
 
 ```by
 def check(a: int | None, b: str | None) -> asserts a is int and b:
+    # error: [overlapping-condition]
     if a is None or not b:
         raise ValueError
 

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -1561,6 +1561,7 @@ class SortParams[F]:
 def build_sort_spec[T](
     sort_params: SortParams[T] | None,
 ) -> dict[T, Literal[1, -1]] | None:
+    # error: [overlapping-condition]
     if not sort_params:
         return None
     return {sort_params.field: 1}

--- a/crates/ty_python_semantic/resources/mdtest/boundness_declaredness/public.md
+++ b/crates/ty_python_semantic/resources/mdtest/boundness_declaredness/public.md
@@ -73,6 +73,9 @@ class Public:
     c: Any
     d: int
 
+    # `flag` is a function, so this is always truthy — the test means `flag()`, but fixing it
+    # changes what the section asserts about possibly-missing attributes
+    # error: [redundant-condition]
     if flag:
         a = 1
         b = 2  # error: [invalid-assignment]
@@ -219,6 +222,8 @@ def flag() -> bool:
     return True
 
 class Public:
+    # as above: `if flag:` is always truthy, and `if flag()` would satisfy the TODO below
+    # error: [redundant-condition]
     if flag:
         a = 1
         b: SomeUnknownName = 1  # error: [unresolved-reference]

--- a/crates/ty_python_semantic/resources/mdtest/conditions.md
+++ b/crates/ty_python_semantic/resources/mdtest/conditions.md
@@ -1,0 +1,546 @@
+# conditions
+
+A condition collapses a value to a single bit. Two checks watch for the ways that goes wrong:
+`overlapping-condition` when the selected branch holds a value that is always there alongside one
+that is only sometimes there, and `redundant-condition` when the outcome is fixed and there is no
+branch at all.
+
+## a truthy test that tells `True` apart
+
+Only the branch the condition *selects* is analysed. `bool | None` has exactly one truthy member, so
+`if a` asks a question with one answer.
+
+```py
+def f(a: bool | None):
+    if a:
+        reveal_type(a)  # revealed: Literal[True]
+```
+
+## a falsy test that does not
+
+The falsy side has two, and the branch cannot say which one it got.
+
+```py
+def f(a: bool | None):
+    # error: [overlapping-condition] "This condition does not distinguish between `Literal[False]` and `None`"
+    if not a:
+        reveal_type(a)  # revealed: Literal[False] | None
+```
+
+## an optional string
+
+The classic one: an empty string and an absent value share a branch.
+
+```py
+def f(name: str | None):
+    # error: [overlapping-condition] "This condition does not distinguish between `str & ~AlwaysTruthy` and `None`"
+    if not name: ...
+```
+
+## telling the members apart is fine
+
+```py
+def f(name: str | None):
+    if name is None: ...
+```
+
+## a class that settles its own truthiness
+
+An instance that always answers `True` is never a falsy member, so both directions are clean.
+
+```py
+from typing import Literal
+
+class A:
+    def __bool__(self) -> Literal[True]:
+        return True
+
+def f(a: A | None):
+    if a:
+        reveal_type(a)  # revealed: A
+    if not a:
+        reveal_type(a)  # revealed: None
+```
+
+## a class that does not
+
+Without `__bool__`, a subclass may still be falsy, so `A` is a falsy member alongside `None`.
+
+```py
+class A: ...
+
+def f(a: A | None):
+    if a:
+        reveal_type(a)  # revealed: A & ~AlwaysFalsy
+    # error: [overlapping-condition] "This condition does not distinguish between `A & ~AlwaysTruthy` and `None`"
+    if not a: ...
+```
+
+## `not not` is not a negation
+
+Polarity is read off the whole chain of `not`s, so the selected branch is the truthy one again.
+
+```py
+def f(a: bool | None):
+    if not not a:
+        reveal_type(a)  # revealed: Literal[True]
+```
+
+## three overlapping members
+
+```py
+from typing import Literal
+
+def f(a: Literal[0] | str | None):
+    # error: [overlapping-condition] "This condition does not distinguish between `Literal[0]`, `str & ~AlwaysTruthy` and `None`"
+    if not a: ...
+```
+
+## every condition position
+
+Each position gets its own function: narrowing from one test would otherwise decide the next.
+
+```py
+def while_(a: bool | None) -> None:
+    while not a:  # error: [overlapping-condition]
+        ...
+
+def assert_(a: bool | None) -> None:
+    assert not a  # error: [overlapping-condition]
+
+def if_expression(a: bool | None) -> None:
+    x = 1 if not a else 2  # error: [overlapping-condition]
+
+def comprehension(a: bool | None) -> None:
+    y = [n for n in range(3) if not a]  # error: [overlapping-condition]
+
+def match_guard(a: bool | None) -> None:
+    match 1:
+        case int() if not a:  # error: [overlapping-condition]
+            ...
+```
+
+## two members that are each only partly in the branch
+
+`if x:` puts a non-empty `str` next to a non-empty `bytes`, and neither of them was ever going to be
+anywhere else — the union already conflated them and the condition added nothing. What the check
+looks for is the asymmetry of one member being unconditionally in the branch.
+
+```py
+def f(x: str | bytes):
+    if x: ...
+    if not x: ...
+```
+
+## nor when every member is unconditionally there
+
+```py
+from typing import Literal
+
+class Truthy:
+    def __bool__(self) -> Literal[True]:
+        return True
+
+class AlsoTruthy:
+    def __bool__(self) -> Literal[True]:
+        return True
+
+def f(x: Truthy | AlsoTruthy | None):
+    if x: ...
+```
+
+## one class, two specializations, one kind
+
+Type arguments are not what truthiness sees: `list[A]` and `list[B]` are both lists, and the branch
+only learns that one of them is empty.
+
+```py
+class A: ...
+class B: ...
+
+def f(xs: list[A] | list[B]):
+    if xs: ...
+```
+
+## a boolean operator is one condition per operand
+
+`a and b` is not a single value being tested — each operand's truthiness is tested on its own — so
+the operator's value (the union of the operands) is not analysed as if it were one member set.
+
+```py
+def f(count: int, leftovers: dict[str, int]):
+    if count > 0 or leftovers: ...
+```
+
+## and each operand is checked on its own
+
+```py
+def f(a: bool | None, name: str | None):
+    # error: [overlapping-condition] "This condition does not distinguish between `Literal[False]` and `None`"
+    # error: [overlapping-condition] "This condition does not distinguish between `str & ~AlwaysTruthy` and `None`"
+    if not a or not name: ...
+```
+
+## polarity carries into the operands
+
+```py
+from typing import Literal
+
+def f(a: Literal[True], b: bool):
+    # error: [redundant-condition] "This condition is always false"
+    if not a and b: ...
+```
+
+## an attribute or a subscript is a value read too
+
+```py
+from typing import Literal
+
+class Holder:
+    flag: bool | None
+    always: Literal[True]
+
+def f(h: Holder, d: dict[str, bool | None]):
+    # error: [overlapping-condition]
+    if not h.flag: ...
+    # error: [redundant-condition] "This condition is always true"
+    if h.always: ...
+    # error: [overlapping-condition]
+    if not d["k"]: ...
+```
+
+## a protocol instance is an instance
+
+```toml
+[analysis]
+overlapping-condition-assume-truthy-instances = true
+```
+
+```py
+from typing import Protocol
+
+class HasName(Protocol):
+    name: str
+
+def f(x: HasName | None):
+    if not x: ...
+```
+
+## exempting a type
+
+`analysis.overlapping-condition-exempt-types` says a member is not worth telling apart. With `int`
+exempt, only `None` is left in the falsy branch.
+
+```toml
+[analysis]
+overlapping-condition-exempt-types = ["int"]
+```
+
+```py
+def f(a: int | None):
+    if not a: ...
+
+def g(a: str | None):
+    # error: [overlapping-condition]
+    if not a: ...
+```
+
+## exempting `None`
+
+```toml
+[analysis]
+overlapping-condition-exempt-types = ["None"]
+```
+
+```py
+def f(a: int | None):
+    if not a: ...
+```
+
+## exempting a qualified name
+
+```toml
+[analysis]
+overlapping-condition-exempt-types = ["decimal.Decimal"]
+```
+
+```py
+from decimal import Decimal
+
+def f(a: Decimal | None):
+    if not a: ...
+```
+
+## assuming an instance is truthy
+
+`analysis.overlapping-condition-assume-truthy-instances` takes a class with no `__bool__` and no
+`__len__` at face value, which drops the report for `if not x` over an optional instance.
+
+```toml
+[analysis]
+overlapping-condition-assume-truthy-instances = true
+```
+
+```py
+class A: ...
+
+def f(a: A | None):
+    if not a:
+        reveal_type(a)  # revealed: (A & ~AlwaysTruthy) | None
+```
+
+## a class that does define `__len__` is unaffected
+
+```toml
+[analysis]
+overlapping-condition-assume-truthy-instances = true
+```
+
+```py
+class A:
+    def __len__(self) -> int:
+        return 0
+
+def f(a: A | None):
+    # error: [overlapping-condition]
+    if not a: ...
+```
+
+## a condition that is always true
+
+```py
+from typing import Literal
+
+def f(a: Literal[True]):
+    # error: [redundant-condition] "This condition is always true"
+    if a: ...
+```
+
+## a condition that is always false
+
+```py
+from typing import Literal
+
+def f(a: Literal[""]):
+    # error: [redundant-condition] "This condition is always false"
+    if a: ...
+```
+
+## a literal condition is deliberate
+
+`while True` and `assert False` mean the constant; they are not a conditional that failed to be
+conditional.
+
+```py
+def f():
+    while True:
+        break
+    if False: ...
+    assert False
+```
+
+## `TYPE_CHECKING` is artificially constant
+
+Its constant outcome is the checker's doing, not the program's.
+
+```py
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import decimal
+
+if not TYPE_CHECKING: ...
+```
+
+## `sys.version_info` is artificially constant
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+import sys
+
+if sys.version_info >= (3, 10): ...
+
+if sys.version_info < (3, 10): ...
+```
+
+## `sys.platform` is artificially constant
+
+```toml
+[environment]
+python-platform = "linux"
+```
+
+```py
+import sys
+
+if sys.platform == "win32": ...
+
+if sys.platform.startswith("linux"): ...
+```
+
+## `os.name` is artificially constant
+
+```toml
+[environment]
+python-platform = "linux"
+```
+
+```py
+import os
+
+if os.name == "nt": ...
+```
+
+## an aliased `sys` still works
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+import sys as system
+
+if system.version_info >= (3, 10): ...
+```
+
+## comparing a `bool` with `True`
+
+```py
+def f(a: bool):
+    # error: [redundant-boolean-comparison] "Comparison of a `bool` with `True` is redundant"
+    if a == True: ...
+```
+
+## comparing a `bool` with `False`
+
+```py
+def f(a: bool):
+    # error: [redundant-boolean-comparison] "Comparison of a `bool` with `False` is redundant"
+    if a is False: ...
+```
+
+## the literal may come first
+
+```py
+def f(a: bool):
+    # error: [redundant-boolean-comparison]
+    if True != a: ...
+```
+
+## an optional `bool` is not redundant
+
+`a == True` really does tell `True` apart from `False` and `None` here.
+
+```py
+def f(a: bool | None):
+    if a == True: ...
+```
+
+## an `int` is not redundant
+
+```py
+def f(a: int):
+    if a == True: ...
+```
+
+## a chained comparison is left alone
+
+Two comparisons over one literal: reporting each pair would double up on that `True`, and neither
+the operand nor its negation replaces the chain.
+
+```py
+def f(a: bool, b: bool):
+    if a == True == b: ...
+```
+
+## the comparison need not be a condition
+
+```py
+def f(a: bool) -> bool:
+    # error: [redundant-boolean-comparison] "Comparison of a `bool` with `True` is redundant"
+    y = a == True
+    return y
+```
+
+## a negated operator flips the advice
+
+```py
+def f(a: bool):
+    # error: [redundant-boolean-comparison] "Comparison of a `bool` with `False` is redundant"
+    if a is not False: ...
+    # error: [redundant-boolean-comparison] "Comparison of a `bool` with `False` is redundant"
+    if a != False: ...
+```
+
+## an operand bounded by `bool`
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+def f[T: bool](t: T):
+    # error: [redundant-boolean-comparison]
+    if t == True: ...
+```
+
+## an ordering comparison is not redundant
+
+```py
+def f(a: bool):
+    if a < True: ...
+```
+
+## diagnostics
+
+```py
+from typing import Literal
+
+def overlap(a: bool | None):
+    # snapshot: overlapping-condition
+    if not a: ...
+
+def redundant(a: Literal[True]):
+    # snapshot: redundant-condition
+    if a: ...
+
+def comparison(a: bool):
+    # snapshot: redundant-boolean-comparison
+    if a == False: ...
+```
+
+```snapshot
+warning[overlapping-condition]: This condition does not distinguish between `Literal[False]` and `None`
+ --> src/mdtest_snippet.py:5:8
+  |
+5 |     if not a: ...
+  |        ^^^^^
+  |
+info: `bool | None` is tested for falsiness
+help: Compare against the specific value instead of testing truthiness
+
+
+warning[redundant-condition]: This condition is always true
+ --> src/mdtest_snippet.py:9:8
+  |
+9 |     if a: ...
+  |        ^
+  |
+info: `Literal[True]` is always truthy
+
+
+warning[redundant-boolean-comparison]: Comparison of a `bool` with `False` is redundant
+  --> src/mdtest_snippet.py:13:8
+   |
+13 |     if a == False: ...
+   |        ^^^^^^^^^^
+   |
+info: `bool` already is the value this comparison produces
+help: Negate the operand with `not` instead
+```

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/semantic_syntax_errors.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/semantic_syntax_errors.md
@@ -214,6 +214,7 @@ reveal_type(i)  # revealed: Unknown
 [(item := 0) for (item, other) in [(0, 1)]]
 
 # error: [invalid-syntax] "assignment expression cannot rebind comprehension variable"
+# error: [redundant-condition]
 [x for x in [1] if (y := x) for y in [1]]
 
 [x for x in [0] if [(y := z) for z in [1]] for y in [2]]

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -3227,6 +3227,7 @@ def color_value_without_red_and_with_restricted_typevar(
 def color_truthy_without_red(color: Color) -> int:
     if color is Color.RED:
         raise ValueError()
+    # error: [redundant-condition]
     if color:
         return 1
 

--- a/crates/ty_python_semantic/resources/mdtest/function/return_type.md
+++ b/crates/ty_python_semantic/resources/mdtest/function/return_type.md
@@ -229,9 +229,11 @@ if not typing.TYPE_CHECKING:
     def p() -> str:
         raise NotImplementedError
 
+# error: [redundant-condition]
 if compat.sub.sub.TYPE_CHECKING:
     def q() -> str: ...
 
+# error: [redundant-condition]
 if not compat.sub.sub.TYPE_CHECKING:
     def r() -> str:
         raise NotImplementedError
@@ -287,6 +289,7 @@ def f() -> int:
 # no implicit return
 def f(cond: bool) -> int:
     cond = True
+    # error: [redundant-condition]
     if cond:
         return 1
 
@@ -295,6 +298,7 @@ def f(cond: bool) -> int:
         cond = True
     else:
         return 1
+    # error: [redundant-condition]
     if cond:
         return 2
 ```
@@ -407,6 +411,7 @@ def f(cond: bool) -> int:
         cond = False
     else:
         return 1
+    # error: [redundant-condition]
     if cond:
         return 2
 ```

--- a/crates/ty_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/for.md
@@ -1809,6 +1809,7 @@ real crash that came up during development checking these lines of `sympy`:
 x = 1
 y = 2
 for _ in range(1_000_000):
+    # error: [redundant-condition]
     if x:
         x, y = y, x
     reveal_type(x)  # revealed: Literal[2, 1]

--- a/crates/ty_python_semantic/resources/mdtest/loops/while_loop.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/while_loop.md
@@ -394,6 +394,7 @@ def random() -> bool:
 
 x = 1
 while random():
+    # error: [redundant-condition]
     if x:
         x = 1
     else:
@@ -463,6 +464,7 @@ def random() -> bool:
 x = 1
 y = 2
 while random():
+    # error: [redundant-condition]
     if x:
         x, y = y, x
     reveal_type(x)  # revealed: Literal[2, 1]

--- a/crates/ty_python_semantic/resources/mdtest/narrow/aliased_conditions.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/aliased_conditions.md
@@ -145,6 +145,7 @@ def _(x: int | None):
         reveal_type(x)  # revealed: None
     if is_none if True else False:
         reveal_type(x)  # revealed: None
+    # error: [redundant-boolean-comparison]
     if is_none == True:
         # TODO: it would be nice to support this case, but even direct narrowing doesn't work here
         reveal_type(x)  # revealed: int | None
@@ -259,6 +260,7 @@ If the alias variable itself is reassigned, it no longer represents the original
 def _(x: int | None):
     is_none = x is None
     is_none = True
+    # error: [redundant-condition]
     if is_none:
         reveal_type(x)  # revealed: int | None
 
@@ -412,6 +414,7 @@ def _(x: int | None):
 
     class Inner:
         is_none = True
+        # error: [redundant-condition]
         if is_none:
             reveal_type(x)  # revealed: int | None
 
@@ -436,6 +439,7 @@ def _(x: int | None):
     def inner():
         nonlocal is_none
         is_none = True
+        # error: [redundant-condition]
         if is_none:
             reveal_type(x)  # revealed: int | None
 
@@ -514,6 +518,7 @@ def _(x: int | None):
 
     class Inner:
         is_none_alias = True
+        # error: [redundant-condition]
         if is_none_alias:
             reveal_type(x)  # revealed: int | None
         if is_none:
@@ -533,6 +538,7 @@ def _(x: int | None):
         if is_none_alias:
             # TODO: should be `None`
             reveal_type(x)  # revealed: int | None
+        # error: [redundant-condition]
         if is_none:
             reveal_type(x)  # revealed: int | None
 
@@ -546,6 +552,7 @@ def _(x: int | None):
 
     def inner():
         is_none_alias = True
+        # error: [redundant-condition]
         if is_none_alias:
             reveal_type(x)  # revealed: int | None
         if is_none:
@@ -553,6 +560,7 @@ def _(x: int | None):
             reveal_type(x)  # revealed: int | None
 
         def inner2():
+            # error: [redundant-condition]
             if is_none_alias:
                 reveal_type(x)  # revealed: int | None
             if is_none:
@@ -564,6 +572,7 @@ def _(x: int | None):
         if is_none_alias:
             # TODO: should be `None`
             reveal_type(x)  # revealed: int | None
+        # error: [redundant-condition]
         if is_none:
             reveal_type(x)  # revealed: int | None
 
@@ -571,6 +580,7 @@ def _(x: int | None):
             if is_none_alias:
                 # TODO: should be `None`
                 reveal_type(x)  # revealed: int | None
+            # error: [redundant-condition]
             if is_none:
                 reveal_type(x)  # revealed: int | None
 ```
@@ -603,6 +613,7 @@ def _(x: int | None):
         is_none_alias = is_none
         is_none = False
         reveal_type(is_none_alias)  # revealed: Literal[True]
+        # error: [redundant-condition]
         if is_none_alias:
             reveal_type(x)  # revealed: int | None
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/complex_target.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/complex_target.md
@@ -239,6 +239,7 @@ def _(t3: tuple[int, str] | tuple[None, None] | tuple[bool, bytes]):
 def _(t4: tuple[bool, int] | tuple[bool, str]):
     # Both tuples have bool at index 0, which is not disjoint from True,
     # so neither gets filtered out when checking `is True`
+    # error: [redundant-boolean-comparison]
     if t4[0] is True:
         reveal_type(t4)  # revealed: tuple[bool, int] | tuple[bool, str]
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -42,12 +42,14 @@ def _(x: None | Literal[1]):
 
 ```py
 def _(x: bool):
+    # error: [redundant-boolean-comparison]
     if x != False:
         reveal_type(x)  # revealed: Literal[True]
     else:
         reveal_type(x)  # revealed: Literal[False]
 
 def _(x: bool):
+    # error: [redundant-boolean-comparison]
     if x == False:
         reveal_type(x)  # revealed: Literal[False]
     else:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is_not.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is_not.md
@@ -34,6 +34,7 @@ This also works for other singleton types with reversed operands:
 
 ```py
 def _(x: bool):
+    # error: [redundant-boolean-comparison]
     if False is not x:
         reveal_type(x)  # revealed: Literal[True]
     else:
@@ -49,6 +50,7 @@ def _(flag: bool):
     x = True if flag else False
     reveal_type(x)  # revealed: bool
 
+    # error: [redundant-boolean-comparison]
     if x is not False:
         reveal_type(x)  # revealed: Literal[True]
     else:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -3436,6 +3436,7 @@ def _(x: Literal["foo", b"bar"] | int):
             pass
         case b"bar" if reveal_type(x):  # revealed: Literal[b"bar"]
             pass
+        # error: [overlapping-condition]
         case _ if reveal_type(x):  # revealed: Literal["foo", b"bar"] | int
             pass
 ```
@@ -3449,6 +3450,7 @@ def _(x: object):
             reveal_type(x)  #  revealed: str
         case "foo" | 42 | None if isinstance(x, int):
             reveal_type(x)  #  revealed: int
+        # error: [redundant-condition]
         case False if x:
             reveal_type(x)  #  revealed: Never
         case "foo" if x := "bar":
@@ -3470,6 +3472,7 @@ match x:
         pass
     case "foo" | 42 | None if isinstance(x, int) and reveal_type(x):  #  revealed: int
         pass
+    # error: [redundant-condition]
     case False if x and reveal_type(x):  #  revealed: Never
         pass
     case "foo" if (x := "bar") and reveal_type(x):  #  revealed: Literal["bar"]

--- a/crates/ty_python_semantic/resources/mdtest/narrow/post_if_statement.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/post_if_statement.md
@@ -395,6 +395,7 @@ async def main(val: int | None):
 data: dict[str, str] = {}
 api_key = data.get("api_key")
 
+# error: [overlapping-condition]
 if not api_key:
     exit(1)
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/truthiness.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/truthiness.md
@@ -8,42 +8,53 @@ from typing import Literal, TypeAlias
 X: TypeAlias = Literal[0, -1, True, False, "", "foo", b"", b"bar", None] | tuple[()]
 
 def _(x: X):
+    # error: [overlapping-condition]
     if x:
         reveal_type(x)  # revealed: Literal[-1, True, "foo", b"bar"]
     else:
         reveal_type(x)  # revealed: Literal[0, False, "", b""] | None | tuple[()]
 
 def _(x: X):
+    # error: [overlapping-condition]
     if not x:
         reveal_type(x)  # revealed: Literal[0, False, "", b""] | None | tuple[()]
     else:
         reveal_type(x)  # revealed: Literal[-1, True, "foo", b"bar"]
 
 def _(x: X):
+    # error: [overlapping-condition]
+    # error: [redundant-condition]
     if x and not x:
         reveal_type(x)  # revealed: Never
     else:
         reveal_type(x)  # revealed: Literal[0, -1, "", "foo", b"", b"bar"] | bool | None | tuple[()]
 
 def _(x: X):
+    # error: [overlapping-condition]
+    # error: [redundant-condition]
     if not (x and not x):
         reveal_type(x)  # revealed: Literal[0, -1, "", "foo", b"", b"bar"] | bool | None | tuple[()]
     else:
         reveal_type(x)  # revealed: Never
 
 def _(x: X):
+    # error: [overlapping-condition]
+    # error: [redundant-condition]
     if x or not x:
         reveal_type(x)  # revealed: Literal[-1, 0, "foo", "", b"bar", b""] | bool | None | tuple[()]
     else:
         reveal_type(x)  # revealed: Never
 
 def _(x: X):
+    # error: [overlapping-condition]
+    # error: [redundant-condition]
     if not (x or not x):
         reveal_type(x)  # revealed: Never
     else:
         reveal_type(x)  # revealed: Literal[-1, 0, "foo", "", b"bar", b""] | bool | None | tuple[()]
 
 def _(x: X):
+    # error: [overlapping-condition]
     if (isinstance(x, int) or isinstance(x, str)) and x:
         reveal_type(x)  # revealed: Literal[-1, True, "foo"]
     else:
@@ -129,6 +140,7 @@ def bar(world: str, *args, **kwargs) -> float:
 
 x = foo if flag() else bar
 
+# error: [redundant-condition]
 if x:
     reveal_type(x)  # revealed: (def foo(hello: int) -> bytes) | (def bar(world: str, *args, **kwargs) -> int | float)
 else:
@@ -204,6 +216,7 @@ class F:
 
 t = T()
 
+# error: [redundant-condition]
 if t:
     reveal_type(t)  # revealed: T
 else:
@@ -211,6 +224,7 @@ else:
 
 f = F()
 
+# error: [redundant-condition]
 if f:
     reveal_type(f)  # revealed: Never
 else:
@@ -257,6 +271,7 @@ if isinstance(x, str) and not isinstance(x, B):
 from typing import Literal
 
 def f(x: Literal[0, 1], y: Literal["", "hello"]):
+    # error: [redundant-condition]
     if x and y and not x and not y:
         reveal_type(x)  # revealed: Never
         reveal_type(y)  # revealed: Never
@@ -265,6 +280,8 @@ def f(x: Literal[0, 1], y: Literal["", "hello"]):
         reveal_type(x)  # revealed: Literal[0, 1]
         reveal_type(y)  # revealed: Literal["", "hello"]
 
+    # error: [redundant-condition]
+    # error: [redundant-condition]
     if (x or not x) and (y and not y):
         reveal_type(x)  # revealed: Never
         reveal_type(y)  # revealed: Never
@@ -330,6 +347,7 @@ def _(
     flag: bool,
 ):
     reveal_type(ta)  # revealed: type[TruthyClass | AmbiguousClass]
+    # error: [overlapping-condition]
     if ta:
         reveal_type(ta)  # revealed: type[TruthyClass] | (type[AmbiguousClass] & ~AlwaysFalsy)
 
@@ -531,6 +549,7 @@ def f(arg1: Empty | None, arg2: NonEmpty | None, arg3: HasNotRequired1 | None, a
     if arg4:
         reveal_type(arg4)  # revealed: HasNotRequired2 & ~AlwaysFalsy
 
+    # error: [redundant-condition]
     if arg5:
         reveal_type(arg5)  # revealed: AlsoNonEmpty
 ```
@@ -550,6 +569,7 @@ def get_person() -> Person | None:
 
 def test() -> None:
     p = get_person()
+    # error: [overlapping-condition]
     if not p:
         raise ValueError("No person")
     reveal_type(p)  # revealed: Person & ~AlwaysFalsy

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_implicit_ret…_(393cb38bf7119649).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_implicit_ret…_(393cb38bf7119649).snap
@@ -33,8 +33,9 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/function/return_type.md
 18 |         cond = False
 19 |     else:
 20 |         return 1
-21 |     if cond:
-22 |         return 2
+21 |     # error: [redundant-condition]
+22 |     if cond:
+23 |         return 2
 ```
 
 # Diagnostics
@@ -67,5 +68,16 @@ error[invalid-return-type]: Function can implicitly return `None`, which is not 
 16 | def f(cond: bool) -> int:
    |                      ^^^
    |
+
+```
+
+```
+warning[redundant-condition]: This condition is always false
+  --> src/mdtest_snippet.py:22:8
+   |
+22 |     if cond:
+   |        ^^^^
+   |
+info: `Literal[False]` is always falsy
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/statically_known_branches.md
+++ b/crates/ty_python_semantic/resources/mdtest/statically_known_branches.md
@@ -1575,6 +1575,7 @@ def _(flag: bool):
         ALWAYS_TRUE_IF_BOUND = True
 
     # error: [possibly-unresolved-reference] "Name `ALWAYS_TRUE_IF_BOUND` used when possibly not defined"
+    # error: [redundant-condition]
     if True and ALWAYS_TRUE_IF_BOUND:
         x = 1
 
@@ -1588,6 +1589,7 @@ def _(flag: bool):
         ALWAYS_TRUE_IF_BOUND = True
 
     # error: [possibly-unresolved-reference] "Name `ALWAYS_TRUE_IF_BOUND` used when possibly not defined"
+    # error: [redundant-condition]
     if True and ALWAYS_TRUE_IF_BOUND:
         x = 1
     else:

--- a/crates/ty_python_semantic/resources/mdtest/unreachable.md
+++ b/crates/ty_python_semantic/resources/mdtest/unreachable.md
@@ -262,11 +262,13 @@ from typing import Literal
 
 FEATURE_X_ACTIVATED: Literal[False] = False
 
+# error: [redundant-condition]
 if FEATURE_X_ACTIVATED:
     def feature_x():
         print("Performing 'X'")
 
 def f():
+    # error: [redundant-condition]
     if FEATURE_X_ACTIVATED:
         # Type checking this particular section as if it were reachable would
         # lead to a false positive, so we should not emit diagnostics here.

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -143,6 +143,21 @@ pub struct AnalysisSettings {
     /// constrains variance not at all. When this is disabled, private attributes are instead
     /// treated as immutable-but-readable, which constrains the type parameter to covariance.
     pub bivariant_private_attributes: bool,
+
+    /// Classes whose values do not count as a distinct member of an overlapping condition.
+    ///
+    /// Entries are qualified class names (`decimal.Decimal`); a class in `builtins` may also be
+    /// spelled bare (`int`), and `None` stands for the type of `None`.
+    pub overlapping_condition_exempt_types: Box<[Box<str>]>,
+
+    /// Whether an instance with no `__bool__` and no `__len__` counts as always truthy when
+    /// looking for an overlapping condition.
+    ///
+    /// Such an instance is only *ambiguously* truthy — a subclass may define `__bool__` — so by
+    /// default it is a falsy member of `if not x` just as `None` is. Enabling this assumes the
+    /// class means what it looks like it means, which drops the reports for the very common
+    /// `if not x` over an optional instance.
+    pub overlapping_condition_assume_truthy_instances: bool,
 }
 
 impl Default for AnalysisSettings {
@@ -155,6 +170,8 @@ impl Default for AnalysisSettings {
             disable_fluid_specializations: false,
             sound_types: false,
             bivariant_private_attributes: true,
+            overlapping_condition_exempt_types: Box::default(),
+            overlapping_condition_assume_truthy_instances: false,
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -212,6 +212,9 @@ pub(crate) fn register_lints(registry: &mut LintRegistryBuilder) {
     registry.register_lint(&INVALID_FROZEN_DATACLASS_SUBCLASS);
     registry.register_lint(&INVALID_TOTAL_ORDERING);
     registry.register_lint(&INVALID_LEGACY_POSITIONAL_PARAMETER);
+    registry.register_lint(&OVERLAPPING_CONDITION);
+    registry.register_lint(&REDUNDANT_CONDITION);
+    registry.register_lint(&REDUNDANT_BOOLEAN_COMPARISON);
 
     // String annotations
     registry.register_lint(&ESCAPE_CHARACTER_IN_FORWARD_ANNOTATION);
@@ -2435,6 +2438,138 @@ declare_lint! {
     pub(crate) static INVALID_LEGACY_POSITIONAL_PARAMETER = {
         summary: "detects incorrect usage of the legacy convention for specifying positional-only parameters",
         status: LintStatus::stable("0.0.15"),
+        default_level: Level::Warn,
+    }
+}
+
+declare_lint! {
+    /// ## What it does
+    /// Checks for a truthiness test whose selected branch holds a value that is
+    /// always there alongside one that is only sometimes there.
+    ///
+    /// ## Why is this bad?
+    /// A condition collapses a value to a single bit, so two members that answer
+    /// the test the same way become indistinguishable inside the branch. The case
+    /// that bites is a sentinel meeting the falsy corner of a value that normally
+    /// belongs to the other branch — `None` meeting `""` in `if not name:`.
+    ///
+    /// Only the branch the condition *selects* is analyzed: `if a` looks at the
+    /// truthy members, `if not a` at the falsy ones. A boolean operator is one
+    /// condition per operand rather than one over its value, since each operand's
+    /// truthiness is tested on its own.
+    ///
+    /// Two members that are *each* only partly in the branch are not reported:
+    /// `if x:` over a `str | bytes` conflates nothing the union did not already
+    /// conflate. Neither are members of one class, or of two classes where one
+    /// derives the other, which a condition was never going to tell apart:
+    /// `Literal[1] | Literal[2]` and `list[A] | list[B]` are each one kind of
+    /// value.
+    ///
+    /// ## Examples
+    /// ```python
+    /// def f(a: bool | None):
+    ///     if a:      # ok — only `True` is truthy
+    ///         ...
+    ///     if not a:  # warning: `False` and `None` are both falsy
+    ///         ...
+    ///
+    /// def g(name: str | None):
+    ///     if not name:  # warning: `""` and `None` are both falsy
+    ///         ...
+    ///     if name is None:  # ok — the members are told apart
+    ///         ...
+    /// ```
+    ///
+    /// ## Options
+    /// - `analysis.overlapping-condition-exempt-types`
+    /// - `analysis.overlapping-condition-assume-truthy-instances`
+    pub(crate) static OVERLAPPING_CONDITION = {
+        summary: "detects a condition that several members of the tested type answer the same way",
+        status: LintStatus::stable("0.0.62"),
+        default_level: Level::Warn,
+    }
+}
+
+declare_lint! {
+    /// ## What it does
+    /// Checks for a condition whose outcome is fixed by the tested type, so the
+    /// branch is not conditional at all.
+    ///
+    /// ## Why is this bad?
+    /// One of the two branches is dead. Either the annotation is wider than the
+    /// author believed, or the test is left over from an earlier version of the
+    /// code.
+    ///
+    /// Only a value *read* is reported — a name, an attribute, a subscript. A
+    /// comparison or a call computes a fresh value, and ty folding that one is the
+    /// statically-known-branch machinery doing its job: `elif isinstance(x, B):`
+    /// closing an exhaustive chain is deliberate, and so is `while True:`, which
+    /// is a literal rather than a read.
+    ///
+    /// A read whose constant outcome comes from the checker's model of the build
+    /// environment (`TYPE_CHECKING`, `sys.version_info`, `sys.platform`, `os.name`)
+    /// rather than from the program's own types is not reported either — those are
+    /// *artificially* constant, and selecting a branch at check time is exactly
+    /// what they are for.
+    ///
+    /// ## Examples
+    /// ```python
+    /// import sys
+    /// from typing import TYPE_CHECKING, Literal
+    ///
+    /// def f(a: Literal[True], x: int):
+    ///     if a:  # warning: always true
+    ///         ...
+    ///     if x is not None:  # ok — a comparison, not a value read
+    ///         ...
+    ///
+    /// while True:  # ok — a literal, not a value read
+    ///     ...
+    ///
+    /// if TYPE_CHECKING:  # ok — artificially constant
+    ///     ...
+    /// if sys.version_info >= (3, 12):  # ok — artificially constant
+    ///     ...
+    /// ```
+    pub(crate) static REDUNDANT_CONDITION = {
+        summary: "detects a condition whose outcome is fixed by the tested type",
+        status: LintStatus::stable("0.0.62"),
+        default_level: Level::Warn,
+    }
+}
+
+declare_lint! {
+    /// ## What it does
+    /// Checks for a comparison of a `bool` against `True` or `False`.
+    ///
+    /// ## Why is this bad?
+    /// The operand is already the value the comparison produces, so the
+    /// comparison only adds noise. Testing the operand — or its negation —
+    /// says the same thing.
+    ///
+    /// An operand that is *not* a `bool` is left alone: `x == True` where
+    /// `x: bool | None` really does tell `True` apart from `False` and `None`,
+    /// and `x == True` where `x: int` is a value comparison. A chained comparison
+    /// (`a == True == b`) is left alone too: it is two comparisons over one
+    /// literal, and neither the operand nor its negation replaces the chain.
+    ///
+    /// ## Examples
+    /// ```python
+    /// def f(a: bool):
+    ///     if a == True:   # warning: redundant comparison
+    ///         ...
+    ///     if a is False:  # warning: redundant comparison
+    ///         ...
+    ///     if a:           # ok
+    ///         ...
+    ///
+    /// def g(a: bool | None):
+    ///     if a == True:  # ok — tells `True` apart from `False` and `None`
+    ///         ...
+    /// ```
+    pub(crate) static REDUNDANT_BOOLEAN_COMPARISON = {
+        summary: "detects a comparison of a `bool` against `True` or `False`",
+        status: LintStatus::stable("0.0.62"),
         default_level: Level::Warn,
     }
 }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -171,6 +171,7 @@ pub(crate) use binary_expressions::{
     fold_tuple_concat, fold_tuple_repeat, literal_binary_op, literal_unary_op,
 };
 mod class;
+mod conditions;
 mod dict;
 mod dynamic_class;
 mod enum_call;
@@ -2536,6 +2537,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             self.infer_match_pattern(pattern);
         } else if let Err(err) = test_ty.try_bool(self.db()) {
             err.report_diagnostic(&self.context, test);
+        } else {
+            self.check_condition(test);
         }
     }
 
@@ -3009,6 +3012,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                 if let Err(err) = guard_ty.try_bool(self.db()) {
                     err.report_diagnostic(&self.context, guard);
+                } else {
+                    self.check_condition(guard);
                 }
             }
 
@@ -5333,6 +5338,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         if let Err(err) = test_ty.try_bool(self.db()) {
             err.report_diagnostic(&self.context, &**test);
+        } else {
+            self.check_condition(test);
         }
 
         self.infer_body(body);
@@ -5351,6 +5358,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         if let Err(err) = test_ty.try_bool(self.db()) {
             err.report_diagnostic(&self.context, &**test);
+        } else {
+            self.check_condition(test);
         }
 
         self.infer_optional_expression(msg.as_deref(), TypeContext::default());
@@ -8913,7 +8922,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         });
 
         for expr in ifs {
-            self.infer_maybe_standalone_expression(expr, TypeContext::default());
+            let guard_ty = self.infer_maybe_standalone_expression(expr, TypeContext::default());
+            // Same shape as every other condition site: a guard whose type has no usable
+            // `__bool__` is skipped. Unlike the others this does not *report* that — ty has never
+            // reported `unsupported-bool-conversion` for a comprehension guard.
+            if guard_ty.try_bool(self.db()).is_ok() {
+                self.check_condition(expr);
+            }
         }
     }
 
@@ -9145,10 +9160,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 (body_ty, orelse_ty)
             };
 
-        match test_ty.try_bool(self.db()).unwrap_or_else(|err| {
-            err.report_diagnostic(&self.context, &**test);
-            err.fallback_truthiness()
-        }) {
+        let truthiness = match test_ty.try_bool(self.db()) {
+            Ok(truthiness) => {
+                self.check_condition(test);
+                truthiness
+            }
+            Err(err) => {
+                err.report_diagnostic(&self.context, &**test);
+                err.fallback_truthiness()
+            }
+        };
+
+        match truthiness {
             Truthiness::AlwaysTrue => body_ty,
             Truthiness::AlwaysFalse => orelse_ty,
             Truthiness::Ambiguous => UnionType::from_two_elements(self.db(), body_ty, orelse_ty),
@@ -13260,6 +13283,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         //
         // As some operators (==, !=, <, <=, >, >=) *can* return an arbitrary type, the logic below
         // is shared with the one in `infer_binary_type_comparison`.
+        //
+        // A chain like `a == True == b` is two comparisons over one literal: reporting each pair
+        // would double up on that `True`, and "test the operand" is not the fix for the chain.
+        let single_comparison = ops.len() == 1;
         self.infer_chained_boolean_types(
             ast::BoolOp::And,
             false,
@@ -13273,6 +13300,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let right_ty = builder.infer_expression(right, TypeContext::default());
 
                 let range = TextRange::new(left.start(), right.end());
+
+                if single_comparison {
+                    builder.check_redundant_boolean_comparison(
+                        left, right, left_ty, right_ty, *op, range,
+                    );
+                }
 
                 // a basedpython keyword-form `is`/`is not` whose rhs is a
                 // class (or a parametric test like `x is list[int]`) is an

--- a/crates/ty_python_semantic/src/types/infer/builder/conditions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/conditions.rs
@@ -1,0 +1,541 @@
+use std::collections::VecDeque;
+
+use ruff_python_ast::{self as ast, helpers::any_over_expr};
+use ruff_text_size::TextRange;
+use ty_module_resolver::KnownModule;
+use ty_python_core::{Truthiness, place::PlaceExpr};
+
+use crate::place::Place;
+use crate::types::{
+    ClassLiteral, IntersectionBuilder, KnownClass, Type,
+    diagnostic::{OVERLAPPING_CONDITION, REDUNDANT_BOOLEAN_COMPARISON, REDUNDANT_CONDITION},
+    infer::TypeInferenceBuilder,
+};
+use crate::{AnalysisSettings, Db};
+
+/// How a condition's outcome is decided.
+///
+/// This is [`Truthiness`] plus the state a type cannot express. `TYPE_CHECKING` and
+/// `sys.version_info` are constant for the same reason a `Literal[True]` parameter is: nothing
+/// distinguishes them at the type level. But their constant-ness is manufactured by the checker's
+/// model of the build environment rather than being a consequence of the program's own types, and
+/// picking a branch with one is the entire point of writing it. That is [`Artificial`], and it is
+/// the one constant outcome that is not worth reporting.
+///
+/// [`Artificial`]: ConditionTruthiness::Artificial
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConditionTruthiness {
+    /// the tested value decides the branch at runtime
+    Ambiguous,
+    /// the tested value's own type decides it
+    AlwaysTrue,
+    AlwaysFalse,
+    /// decided, but by the build environment rather than by the program
+    Artificial,
+}
+
+impl ConditionTruthiness {
+    /// Classify a condition. `artificial` is only consulted for an outcome that is already
+    /// constant, and is a closure because answering it walks the condition.
+    fn classify(
+        truthiness: Truthiness,
+        polarity: ConditionPolarity,
+        artificial: impl FnOnce() -> bool,
+    ) -> Self {
+        let selected = match truthiness {
+            Truthiness::Ambiguous => return Self::Ambiguous,
+            _ if artificial() => return Self::Artificial,
+            Truthiness::AlwaysTrue => ConditionPolarity::Truthy,
+            Truthiness::AlwaysFalse => ConditionPolarity::Falsy,
+        };
+        if selected == polarity {
+            Self::AlwaysTrue
+        } else {
+            Self::AlwaysFalse
+        }
+    }
+
+    /// The outcome of a condition that has one, and the word for the truthiness behind it.
+    const fn constant_outcome(self) -> Option<(&'static str, &'static str)> {
+        match self {
+            Self::AlwaysTrue => Some(("true", "truthy")),
+            Self::AlwaysFalse => Some(("false", "falsy")),
+            Self::Ambiguous | Self::Artificial => None,
+        }
+    }
+}
+
+/// Which half of the tested value a condition selects.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConditionPolarity {
+    Truthy,
+    Falsy,
+}
+
+impl ConditionPolarity {
+    #[must_use]
+    const fn negate(self) -> Self {
+        match self {
+            Self::Truthy => Self::Falsy,
+            Self::Falsy => Self::Truthy,
+        }
+    }
+
+    const fn noun(self) -> &'static str {
+        match self {
+            Self::Truthy => "truthiness",
+            Self::Falsy => "falsiness",
+        }
+    }
+
+    /// The half of an arm that this polarity rejects outright.
+    const fn rejects<'db>(self) -> Type<'db> {
+        match self {
+            Self::Truthy => Type::AlwaysFalsy,
+            Self::Falsy => Type::AlwaysTruthy,
+        }
+    }
+}
+
+/// Strip the `not`s off a condition, returning the expression whose truthiness is really tested
+/// and the half of it the condition selects.
+///
+/// A walrus is stripped too: `while (chunk := read()):` tests what `read()` returned, and reading
+/// the condition as the *target* would make a `while (x := False):` look like a constant place
+/// rather than the literal it is.
+fn condition_root(
+    test: &ast::Expr,
+    mut polarity: ConditionPolarity,
+) -> (&ast::Expr, ConditionPolarity) {
+    let mut root = test;
+    loop {
+        match root {
+            ast::Expr::UnaryOp(unary) if unary.op == ast::UnaryOp::Not => {
+                root = &unary.operand;
+                polarity = polarity.negate();
+            }
+            ast::Expr::Named(named) => root = &named.value,
+            _ => return (root, polarity),
+        }
+    }
+}
+
+impl<'db> TypeInferenceBuilder<'db, '_> {
+    /// Check a condition — the test of an `if`/`elif`/`while`/`assert`, a conditional expression
+    /// or a comprehension guard — for the two ways a truthiness test can go wrong: the branch it
+    /// selects is shared by members the branch cannot tell apart, or it selects nothing because
+    /// the outcome is already fixed.
+    ///
+    /// A boolean operator is not one condition but one per operand: each operand's truthiness is
+    /// tested on its own at runtime, and the operator's *value* — the union of the operands — is
+    /// not a value anything is tested for. `if count > 0 or leftovers:` asks two questions, and
+    /// reading it as one would claim it conflates a `bool` with a `dict`.
+    pub(super) fn check_condition(&mut self, test: &ast::Expr) {
+        if !self.context.is_lint_enabled(&OVERLAPPING_CONDITION)
+            && !self.context.is_lint_enabled(&REDUNDANT_CONDITION)
+        {
+            return;
+        }
+        // An explicit queue rather than recursion: a same-operator chain flattens into one
+        // `BoolOp`, but `a and (b or (…))` nests, and unbounded recursion in this crate spends a
+        // stack budget that windows measures in one megabyte.
+        let mut queue = VecDeque::from([(test, ConditionPolarity::Truthy)]);
+        while let Some((test, polarity)) = queue.pop_front() {
+            let (root, polarity) = condition_root(test, polarity);
+            if let ast::Expr::BoolOp(bool_op) = root {
+                // front, so operands are checked in source order
+                for operand in bool_op.values.iter().rev() {
+                    queue.push_front((operand, polarity));
+                }
+                continue;
+            }
+            self.check_single_condition(test, root, polarity);
+        }
+    }
+
+    fn check_single_condition(
+        &mut self,
+        test: &ast::Expr,
+        root: &ast::Expr,
+        polarity: ConditionPolarity,
+    ) {
+        // Only a value *read* can have its outcome fixed by its own type. A comparison or a call
+        // computes a fresh value, and ty folding that one is the statically-known-branch
+        // machinery doing its job — `elif isinstance(x, B):` closing an exhaustive chain is
+        // deliberate, not a conditional that failed to be conditional.
+        let is_place = PlaceExpr::try_from_expr(root).is_some();
+        let truthiness = ConditionTruthiness::classify(
+            self.expression_type(root).bool(self.db()),
+            polarity,
+            || is_place && self.is_artificial(root),
+        );
+        match truthiness {
+            ConditionTruthiness::Ambiguous => {
+                self.check_overlapping_condition(test, root, polarity);
+            }
+            ConditionTruthiness::AlwaysTrue | ConditionTruthiness::AlwaysFalse if is_place => {
+                self.report_redundant_condition(test, root, truthiness);
+            }
+            // a constant that is not a value read, or one the build environment manufactured
+            ConditionTruthiness::AlwaysTrue
+            | ConditionTruthiness::AlwaysFalse
+            | ConditionTruthiness::Artificial => {}
+        }
+    }
+
+    fn report_redundant_condition(
+        &mut self,
+        test: &ast::Expr,
+        root: &ast::Expr,
+        truthiness: ConditionTruthiness,
+    ) {
+        let Some((outcome, adjective)) = truthiness.constant_outcome() else {
+            return;
+        };
+        let Some(builder) = self.context.report_lint(&REDUNDANT_CONDITION, test) else {
+            return;
+        };
+        let mut diagnostic =
+            builder.into_diagnostic(format_args!("This condition is always {outcome}"));
+        diagnostic.info(format_args!(
+            "`{}` is always {adjective}",
+            self.expression_type(root).display(self.db())
+        ));
+    }
+
+    /// Whether any part of `test` is a build-environment fact, which makes the whole condition's
+    /// constant outcome the checker's doing rather than the program's.
+    fn is_artificial(&self, test: &ast::Expr) -> bool {
+        any_over_expr(test, &|expr: &ast::Expr| self.is_environment_fact(expr))
+    }
+
+    /// Whether `expr` reads a fact about the environment ty is checking *for*, as opposed to a
+    /// value the program computes.
+    ///
+    /// `sys.version_info` has a type of its own, so it is recognised wherever it is bound.
+    /// `sys.platform` and `os.name` are ordinary string literals by the time they have a type, so
+    /// they are recognised by the module they are read off — a `from sys import platform` binding
+    /// is indistinguishable from any other string and is missed. `TYPE_CHECKING` is recognised by
+    /// its name, which is also all ty itself goes on when it gives the binding `Literal[True]`, so
+    /// an import that renames it is missed as well.
+    fn is_environment_fact(&self, expr: &ast::Expr) -> bool {
+        let db = self.db();
+        let is_version_info = |expr: &ast::Expr| {
+            matches!(
+                self.try_expression_type(expr),
+                Some(Type::NominalInstance(instance)) if instance.is_sys_version_info()
+            )
+        };
+        match expr {
+            ast::Expr::Name(name) => name.id == "TYPE_CHECKING" || is_version_info(expr),
+            ast::Expr::Attribute(attribute) => {
+                if is_version_info(expr) {
+                    return true;
+                }
+                let Some(Type::ModuleLiteral(module)) = self.try_expression_type(&attribute.value)
+                else {
+                    return false;
+                };
+                let module = module.module(db);
+                match &*attribute.attr {
+                    "version_info" | "platform" => module.is_known(db, KnownModule::Sys),
+                    "name" => module.is_known(db, KnownModule::Os),
+                    "TYPE_CHECKING" => {
+                        module.is_known(db, KnownModule::Typing)
+                            || module.is_known(db, KnownModule::TypingExtensions)
+                    }
+                    _ => false,
+                }
+            }
+            _ => false,
+        }
+    }
+
+    fn check_overlapping_condition(
+        &mut self,
+        test: &ast::Expr,
+        root: &ast::Expr,
+        polarity: ConditionPolarity,
+    ) {
+        if !self.context.is_lint_enabled(&OVERLAPPING_CONDITION) {
+            return;
+        }
+        let db = self.db();
+        let Some(tested) = self.try_expression_type(root) else {
+            return;
+        };
+        let selected = selected_branch(db, tested, polarity, db.analysis_settings(self.file()));
+        if !selected.conflates() {
+            return;
+        }
+
+        let Some(builder) = self.context.report_lint(&OVERLAPPING_CONDITION, test) else {
+            return;
+        };
+        let [leading @ .., last] = &*selected.kinds else {
+            return;
+        };
+        let leading = leading
+            .iter()
+            .map(|kind| format!("`{}`", kind.part.display(db)))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let mut diagnostic = builder.into_diagnostic(format_args!(
+            "This condition does not distinguish between {leading} and `{}`",
+            last.part.display(db)
+        ));
+        diagnostic.info(format_args!(
+            "`{}` is tested for {}",
+            tested.display(db),
+            polarity.noun()
+        ));
+        diagnostic.help("Compare against the specific value instead of testing truthiness");
+    }
+
+    /// Check a comparison against a `True`/`False` literal whose other operand is already a
+    /// `bool`, which says exactly what the operand says.
+    pub(super) fn check_redundant_boolean_comparison(
+        &self,
+        left: &ast::Expr,
+        right: &ast::Expr,
+        left_ty: Type<'db>,
+        right_ty: Type<'db>,
+        op: ast::CmpOp,
+        range: TextRange,
+    ) {
+        if !self.context.is_lint_enabled(&REDUNDANT_BOOLEAN_COMPARISON) {
+            return;
+        }
+        let is_equality = match op {
+            ast::CmpOp::Eq | ast::CmpOp::Is => true,
+            ast::CmpOp::NotEq | ast::CmpOp::IsNot => false,
+            _ => return,
+        };
+        let as_bool_literal = |expr: &ast::Expr| match expr {
+            ast::Expr::BooleanLiteral(literal) => Some(literal.value),
+            _ => None,
+        };
+        // `True == False` compares two constants, which is a deliberate constant, not a
+        // redundant comparison
+        let (operand_ty, literal) = match (as_bool_literal(left), as_bool_literal(right)) {
+            (None, Some(literal)) => (left_ty, literal),
+            (Some(literal), None) => (right_ty, literal),
+            _ => return,
+        };
+        let db = self.db();
+        if !operand_ty.is_subtype_of(db, KnownClass::Bool.to_instance(db)) {
+            return;
+        }
+
+        let Some(builder) = self
+            .context
+            .report_lint(&REDUNDANT_BOOLEAN_COMPARISON, range)
+        else {
+            return;
+        };
+        let mut diagnostic = builder.into_diagnostic(format_args!(
+            "Comparison of a `bool` with `{}` is redundant",
+            if literal { "True" } else { "False" }
+        ));
+        diagnostic.info(format_args!(
+            "`{}` already is the value this comparison produces",
+            operand_ty.display(db)
+        ));
+        if is_equality == literal {
+            diagnostic.help("Test the operand directly");
+        } else {
+            diagnostic.help("Negate the operand with `not` instead");
+        }
+    }
+}
+
+/// One kind of value that reaches the selected branch.
+struct SelectedKind<'db> {
+    /// the class its values are instances of; two arms of the same kind are one entry
+    class: ClassLiteral<'db>,
+    /// the part of the arm that reaches the branch, as it should be spelled in the diagnostic
+    part: Type<'db>,
+}
+
+/// What the branch a condition selects can contain.
+struct SelectedBranch<'db> {
+    kinds: Vec<SelectedKind<'db>>,
+    /// some arm reaches the branch in its entirety
+    has_whole: bool,
+    /// some arm reaches it only in part — the rest of that arm goes the other way
+    has_partial: bool,
+}
+
+impl SelectedBranch<'_> {
+    /// Whether the branch conflates values a reader would expect it to tell apart.
+    ///
+    /// The bug is a value that is *unconditionally* in this branch sharing it with one that is
+    /// only conditionally here: a sentinel meeting the falsy corner of a value that normally
+    /// belongs to the other branch, as `None` meets `""` in `if not name:`. Two arms that are
+    /// each only partly here — `if x:` over a `str | bytes` — conflate nothing that the union
+    /// did not already conflate, and neither does a branch that holds whole arms only.
+    fn conflates(&self) -> bool {
+        self.kinds.len() >= 2 && self.has_whole && self.has_partial
+    }
+}
+
+/// Work out what the branch `polarity` selects out of `tested` can contain.
+///
+/// Arms of the same class — or of two classes one of which derives the other — are one kind:
+/// truthiness was never going to tell a `1` from a `2`, or a `list[A]` from a `list[B]`, and
+/// nobody expected it to.
+fn selected_branch<'db>(
+    db: &'db dyn Db,
+    tested: Type<'db>,
+    polarity: ConditionPolarity,
+    settings: &AnalysisSettings,
+) -> SelectedBranch<'db> {
+    let mut selected = SelectedBranch {
+        kinds: Vec::new(),
+        has_whole: false,
+        has_partial: false,
+    };
+    for_each_arm(db, tested, &mut |arm| {
+        let Some(class) = arm_class(db, arm) else {
+            return;
+        };
+        if is_exempt(db, arm, class, &settings.overlapping_condition_exempt_types) {
+            return;
+        }
+        let truthiness = arm_truthiness(db, arm, settings);
+        let whole = !truthiness.is_ambiguous();
+        let part = match truthiness {
+            Truthiness::AlwaysTrue if polarity == ConditionPolarity::Falsy => return,
+            Truthiness::AlwaysFalse if polarity == ConditionPolarity::Truthy => return,
+            Truthiness::Ambiguous => IntersectionBuilder::new(db)
+                .add_positive(arm)
+                .add_negative(polarity.rejects())
+                .build(),
+            _ => arm,
+        };
+        if part.is_never() {
+            return;
+        }
+        if whole {
+            selected.has_whole = true;
+        } else {
+            selected.has_partial = true;
+        }
+        match selected
+            .kinds
+            .iter_mut()
+            .find(|kind| same_kind(db, kind.class, class))
+        {
+            // keep the most general class of the group, so which arm the message names does not
+            // depend on the order the arms happen to be in
+            Some(kind) if derives(db, kind.class, class) => {
+                kind.class = class;
+                kind.part = part;
+            }
+            Some(_) => {}
+            None => selected.kinds.push(SelectedKind { class, part }),
+        }
+    });
+    selected
+}
+
+/// Visit the union arms of `tested`, or `tested` itself when it has only the one.
+///
+/// An enum complement and an intersection with a finite alternative are unions in all but name.
+fn for_each_arm<'db>(db: &'db dyn Db, tested: Type<'db>, visit: &mut impl FnMut(Type<'db>)) {
+    if let Some(union) = tested.as_union_like(db) {
+        for arm in union.elements(db) {
+            visit(*arm);
+        }
+        return;
+    }
+    let alternatives = match tested {
+        Type::EnumComplement(complement) => Some(complement.remaining_literal_union(db)),
+        Type::Intersection(intersection) => intersection.finite_alternative_union(db),
+        _ => None,
+    };
+    match alternatives {
+        // the equality guard keeps a type that describes itself from recursing forever
+        Some(alternatives) if alternatives != tested => for_each_arm(db, alternatives, visit),
+        _ => visit(tested),
+    }
+}
+
+fn arm_truthiness<'db>(db: &'db dyn Db, arm: Type<'db>, settings: &AnalysisSettings) -> Truthiness {
+    let truthiness = arm.bool(db);
+    if truthiness.is_ambiguous()
+        && settings.overlapping_condition_assume_truthy_instances
+        && defines_no_truthiness(db, arm)
+    {
+        return Truthiness::AlwaysTrue;
+    }
+    truthiness
+}
+
+/// Whether `ty` is an instance that says nothing about its own truthiness.
+///
+/// Such an instance is truthy unless a subclass says otherwise, which is why ty calls it
+/// ambiguous; `overlapping-condition-assume-truthy-instances` takes it at face value instead.
+fn defines_no_truthiness<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
+    matches!(ty, Type::NominalInstance(_) | Type::ProtocolInstance(_))
+        && ["__bool__", "__len__"]
+            .iter()
+            .all(|dunder| matches!(ty.member(db, dunder).place, Place::Undefined))
+}
+
+/// The class whose instances a union arm holds, if it has one.
+///
+/// Two kinds of arm have none, and both are deliberately left out of the count. A gradual type
+/// stands in for anything at all, so it is not a value the branch could have meant. And an
+/// intersection is a remnant of some earlier narrowing whose truthiness ty models only
+/// approximately: `str & ~AlwaysFalsy` cannot be falsy, but ty still calls it ambiguous, so
+/// counting it would report a falsy branch that only ever holds `None`.
+fn arm_class<'db>(db: &'db dyn Db, arm: Type<'db>) -> Option<ClassLiteral<'db>> {
+    if arm.is_intersection() {
+        return None;
+    }
+    match arm.to_meta_type(db) {
+        Type::ClassLiteral(class) => Some(class),
+        Type::GenericAlias(alias) => Some(ClassLiteral::Static(alias.origin(db))),
+        Type::SubclassOf(subclass_of) => subclass_of
+            .subclass_of()
+            .into_class(db)
+            .map(|class| class.class_literal(db)),
+        _ => None,
+    }
+}
+
+/// Whether two arms hold the same kind of value, so that a condition was never going to tell them
+/// apart in the first place.
+///
+/// Type arguments are deliberately out of scope: `list[A]` and `list[B]` are both lists, and a
+/// truthiness test sees only that one of them is empty.
+fn same_kind<'db>(db: &'db dyn Db, left: ClassLiteral<'db>, right: ClassLiteral<'db>) -> bool {
+    left == right || derives(db, left, right) || derives(db, right, left)
+}
+
+/// Whether `subclass` derives `base`, ignoring type arguments.
+fn derives<'db>(db: &'db dyn Db, subclass: ClassLiteral<'db>, base: ClassLiteral<'db>) -> bool {
+    subclass != base
+        && subclass
+            .default_specialization(db)
+            .is_subclass_of(db, base.default_specialization(db))
+}
+
+/// Whether the user has told us not to count this arm as distinct.
+fn is_exempt<'db>(
+    db: &'db dyn Db,
+    arm: Type<'db>,
+    class: ClassLiteral<'db>,
+    exempt: &[Box<str>],
+) -> bool {
+    if exempt.is_empty() {
+        return false;
+    }
+    let matches = |name: &str| exempt.iter().any(|entry| &**entry == name);
+    if arm.is_none(db) && matches("None") {
+        return true;
+    }
+    let qualified = class.qualified_name(db).to_string();
+    matches(&qualified) || qualified.strip_prefix("builtins.").is_some_and(matches)
+}

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -434,7 +434,9 @@ fn unbound_symbol_no_reachability_constraint_check() {
     .unwrap();
 
     db.clear_salsa_events();
-    assert_file_diagnostics(&db, "src/a.py", &[]);
+    // `flag` narrows to `Literal[True]` at the `if`, so the condition is redundant; that is
+    // beside the point here, but it is what the file has to say
+    assert_file_diagnostics(&db, "src/a.py", &["This condition is always true"]);
     let events = db.take_salsa_events();
     let cycles = salsa::attach(&db, || {
         events

--- a/crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
@@ -186,6 +186,8 @@ Settings: Settings {
         disable_fluid_specializations: false,
         sound_types: false,
         bivariant_private_attributes: true,
+        overlapping_condition_exempt_types: [],
+        overlapping_condition_assume_truthy_instances: false,
     },
     overrides: [],
 }

--- a/crates/ty_test/src/config.rs
+++ b/crates/ty_test/src/config.rs
@@ -164,6 +164,10 @@ pub(crate) struct Analysis {
     pub(crate) sound_types: Option<bool>,
 
     pub(crate) bivariant_private_attributes: Option<bool>,
+
+    pub(crate) overlapping_condition_exempt_types: Option<Vec<String>>,
+
+    pub(crate) overlapping_condition_assume_truthy_instances: Option<bool>,
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/crates/ty_test/src/db.rs
+++ b/crates/ty_test/src/db.rs
@@ -259,6 +259,9 @@ fn mdtest_analysis_settings(options: Option<&Analysis>) -> AnalysisSettings {
         disable_fluid_specializations: disable_fluid_specializations_default,
         sound_types: sound_types_default,
         bivariant_private_attributes: bivariant_private_attributes_default,
+        overlapping_condition_exempt_types: overlapping_condition_exempt_types_default,
+        overlapping_condition_assume_truthy_instances:
+            overlapping_condition_assume_truthy_instances_default,
     } = AnalysisSettings::default();
 
     let allowed_unresolved_imports =
@@ -303,6 +306,14 @@ fn mdtest_analysis_settings(options: Option<&Analysis>) -> AnalysisSettings {
         bivariant_private_attributes: options
             .bivariant_private_attributes
             .unwrap_or(bivariant_private_attributes_default),
+        overlapping_condition_exempt_types: options
+            .overlapping_condition_exempt_types
+            .as_deref()
+            .map(|types| types.iter().map(|name| Box::from(&**name)).collect())
+            .unwrap_or(overlapping_condition_exempt_types_default),
+        overlapping_condition_assume_truthy_instances: options
+            .overlapping_condition_assume_truthy_instances
+            .unwrap_or(overlapping_condition_assume_truthy_instances_default),
     }
 }
 

--- a/docs/basedpython/features/conditions.md
+++ b/docs/basedpython/features/conditions.md
@@ -1,0 +1,151 @@
+# boolean conditions
+
+a condition collapses a value to a single bit. that is fine when the bit answers the question the
+code is asking, and a bug when it does not. three checks watch the ways it goes wrong
+
+## overlapping conditions
+
+`overlapping-condition` fires when the branch a condition *selects* holds a value that is always
+there alongside one that is only sometimes there. inside that branch the two are
+indistinguishable, so whatever the condition was meant to ask, the answer it got back conflates
+them
+
+```python
+def f(a: bool | None):
+    if a:      # ok — only `True` is truthy
+        ...
+    if not a:  # warning: does not distinguish between `False` and `None`
+        ...
+```
+
+only the selected branch is analysed. `if a` looks at the truthy members, `if not a` at the falsy
+ones — and a chain of `not`s flips the polarity each time, so `not not a` is a truthy test again
+
+a boolean operator is not one condition but one per operand: each operand's truthiness is tested on
+its own at runtime, and the operator's *value* — the union of the operands — is not a value anything
+is tested for. `if count > 0 or leftovers:` asks two questions, each with one answer
+
+```by
+def f(a: bool?, name: str?):
+    if not a or not name:  # two warnings, one per operand
+        ...
+```
+
+the classic instance is an optional string, where the empty string and the absent value share a
+branch
+
+```python
+def f(name: str | None):
+    if not name:      # warning: `""` and `None` are both falsy
+        ...
+    if name is None:  # ok — the members are told apart
+        ...
+```
+
+a class settles its own case with `__bool__`. an instance that always answers `True` is never a
+falsy member, so both directions of the test are clean
+
+```by
+class A:
+    def __bool__(self) -> True:
+        return True
+
+def f(a: A | None):
+    if a:      # ok — `A`
+        ...
+    if not a:  # ok — `None`
+        ...
+```
+
+without `__bool__` (or `__len__`), a subclass could still be falsy, so `A` joins `None` in the falsy
+branch and `if not a` is reported. the `analysis.overlapping-condition-assume-truthy-instances`
+option takes such a class at face value instead
+
+```toml
+[analysis]
+overlapping-condition-assume-truthy-instances = true
+```
+
+two members that are *each* only partly in the branch are not reported. `if x:` over a `str | bytes`
+puts a non-empty `str` next to a non-empty `bytes`, and neither of them was ever going to be
+somewhere else — the union already conflated them and the condition added nothing. what the check is
+looking for is the asymmetry: one member unconditionally here, another only in the corner of itself
+that answers this way
+
+```by
+def f(a: str | bytes, b: str?):
+    if a: ...      # ok — both members are only partly here
+    if not b: ...  # warning: `None` is always here, `""` only sometimes
+```
+
+members of one class — or of two classes where one derives the other — are one kind of value, and a
+condition was never going to tell them apart either. `Literal[1] | Literal[2]` is not an overlap,
+and neither is `list[A] | list[B]`: type arguments are not something truthiness can see.
+`analysis.overlapping-condition-exempt-types` extends that to classes of your choosing, so a project
+that does not mind conflating a falsy `int` with anything else can say so
+
+```toml
+[analysis]
+overlapping-condition-exempt-types = ["int"]
+```
+
+entries are qualified class names (`decimal.Decimal`); a class in `builtins` may also be spelled
+bare, and `None` stands for the type of `None`. an entry that is not spelled like a class name is a
+configuration error; one that is well-formed but resolves to nothing simply never matches
+
+## redundant conditions
+
+`redundant-condition` fires when the tested value's own type fixes the outcome, so one of the two
+branches is dead
+
+```by
+def f(a: True):
+    if a:  # warning: always true
+        ...
+```
+
+the check applies to a value *read* — a name, an attribute, a subscript. a comparison or a call
+computes a fresh value, and ty folding *that* one is the statically-known-branch machinery doing its
+job: `elif isinstance(x, B):` closing an exhaustive chain is deliberate, and so is `while True`
+
+## artificial truthiness
+
+some constants are constant only because of how ty models the build it is checking for.
+`TYPE_CHECKING`, `sys.version_info`, `sys.platform` and `os.name` all carry a fixed value that the
+program itself never computes, and selecting a branch with one is the entire point of writing it.
+their truthiness is *artificial*, and a redundant-condition report on it would be wrong
+
+```py
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:                    # ok
+    from collections.abc import Sequence
+
+if sys.version_info >= (3, 12):      # ok
+    ...
+```
+
+`sys.version_info` has a type of its own and is recognised wherever it is bound. the others are
+ordinary literals by the time they have a type, so they are recognised by the module they are read
+off (`sys.platform`) or by their name (`TYPE_CHECKING`) — an import that renames them is missed
+
+## redundant boolean comparisons
+
+`redundant-boolean-comparison` fires on a comparison of a `bool` against `True` or `False`. the
+operand already is the value the comparison produces
+
+```python
+def f(a: bool):
+    if a == True:   # warning: redundant
+        ...
+    if a is False:  # warning: redundant — write `not a`
+        ...
+    if a:           # ok
+        ...
+```
+
+an operand that is not a `bool` is left alone. `x == True` really does tell `True` apart from
+`False` and `None` when `x` is a `bool?`, and it is a value comparison when `x` is an `int`. a
+chained comparison (`a == True == b`) is left alone too — it is two comparisons over one literal,
+and neither the operand nor its negation replaces the chain

--- a/docs/basedpython/features/index.md
+++ b/docs/basedpython/features/index.md
@@ -18,6 +18,7 @@ type-checking improvements with no new syntax — they work in `.by` and `.py` f
 - [fluid specializations](fluid-specializations.md)
 - [sound types](sound-types.md) — infer precise types instead of gradual ones
 - [regex group types](regex-groups.md) — type a match from the pattern it came from
+- [boolean conditions](conditions.md) — catch a test that conflates two members, or asks nothing
 
 ## type system
 

--- a/scripts/check_ecosystem.py
+++ b/scripts/check_ecosystem.py
@@ -213,7 +213,7 @@ async def check(
     lines = [
         line
         for line in result.decode("utf8").splitlines()
-        if not SUMMARY_LINE_RE.match(line)
+        if SUMMARY_LINE_RE.match(line) is None
     ]
 
     return sorted(lines)

--- a/scripts/generate_mkdocs.py
+++ b/scripts/generate_mkdocs.py
@@ -120,8 +120,10 @@ def generate_rule_metadata(rule_doc: Path) -> None:
         lines = f.readlines()
 
     # Get the description and rule code from the rule doc lines.
-    rule_code = None
-    description = None
+    # Empty rather than `None`: both spellings mean "not found yet", and a single `str` keeps the
+    # truthiness tests below asking one question instead of two.
+    rule_code = ""
+    description = ""
     what_it_does_found = False
     for line in lines:
         if line == "\n":

--- a/scripts/setup_primer_project.py
+++ b/scripts/setup_primer_project.py
@@ -94,7 +94,9 @@ def main() -> None:
     args = parser.parse_args()
 
     project = find_project(args.project)
-    revision = args.revision or project.revision
+    # Normalized to a plain `str`: mypy_primer treats an empty revision as absent too, and a
+    # single type keeps the truthiness tests below asking one question instead of two.
+    revision = args.revision or project.revision or ""
 
     target_dir = Path(args.directory or project.name).resolve()
 

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -96,6 +96,23 @@
             "null"
           ]
         },
+        "overlapping-condition-assume-truthy-instances": {
+          "description": "Whether an instance with no `__bool__` and no `__len__` counts as always truthy when\nlooking for an [`overlapping-condition`](rules.md#overlapping-condition).\n\nSuch an instance is only *ambiguously* truthy — a subclass may define `__bool__` — so by\ndefault it is a falsy member of `if not x` just as `None` is. Enabling this assumes the\nclass means what it looks like it means, which drops the reports for the very common\n`if not x` over an optional instance.\n\nDefaults to `false`.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "overlapping-condition-exempt-types": {
+          "description": "A list of classes whose values do not count as a distinct member of an\n[`overlapping-condition`](rules.md#overlapping-condition).\n\n`if not x` over an `int | None` selects both a falsy `int` and `None`, and is reported\nbecause the branch cannot tell them apart. Listing `int` here says that conflating a falsy\n`int` with anything else is fine, so only `None` is left and the condition is accepted.\n\nEntries are qualified class names (`decimal.Decimal`). A class in `builtins` may also be\nspelled bare (`int`), and `None` stands for the type of `None`.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/string"
+          }
+        },
         "replace-imports-with-any": {
           "description": "A list of module glob patterns whose imports should be replaced with `typing.Any`.\n\nUnlike `allowed-unresolved-imports`, this setting replaces the module's type information\nwith `typing.Any` even if the module can be resolved. Import diagnostics are\nunconditionally suppressed for matching modules.\n\n- Prefix a pattern with `!` to exclude matching modules\n\nWhen multiple patterns match, later entries take precedence.\n\nGlob patterns can be used in combinations with each other. For example, to suppress errors for\nany module where the first component contains the substring `test`, use `*test*.**`.\n\nWhen multiple patterns match, later entries take precedence.",
           "type": [
@@ -1468,6 +1485,16 @@
             }
           ]
         },
+        "overlapping-condition": {
+          "title": "detects a condition that several members of the tested type answer the same way",
+          "description": "## What it does\nChecks for a truthiness test whose selected branch holds a value that is\nalways there alongside one that is only sometimes there.\n\n## Why is this bad?\nA condition collapses a value to a single bit, so two members that answer\nthe test the same way become indistinguishable inside the branch. The case\nthat bites is a sentinel meeting the falsy corner of a value that normally\nbelongs to the other branch — `None` meeting `\"\"` in `if not name:`.\n\nOnly the branch the condition *selects* is analyzed: `if a` looks at the\ntruthy members, `if not a` at the falsy ones. A boolean operator is one\ncondition per operand rather than one over its value, since each operand's\ntruthiness is tested on its own.\n\nTwo members that are *each* only partly in the branch are not reported:\n`if x:` over a `str | bytes` conflates nothing the union did not already\nconflate. Neither are members of one class, or of two classes where one\nderives the other, which a condition was never going to tell apart:\n`Literal[1] | Literal[2]` and `list[A] | list[B]` are each one kind of\nvalue.\n\n## Examples\n```python\ndef f(a: bool | None):\n    if a:      # ok — only `True` is truthy\n        ...\n    if not a:  # warning: `False` and `None` are both falsy\n        ...\n\ndef g(name: str | None):\n    if not name:  # warning: `\"\"` and `None` are both falsy\n        ...\n    if name is None:  # ok — the members are told apart\n        ...\n```\n\n## Options\n- `analysis.overlapping-condition-exempt-types`\n- `analysis.overlapping-condition-assume-truthy-instances`",
+          "default": "warn",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Level"
+            }
+          ]
+        },
         "override-of-final-method": {
           "title": "detects overrides of final methods",
           "description": "## What it does\n\nChecks for methods on subclasses that override superclass methods decorated with `@final`.\n\n## Why is this bad?\n\nDecorating a method with `@final` declares to the type checker that it should not be\noverridden on any subclass.\n\n## Example\n\n```python\nfrom typing import final\n\n\nclass A:\n    @final\n    def foo(self): ...\n\n\nclass B(A):\n    def foo(self): ...  # error\n```",
@@ -1598,9 +1625,29 @@
             }
           ]
         },
+        "redundant-boolean-comparison": {
+          "title": "detects a comparison of a `bool` against `True` or `False`",
+          "description": "## What it does\nChecks for a comparison of a `bool` against `True` or `False`.\n\n## Why is this bad?\nThe operand is already the value the comparison produces, so the\ncomparison only adds noise. Testing the operand — or its negation —\nsays the same thing.\n\nAn operand that is *not* a `bool` is left alone: `x == True` where\n`x: bool | None` really does tell `True` apart from `False` and `None`,\nand `x == True` where `x: int` is a value comparison. A chained comparison\n(`a == True == b`) is left alone too: it is two comparisons over one\nliteral, and neither the operand nor its negation replaces the chain.\n\n## Examples\n```python\ndef f(a: bool):\n    if a == True:   # warning: redundant comparison\n        ...\n    if a is False:  # warning: redundant comparison\n        ...\n    if a:           # ok\n        ...\n\ndef g(a: bool | None):\n    if a == True:  # ok — tells `True` apart from `False` and `None`\n        ...\n```",
+          "default": "warn",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Level"
+            }
+          ]
+        },
         "redundant-cast": {
           "title": "detects redundant `cast` calls",
           "description": "## What it does\n\nDetects redundant `cast` calls where the value already has the target type.\n\n## Why is this bad?\n\nThese casts have no effect and can be removed.\n\n## Example\n\n```python\nfrom typing import cast\n\n\ndef f() -> int:\n    return 10\n\n\n# Redundant\ncast(int, f())  # error\n```",
+          "default": "warn",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Level"
+            }
+          ]
+        },
+        "redundant-condition": {
+          "title": "detects a condition whose outcome is fixed by the tested type",
+          "description": "## What it does\nChecks for a condition whose outcome is fixed by the tested type, so the\nbranch is not conditional at all.\n\n## Why is this bad?\nOne of the two branches is dead. Either the annotation is wider than the\nauthor believed, or the test is left over from an earlier version of the\ncode.\n\nOnly a value *read* is reported — a name, an attribute, a subscript. A\ncomparison or a call computes a fresh value, and ty folding that one is the\nstatically-known-branch machinery doing its job: `elif isinstance(x, B):`\nclosing an exhaustive chain is deliberate, and so is `while True:`, which\nis a literal rather than a read.\n\nA read whose constant outcome comes from the checker's model of the build\nenvironment (`TYPE_CHECKING`, `sys.version_info`, `sys.platform`, `os.name`)\nrather than from the program's own types is not reported either — those are\n*artificially* constant, and selecting a branch at check time is exactly\nwhat they are for.\n\n## Examples\n```python\nimport sys\nfrom typing import TYPE_CHECKING, Literal\n\ndef f(a: Literal[True], x: int):\n    if a:  # warning: always true\n        ...\n    if x is not None:  # ok — a comparison, not a value read\n        ...\n\nwhile True:  # ok — a literal, not a value read\n    ...\n\nif TYPE_CHECKING:  # ok — artificially constant\n    ...\nif sys.version_info >= (3, 12):  # ok — artificially constant\n    ...\n```",
           "default": "warn",
           "oneOf": [
             {

--- a/zensical.toml
+++ b/zensical.toml
@@ -33,6 +33,7 @@ features = [
   { "fluid specializations" = "features/fluid-specializations.md" },
   { "sound types" = "features/sound-types.md" },
   { "regex group types" = "features/regex-groups.md" },
+  { "boolean conditions" = "features/conditions.md" },
   { "tuple type literals" = "features/tuple-types.md" },
   { "callable arrow syntax" = "features/callable.md" },
   { "implicit receivers" = "features/implicit-receivers.md" },


### PR DESCRIPTION
three ty lints on truthiness tests:

- `overlapping-condition` — the branch a condition selects is reached by more than one kind of member, so it cannot tell them apart. only the selected branch is analysed (`if a` truthy, `if not a` falsy), and members of one class (or two where one derives the other) count as one kind
- `redundant-condition` — the tested value's own type fixes the outcome. restricted to a value read: ty folding a comparison or call is the statically-known-branch machinery doing its job
- `redundant-boolean-comparison` — `a == True` where `a` is a `bool`

`ConditionTruthiness` adds a fourth state to `Truthiness`: artificial, for a constant the checker's model of the build produced rather than the program's types — `TYPE_CHECKING`, `sys.version_info`, `sys.platform`, `os.name`. a redundant-condition report on one of those would be wrong

two options tune the overlap check:
`analysis.overlapping-condition-exempt-types` drops members of the named classes, and `analysis.overlapping-condition-assume-truthy-instances` takes a class with no `__bool__`/`__len__` at face value
