### PR TITLE
check function bodies against symbolic arithmetic return types

### DIFF
--- a/crates/by_transforms/src/type_info.rs
+++ b/crates/by_transforms/src/type_info.rs
@@ -6,9 +6,9 @@ use ruff_text_size::TextRange;
 use ty_python_core::scope::ScopeKind;
 use ty_python_core::{global_scope, place_table, semantic_index};
 use ty_python_semantic::types::{
-    DynamicType, KnownClass, KnownInstanceType, Type, UnpackedKwargs, character,
+    DisplaySettings, DynamicType, KnownClass, KnownInstanceType, Type, UnpackedKwargs, character,
 };
-use ty_python_semantic::{HasType, ImplicitReceiverReference, SemanticModel};
+use ty_python_semantic::{Db, HasType, ImplicitReceiverReference, SemanticModel};
 
 /// How the postfix `^` / `!` operators test the "absent" arm of an operand's
 /// wrapped type. `T?` lowers to `T | None`, so its absent arm is `None`; a
@@ -702,7 +702,7 @@ impl TypeInfo for SemanticModel<'_> {
     fn promoted_type_display(&self, expr: &Expr) -> Option<String> {
         let ty = expr.inferred_type(self)?;
         let promoted = ty.promote(self.db());
-        let rendered = promoted.display(self.db()).to_string();
+        let rendered = display_for_python(self.db(), promoted);
         // ty's default display tags type variables with their binding scope
         // for disambiguation (e.g. `T@render`); that suffix is not valid in
         // emitted Python source. strip it before returning so the rendered
@@ -721,9 +721,10 @@ impl TypeInfo for SemanticModel<'_> {
         }
         // display with the standard (non-basedpython) renderer so literals come
         // out as `Literal[..]` rather than bare — the transpiler emits python
-        Some(strip_binding_context_suffix(
-            &ty.display(self.db()).to_string(),
-        ))
+        Some(strip_binding_context_suffix(&display_for_python(
+            self.db(),
+            ty,
+        )))
     }
 
     fn class_typevars(&self, expr: &Expr) -> Option<Vec<(String, Option<String>)>> {
@@ -736,7 +737,7 @@ impl TypeInfo for SemanticModel<'_> {
                     let name = tv.name(self.db()).to_string();
                     let default = tv
                         .default_type(self.db())
-                        .map(|d| d.display(self.db()).to_string());
+                        .map(|d| display_for_python(self.db(), d));
                     (name, default)
                 })
                 .collect(),
@@ -760,7 +761,7 @@ impl TypeInfo for SemanticModel<'_> {
                     .map(|(name, ty)| {
                         (
                             name.to_string(),
-                            strip_binding_context_suffix(&ty.display(db).to_string()),
+                            strip_binding_context_suffix(&display_for_python(db, ty)),
                         )
                     })
                     .collect(),
@@ -954,9 +955,10 @@ impl TypeInfo for SemanticModel<'_> {
             return None;
         }
         let promoted = ty.promote(self.db());
-        Some(strip_binding_context_suffix(
-            &promoted.display(self.db()).to_string(),
-        ))
+        Some(strip_binding_context_suffix(&display_for_python(
+            self.db(),
+            promoted,
+        )))
     }
 
     fn class_body_annotation_is_semantic(&self, class_def: &StmtClassDef) -> bool {
@@ -974,6 +976,18 @@ impl TypeInfo for SemanticModel<'_> {
             Some(Type::KnownInstance(KnownInstanceType::Field(_)))
         )
     }
+}
+
+/// Render a type as python source text. ty's own display is written for the reader of a
+/// diagnostic, where a symbolic arithmetic operation is shown as the expression it stands
+/// for (`I + 1`); emitting that would evaluate `_I + 1` on a `TypeVar` object at import, so
+/// the transpiler asks for the type it reduces to instead
+fn display_for_python<'db>(db: &'db dyn Db, ty: Type<'db>) -> String {
+    ty.display_with(
+        db,
+        DisplaySettings::default().with_reduced_symbolic_operations(),
+    )
+    .to_string()
 }
 
 /// Strip ty's `@<scope>` binding-context suffix from type variable display

--- a/crates/ty_python_semantic/resources/mdtest/basedpython_deferred_type_ops.md
+++ b/crates/ty_python_semantic/resources/mdtest/basedpython_deferred_type_ops.md
@@ -152,3 +152,151 @@ def extend[Dim: int](a: Array[Dim]) -> Array[Dim + 1]:
 def foo(data: Array[int]):
     reveal_type(extend(data))  # revealed: Array[int]
 ```
+
+## a body is checked against the operation, not its reduced form
+
+`I + 1` names one value per specialization, so a body has to produce *that* value. checking against
+the reduced form would ask only for an `int`, which `i` already is.
+
+```by
+def wrong[I: int](i: I) -> I + 1:
+    # error: [invalid-return-type] "Return type does not match returned value: expected `I@wrong + 1`, found `I@wrong`"
+    return i
+
+def off_by_one[I: int](i: I) -> I + 1:
+    # error: [invalid-return-type] "Return type does not match returned value: expected `I@off_by_one + 1`, found `I@off_by_one + 2`"
+    return i + 2
+
+def unrelated[I: int](i: I, n: int) -> I + 1:
+    # error: [invalid-return-type] "Return type does not match returned value: expected `I@unrelated + 1`, found `int`"
+    return n
+```
+
+the arithmetic on values is kept symbolic for this, so the two sides can be compared at all:
+
+```by
+def succ[I: int](i: I) -> I + 1:
+    reveal_type(i + 1)  # revealed: I@succ + 1
+    return i + 1
+```
+
+## agreement is decided by value, not by shape
+
+two expressions naming the same value need not be written the same way. operands may be commuted,
+constants folded together, and terms cancelled.
+
+```by
+def commuted[I: int](i: I) -> I + 1:
+    return 1 + i
+
+def cancelling[I: int](i: I) -> I + 1:
+    return (i + 3) - 2
+
+def rearranged[I: int](i: I) -> I * 2 + 1:
+    return 1 + 2 * i
+
+def scaled[I: int](i: I) -> I * 2:
+    return i + i
+```
+
+that holds of several parameters at once — the terms are compared as terms, not in the order the
+expression happens to introduce them:
+
+```by
+def sum_of[A: int, B: int](a: A, b: B) -> A + B:
+    return b + a
+
+def difference[A: int, B: int](a: A, b: B) -> A - B:
+    # error: [invalid-return-type] "Return type does not match returned value: expected `A@difference - B@difference`, found `B@difference - A@difference`"
+    return b - a
+```
+
+a call whose own return type is symbolic composes, so applying `succ` twice reaches `I + 2`:
+
+```by
+def succ[I: int](i: I) -> I + 1:
+    return i + 1
+
+def twice[I: int](i: I) -> I + 2:
+    return succ(succ(i))
+
+def thrice[I: int](i: I) -> I + 3:
+    # error: [invalid-return-type] "Return type does not match returned value: expected `I@thrice + 3`, found `I@thrice + 1 + 1`"
+    return succ(succ(i))
+```
+
+## subtraction and the unary operators
+
+```by
+def pred[I: int](i: I) -> I - 1:
+    return i - 1
+
+def negate[I: int](i: I) -> -I:
+    return -i
+
+def wrong_sign[I: int](i: I) -> -I:
+    # error: [invalid-return-type] "Return type does not match returned value: expected `-I@wrong_sign`, found `I@wrong_sign`"
+    return i
+
+def invert[I: int](i: I) -> ~I:
+    return ~i
+```
+
+`~I` is left whole rather than rewritten as `-I - 1`, so it agrees with itself and nothing else:
+
+```by
+def spelled_out[I: int](i: I) -> ~I:
+    # error: [invalid-return-type] "Return type does not match returned value: expected `~I@spelled_out`, found `-I@spelled_out - 1`"
+    return -i - 1
+```
+
+## a gradual value still satisfies a symbolic return type
+
+`Unknown` stands for anything, including the value the annotation names — rejecting it would make an
+unannotated helper unusable in symbolic code.
+
+```by
+def unannotated(x):
+    return x
+
+def gradual[I: int](i: I) -> I + 1:
+    return unannotated(i)
+```
+
+## only operations with a decision procedure are checked
+
+`+`, `-`, `*` and the unary operators flatten to a form that decides whether two expressions name
+the same value. a comparison, a method call or an attribute type has no such form, so a body
+annotated with one is still checked only against the reduced type.
+
+```by
+def compares[I: int](i: I) -> I < 10:
+    return True
+
+def starts[S: str](s: S) -> S.startswith("foo"):
+    return False
+```
+
+## a product of two parameters is not linear
+
+neither operand is a constant, so the product stands for itself and agrees only with an identical
+expression.
+
+```by
+def area[W: int, H: int](w: W, h: H) -> W * H:
+    return w * h
+
+def transposed[W: int, H: int](w: W, h: H) -> W * H:
+    # error: [invalid-return-type] "Return type does not match returned value: expected `W@transposed * H@transposed`, found `H@transposed * W@transposed`"
+    return h * w
+```
+
+## an unprovable body can be cast
+
+a body may be correct for a reason the checker cannot see. the escape hatch is the one every other
+unprovable assignment uses.
+
+```by
+def from_len[I: int](i: I, xs: list[int]) -> I + 1:
+    return len(xs) cast I + 1
+```

--- a/crates/ty_python_semantic/src/types/deferred.rs
+++ b/crates/ty_python_semantic/src/types/deferred.rs
@@ -43,13 +43,13 @@ use super::infer::{
     deferred_comparison, fold_tuple_concat, fold_tuple_repeat, literal_binary_op, literal_unary_op,
 };
 use super::visitor::{self, any_over_type};
-use crate::Db;
 use crate::types::call::CallArguments;
 use crate::types::match_type::{MatchTypeOutcome, evaluate_match_type};
 use crate::types::type_fn::{
     TypeFnArguments, TypeFnOutcome, declared_return_type, evaluate_type_fn,
 };
 use crate::types::{KnownClass, KnownInstanceType, TypeContext};
+use crate::{Db, FxOrderMap};
 
 /// The kind of a [`DeferredType`]'s pending operation. Each variant fixes how many
 /// operands the deferral carries and which value-level fold re-evaluates it.
@@ -87,6 +87,23 @@ pub enum DeferredOperation {
 }
 
 impl DeferredOperation {
+    /// basedpython: whether a body written against this operation can be checked.
+    ///
+    /// [`LinearForm`] decides when two integer expressions name the same value, which
+    /// covers `+`, `-`, `*` and the unary operators. Every other kind — a call, a
+    /// `type def`, a match type, an attribute type — has no such decision procedure, so
+    /// annotating with one leaves the body checked only against the reduced form.
+    pub(crate) const fn is_checked_arithmetic(&self) -> bool {
+        matches!(
+            self,
+            DeferredOperation::Binary(
+                ast::Operator::Add | ast::Operator::Sub | ast::Operator::Mult
+            ) | DeferredOperation::Unary(
+                ast::UnaryOp::USub | ast::UnaryOp::UAdd | ast::UnaryOp::Invert
+            )
+        )
+    }
+
     /// The operands that decide whether the operation can be evaluated yet.
     ///
     /// For most kinds that is every operand. A [`DeferredOperation::MatchType`] carries the
@@ -193,6 +210,176 @@ impl<'db> DeferredType<'db> {
     /// basedpython: whether this deferral is an attribute type (`T.a`).
     pub(crate) fn is_attribute(self, db: &'db dyn Db) -> bool {
         matches!(self.operation(db), DeferredOperation::Attribute(_))
+    }
+
+    /// basedpython: see [`DeferredOperation::is_checked_arithmetic`].
+    pub(crate) fn is_checked_arithmetic(self, db: &'db dyn Db) -> bool {
+        self.operation(db).is_checked_arithmetic()
+    }
+}
+
+/// basedpython: whether a value-level operand is one whose value a specialization decides.
+///
+/// Unlike [`DeferredType::is_deferred`] this looks only at the operand itself instead of
+/// walking into it. An arithmetic operand is a scalar, so a type parameter buried inside one
+/// — the `T` in `list[T]` — contributes no value to keep symbolic; staying shallow also keeps
+/// this off the hot path of every `+` in a basedpython file.
+pub(crate) const fn is_symbolic_operand(ty: Type<'_>) -> bool {
+    matches!(ty, Type::TypeVar(_) | Type::Deferred(_))
+}
+
+/// basedpython: whether a value-level operand is an integer, and so has a [`LinearForm`] that
+/// can be compared against a declared return type. A non-integer operand — `str`
+/// concatenation, say — has no such form, so keeping its operation symbolic would buy a
+/// weaker relation and nothing else.
+pub(crate) fn is_integer_operand<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
+    ty.reduce_deferred(db)
+        .is_subtype_of(db, KnownClass::Int.to_instance(db))
+}
+
+/// basedpython: an integer expression over type parameters flattened to
+/// `constant + Σ coefficient × atom`.
+///
+/// A symbolic return type names one specific value per specialization, so a body must be
+/// checked against the operation itself rather than against its reduced form — otherwise
+/// `-> I + 1` accepts every `int`, including `i`. Two expressions that name the same value
+/// need not be the same tree, though: `1 + i` differs from `i + 1` only in operand order,
+/// and two applications of `-> I + 1` build `(I + 1) + 1` where the author wrote `I + 2`.
+/// Flattening decides those agreements without needing a canonical form, which would have
+/// to rank types against each other and make the answer depend on that ranking.
+///
+/// Only the operations [`DeferredOperation::is_checked_arithmetic`] admits are taken apart.
+/// Anything else — a call, an attribute type, a bare type parameter — is an *atom*: it
+/// stands for itself and agrees only with an identical type.
+#[derive(Debug)]
+pub(crate) struct LinearForm<'db> {
+    constant: i64,
+    /// A zero coefficient is dropped rather than stored, so that two forms are equal exactly
+    /// when they agree on every term.
+    terms: FxOrderMap<Type<'db>, i64>,
+}
+
+impl PartialEq for LinearForm<'_> {
+    /// Two forms are compared term by term rather than in the order the terms happen to have
+    /// been collected, so `A + B` and `B + A` are the same form. The map's own `Eq` would
+    /// answer by insertion order, which is an artefact of the expression's shape — the very
+    /// thing flattening exists to look past.
+    fn eq(&self, other: &Self) -> bool {
+        self.constant == other.constant
+            && self.terms.len() == other.terms.len()
+            && self
+                .terms
+                .iter()
+                .all(|(atom, coefficient)| other.terms.get(atom) == Some(coefficient))
+    }
+}
+
+impl Eq for LinearForm<'_> {}
+
+impl<'db> LinearForm<'db> {
+    fn constant(constant: i64) -> Self {
+        Self {
+            constant,
+            terms: FxOrderMap::default(),
+        }
+    }
+
+    fn atom(ty: Type<'db>) -> Self {
+        Self {
+            constant: 0,
+            terms: std::iter::once((ty, 1)).collect(),
+        }
+    }
+
+    fn as_constant(&self) -> Option<i64> {
+        self.terms.is_empty().then_some(self.constant)
+    }
+
+    fn add(mut self, other: Self) -> Option<Self> {
+        self.constant = self.constant.checked_add(other.constant)?;
+        for (atom, coefficient) in other.terms {
+            let combined = self
+                .terms
+                .get(&atom)
+                .copied()
+                .unwrap_or_default()
+                .checked_add(coefficient)?;
+            if combined == 0 {
+                self.terms.remove(&atom);
+            } else {
+                self.terms.insert(atom, combined);
+            }
+        }
+        Some(self)
+    }
+
+    fn scale(mut self, factor: i64) -> Option<Self> {
+        if factor == 0 {
+            return Some(Self::constant(0));
+        }
+        self.constant = self.constant.checked_mul(factor)?;
+        for coefficient in self.terms.values_mut() {
+            *coefficient = coefficient.checked_mul(factor)?;
+        }
+        Some(self)
+    }
+
+    fn negate(self) -> Option<Self> {
+        self.scale(-1)
+    }
+
+    /// Flatten `ty`. `None` means the question cannot be decided — the arithmetic overflowed
+    /// — rather than that the type has no form; the caller must not read that as disagreement.
+    fn of(db: &'db dyn Db, ty: Type<'db>) -> Option<Self> {
+        if let Some(value) = ty
+            .as_literal_value()
+            .and_then(super::literal::LiteralValueType::as_int)
+        {
+            return Some(Self::constant(value));
+        }
+
+        let Type::Deferred(deferred) = ty else {
+            return Some(Self::atom(ty));
+        };
+        if !deferred.is_checked_arithmetic(db) {
+            return Some(Self::atom(ty));
+        }
+
+        match (deferred.operation(db), deferred.operands(db)) {
+            (DeferredOperation::Binary(op), [left, right]) => {
+                let left = Self::of(db, *left)?;
+                let right = Self::of(db, *right)?;
+                match op {
+                    ast::Operator::Add => left.add(right),
+                    ast::Operator::Sub => left.add(right.negate()?),
+                    // a product of two unknowns is not linear, so it stands for itself
+                    ast::Operator::Mult => match (left.as_constant(), right.as_constant()) {
+                        (Some(factor), _) => right.scale(factor),
+                        (_, Some(factor)) => left.scale(factor),
+                        _ => Some(Self::atom(ty)),
+                    },
+                    _ => Some(Self::atom(ty)),
+                }
+            }
+            (DeferredOperation::Unary(op), [operand]) => match op {
+                ast::UnaryOp::USub => Self::of(db, *operand)?.negate(),
+                ast::UnaryOp::UAdd => Self::of(db, *operand),
+                // `~I` is `-I - 1`, but only for an integer, and the operand's bound is not
+                // consulted here. leaving it whole costs nothing: it still agrees with itself
+                _ => Some(Self::atom(ty)),
+            },
+            _ => Some(Self::atom(ty)),
+        }
+    }
+
+    /// Whether `source` and `target` name the same value. `None` when undecidable, in which
+    /// case the caller falls back to the reduced relation rather than inventing an answer.
+    pub(crate) fn same_value(
+        db: &'db dyn Db,
+        source: Type<'db>,
+        target: Type<'db>,
+    ) -> Option<bool> {
+        Some(Self::of(db, source)? == Self::of(db, target)?)
     }
 }
 

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -8,6 +8,7 @@ use std::rc::Rc;
 
 use ruff_db::files::FilePath;
 use ruff_db::source::{line_index, source_text};
+use ruff_python_ast as ast;
 use ruff_python_ast::str::{Quote, TripleQuotes};
 use ruff_python_literal::escape::AsciiEscape;
 use ruff_source_file::LineColumn;
@@ -31,11 +32,11 @@ use crate::types::tuple::{TupleSpec, VariableSegment};
 use crate::types::typevar::BoundTypeVarIdentity;
 use crate::types::visitor::TypeVisitor;
 use crate::types::{
-    CallableType, DynamicType, IntersectionType, KnownBoundMethodType, KnownClass,
-    KnownInstanceType, LiteralValueType, LiteralValueTypeKind, MaterializationKind,
-    PropertyInstanceType, Protocol, ProtocolInstanceType, SpecialFormType, StringLiteralType,
-    SubclassOfInner, SubclassOfType, Type, TypeAliasType, TypeGuardLike, TypedDictModule,
-    TypedDictType, UnionType, WrapperDescriptorKind, visitor,
+    CallableType, DeferredOperation, DeferredType, DynamicType, IntersectionType,
+    KnownBoundMethodType, KnownClass, KnownInstanceType, LiteralValueType, LiteralValueTypeKind,
+    MaterializationKind, PropertyInstanceType, Protocol, ProtocolInstanceType, SpecialFormType,
+    StringLiteralType, SubclassOfInner, SubclassOfType, Type, TypeAliasType, TypeGuardLike,
+    TypedDictModule, TypedDictType, UnionType, WrapperDescriptorKind, visitor,
 };
 use ty_python_core::definition::Definition;
 use ty_python_core::scope::{FileScopeId, ScopeKind};
@@ -137,6 +138,12 @@ pub struct DisplaySettings<'db> {
     /// subscript writes it. Only ever set for `.by` output — python's subscript
     /// grammar has no keyword form.
     pub name_type_arguments: bool,
+    /// basedpython: whether a symbolic arithmetic operation is shown as the type it
+    /// reduces to (`int`) rather than as the expression it stands for (`I + 1`). Only
+    /// ever set by the transpiler: an expression reads better everywhere a human sees
+    /// it, but emitting one as python would evaluate `_I + 1` on a `TypeVar` object at
+    /// import time.
+    pub reduce_symbolic_operations: bool,
 }
 
 impl<'db> DisplaySettings<'db> {
@@ -145,6 +152,16 @@ impl<'db> DisplaySettings<'db> {
     pub fn with_named_type_arguments(&self) -> Self {
         Self {
             name_type_arguments: true,
+            ..self.clone()
+        }
+    }
+
+    /// basedpython: show a symbolic arithmetic operation as the type it reduces to, for
+    /// output that has to be valid python.
+    #[must_use]
+    pub fn with_reduced_symbolic_operations(&self) -> Self {
+        Self {
+            reduce_symbolic_operations: true,
             ..self.clone()
         }
     }
@@ -1011,6 +1028,72 @@ fn fmt_type_guard_like<'db, T: TypeGuardLike<'db>>(
     f.write_str("]")
 }
 
+/// basedpython: how tightly a symbolic arithmetic operation binds, so that a nested operand
+/// is parenthesised exactly when the expression would otherwise read as a different one.
+/// Anything that is not such an operation is a leaf and never needs parentheses.
+fn deferred_binding_power(db: &dyn Db, ty: Type<'_>) -> u8 {
+    let Type::Deferred(deferred) = ty else {
+        return u8::MAX;
+    };
+    match deferred.operation(db) {
+        DeferredOperation::Binary(ast::Operator::Add | ast::Operator::Sub) => 1,
+        DeferredOperation::Binary(ast::Operator::Mult) => 2,
+        DeferredOperation::Unary(_) => 3,
+        _ => u8::MAX,
+    }
+}
+
+/// basedpython: write a symbolic arithmetic operation back out as the expression it stands
+/// for, e.g. `I@succ + 1`. `minimum_binding_power` is what the surrounding operator requires
+/// of this position; a weaker-binding operation there is parenthesised.
+fn fmt_deferred_arithmetic<'db>(
+    db: &'db dyn Db,
+    deferred: DeferredType<'db>,
+    settings: &DisplaySettings<'db>,
+    minimum_binding_power: u8,
+    f: &mut TypeWriter<'_, '_, 'db>,
+) -> fmt::Result {
+    let binding_power = deferred_binding_power(db, Type::Deferred(deferred));
+    let parenthesised = binding_power < minimum_binding_power;
+    if parenthesised {
+        f.write_char('(')?;
+    }
+
+    let operand = |f: &mut TypeWriter<'_, '_, 'db>, ty: Type<'db>, minimum: u8| match ty {
+        Type::Deferred(nested) if nested.is_checked_arithmetic(db) => {
+            fmt_deferred_arithmetic(db, nested, settings, minimum, f)
+        }
+        _ => ty.display_with(db, settings.clone()).fmt_detailed(f),
+    };
+
+    match (deferred.operation(db), deferred.operands(db)) {
+        (DeferredOperation::Binary(op), [left, right]) => {
+            operand(f, *left, binding_power)?;
+            f.write_char(' ')?;
+            f.write_str(op.as_str())?;
+            f.write_char(' ')?;
+            // `a - (b - c)` is not `a - b - c`, so the right operand of a left-associative
+            // operator has to bind one step tighter to go unparenthesised
+            operand(f, *right, binding_power + 1)?;
+        }
+        (DeferredOperation::Unary(op), [inner]) => {
+            f.write_str(op.as_str())?;
+            operand(f, *inner, binding_power)?;
+        }
+        // `is_checked_arithmetic` admits no other shape; a deferral built with the wrong
+        // operand count is still better shown reduced than not at all
+        _ => Type::Deferred(deferred)
+            .reduce_deferred(db)
+            .display_with(db, settings.clone())
+            .fmt_detailed(f)?,
+    }
+
+    if parenthesised {
+        f.write_char(')')?;
+    }
+    Ok(())
+}
+
 /// Writes the string representation of a type, which is the value displayed either as
 /// `Literal[<repr>]` or `Literal[<repr1>, <repr2>]` for literal types or as `<repr>` for
 /// non literals
@@ -1540,9 +1623,18 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     .fmt_detailed(f)?;
                 f.write_char(']')
             }
-            // an unspecialized deferred operation displays as its reduced form (e.g.
-            // `Array[Dim + 1]` shows as `Array[int]`); once specialized it has folded
-            // to a concrete type and this arm is not reached
+            // an arithmetic operation is written back out as the expression it stands for:
+            // a body checked against `I + 1` is rejected by naming a *different* value, and
+            // the reduced form would report that as `int` against `int`
+            Type::Deferred(deferred)
+                if deferred.is_checked_arithmetic(self.db)
+                    && !self.settings.reduce_symbolic_operations =>
+            {
+                fmt_deferred_arithmetic(self.db, deferred, &self.settings, 0, f)
+            }
+            // every other unspecialized operation displays as its reduced form (`T.a` shows
+            // as the bound's `a`); once specialized it has folded to a concrete type and
+            // this arm is not reached
             Type::Deferred(deferred) => deferred
                 .reduced(self.db)
                 .display_with(self.db, self.settings.clone())

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -63,6 +63,7 @@ use crate::types::constraints::{ConstraintSetBuilder, PathBounds, Solutions};
 use crate::types::context::InferContext;
 use crate::types::context_sensitive;
 use crate::types::dedicated::{django, pydantic};
+use crate::types::deferred::{is_integer_operand, is_symbolic_operand};
 use crate::types::diagnostic::{
     self, AMBIGUOUS_EXTENSION_MEMBER, CALL_NON_CALLABLE, CONFLICTING_DECLARATIONS,
     CYCLIC_TYPE_ALIAS_DEFINITION, ERASED_CAST_ARGUMENT, ERASED_TYPE_CHECK, FINAL_ON_VARIABLE,
@@ -13065,6 +13066,21 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             (_, Type::Overlapping(overlapping)) => overlapping.value_type(self.db()),
             (_, Type::Restricted(restricted)) => {
                 self.infer_unary_expression_type(op, restricted.value_type(self.db()), unary)
+            }
+            // basedpython: the counterpart of the symbolic arithmetic in
+            // `infer_binary_expression_type_impl` — `-i` has to build the same operation the
+            // annotation `-> -I` builds, or the two could never be compared
+            (op, operand_type)
+                if self.is_basedpython_file()
+                    && DeferredOperation::Unary(op).is_checked_arithmetic()
+                    && is_symbolic_operand(operand_type)
+                    && is_integer_operand(self.db(), operand_type) =>
+            {
+                DeferredType::build(
+                    self.db(),
+                    &DeferredOperation::Unary(op),
+                    Box::new([operand_type]),
+                )
             }
             (_, Type::Deferred(deferred)) => deferred.reduced(self.db()),
             (ast::UnaryOp::Invert | ast::UnaryOp::UAdd | ast::UnaryOp::USub, Type::Dynamic(_))

--- a/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
@@ -6,6 +6,7 @@ use crate::Db;
 use crate::types::call::CallArguments;
 use crate::types::constraints::ConstraintSetBuilder;
 use crate::types::cyclic::CycleDetector;
+use crate::types::deferred::{is_integer_operand, is_symbolic_operand};
 use crate::types::diagnostic::{
     DIVISION_BY_ZERO, report_unsupported_augmented_assignment, report_unsupported_binary_operation,
 };
@@ -13,9 +14,10 @@ use crate::types::set_theoretic::RecursivelyDefined;
 use crate::types::tuple::Tuple;
 use crate::types::typevar::TypeVarConstraints;
 use crate::types::{
-    DynamicType, InternedConstraintSet, KnownClass, KnownInstanceType, LiteralValueTypeKind,
-    MemberLookupPolicy, Type, TypeContext, TypeVarBoundOrConstraints, TypedDictType, UnionBuilder,
-    UnionType, UnionTypeInstance, UnsafeUnionType,
+    DeferredOperation, DeferredType, DynamicType, InternedConstraintSet, KnownClass,
+    KnownInstanceType, LiteralValueTypeKind, MemberLookupPolicy, Type, TypeContext,
+    TypeVarBoundOrConstraints, TypedDictType, UnionBuilder, UnionType, UnionTypeInstance,
+    UnsafeUnionType,
 };
 
 enum BinaryExpressionOperandTypes<'db> {
@@ -407,6 +409,23 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         tcx,
                     )
                 })
+            }
+            // basedpython: arithmetic on a type parameter names a value that depends on the
+            // specialization, so evaluating it through the bound's `__add__` would answer
+            // `int` and throw that away. build the same symbolic operation the annotation
+            // `-> I + 1` builds, so a body can be checked against its declared return type
+            (left, right, op)
+                if self.is_basedpython_file()
+                    && DeferredOperation::Binary(op).is_checked_arithmetic()
+                    && (is_symbolic_operand(left) || is_symbolic_operand(right))
+                    && is_integer_operand(db, left)
+                    && is_integer_operand(db, right) =>
+            {
+                Some(DeferredType::build(
+                    db,
+                    &DeferredOperation::Binary(op),
+                    Box::new([left, right]),
+                ))
             }
             (Type::Deferred(deferred), _, _) => visitor.visit(db, (left_ty, op, right_ty), || {
                 self.infer_binary_expression_type_impl(

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -20,12 +20,14 @@ use crate::types::constraints::{
     OwnedConstraintSet,
 };
 use crate::types::cyclic::{HasIdentity, PairVisitor, TypeIdentity};
+use crate::types::deferred::LinearForm;
 use crate::types::enums::is_single_member_enum;
 use crate::types::function::FunctionDecorators;
 use crate::types::restricted::restriction_admits;
 use crate::types::set_theoretic::RecursivelyDefined;
 use crate::types::signatures::{ParametersKind, SignatureRelationVisitor};
 use crate::types::tuple::TupleType;
+use crate::types::visitor::any_over_type;
 use crate::types::{
     ApplyTypeMappingVisitor, CallableType, ClassBase, ClassLiteral, ClassType, CycleDetector,
     IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
@@ -1288,6 +1290,33 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
             (Type::Restricted(source_restricted), _) => {
                 self.check_type_pair(db, source_restricted.value_type(db), target)
+            }
+
+            // basedpython: in *target* position an arithmetic deferral names one specific
+            // value per specialization, so reducing it the way the source arm below does
+            // would let any `int` stand in for `I + 1` — including `I` itself. the source has
+            // to name the same value, which [`LinearForm`] decides. a gradual source keeps
+            // its licence to stand for anything, and an undecidable comparison falls back to
+            // the reduced relation rather than reporting a disagreement it did not establish.
+            //
+            // this has to precede the source arm: a source that is itself an arithmetic
+            // deferral is exactly the interesting case, and reducing it first would compare
+            // `int` against `int` and always agree
+            (_, Type::Deferred(target_deferred)) if target_deferred.is_checked_arithmetic(db) => {
+                let names_another_value = !any_over_type(db, source, false, |ty| ty.is_dynamic())
+                    && LinearForm::same_value(db, source, target) == Some(false);
+                if names_another_value {
+                    self.never()
+                } else {
+                    // the symbolic question is settled, so both sides reduce here rather
+                    // than falling through — reducing only the source would re-enter this
+                    // arm and ask it of a source that no longer mentions the parameter
+                    self.check_type_pair(
+                        db,
+                        source.reduce_deferred(db),
+                        target_deferred.reduced(db),
+                    )
+                }
             }
 
             (Type::Deferred(source_deferred), _) => {

--- a/docs/basedpython/features/symbolic-type-ops.md
+++ b/docs/basedpython/features/symbolic-type-ops.md
@@ -52,6 +52,66 @@ an operation ty cannot resolve to a concrete type (for example `+` between two
 classes) is left untouched and reported as an invalid type form, the same as any
 other unusable annotation.
 
+## a type parameter operand
+
+an operand may be a type parameter, which is not known where the annotation is
+written. the operation is then kept symbolic rather than collapsed to the
+parameter's bound, and re-evaluated against each specialization:
+
+```by
+class Array[Dim: int]
+
+def extend[Dim: int](a: Array[Dim]) -> Array[Dim + 1]:
+    return a
+
+def f(data: Array[5]):
+    reveal_type(extend(data))       # `Array[6]`
+    reveal_type(extend(extend(data)))  # `Array[7]`
+```
+
+collapsing `Dim + 1` to `int` at the definition would throw the relationship
+away and infer `Array[int]` at every call site.
+
+### the body is checked against the operation
+
+`I + 1` names one value per specialization, so a body has to produce *that*
+value — checking against the reduced form would ask only for an `int`:
+
+```by
+def succ[I: int](i: I) -> I + 1:
+    return i + 1        # ok
+
+def wrong[I: int](i: I) -> I + 1:
+    return i            # error: expected `I + 1`, found `I`
+```
+
+arithmetic on values is kept symbolic for this, so `i + 1` has the type `I + 1`
+rather than `int`. two expressions naming the same value need not be written the
+same way: operands may be commuted, constants folded together, terms cancelled,
+and calls whose own return type is symbolic composed.
+
+```by
+def commuted[I: int](i: I) -> I + 1:
+    return 1 + i
+
+def rearranged[I: int](i: I) -> I * 2 + 1:
+    return 1 + 2 * i
+
+def twice[I: int](i: I) -> I + 2:
+    return succ(succ(i))
+```
+
+`+`, `-`, `*` and the unary operators are decided this way. a comparison, a
+method call or an [attribute type](attribute-types.md) has no such decision
+procedure, so a body annotated with one is checked only against the type the
+operation reduces to. a body that is correct for a reason the checker cannot see
+takes the escape hatch every other unprovable assignment takes:
+
+```by
+def from_len[I: int](i: I, xs: list[int]) -> I + 1:
+    return len(xs) cast I + 1
+```
+
 ## polyfill
 
 there is no runtime construct: the operation is resolved at transpile time and


### PR DESCRIPTION
`-> I + 1` names one value per specialization, but the relation reduced it to `int` in target position, so `return i` was accepted. bodies are now checked against the operation itself, decided by flattening both sides to a linear form so `1 + i`, `(i + 3) - 2` and `succ(succ(i))` still agree with what they name.

value-level arithmetic on a type parameter is kept symbolic for this, gated on basedpython files. only `+`, `-`, `*` and the unary operators are decided this way; a call, a comparison or an attribute type has no such procedure and keeps the reduced relation. a gradual source still satisfies any of them.

deferred arithmetic now displays as the expression it stands for, so the diagnostic reads `expected I@f + 1, found I@f` rather than `int` against `int`. the transpiler asks for the reduced form instead — `_I + 1` on a TypeVar object would be a TypeError at import.
