### PR TITLE
a widened view of a private member cannot write to it

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/basedpython_safe_variance.md
+++ b/crates/ty_python_semantic/resources/mdtest/basedpython_safe_variance.md
@@ -3,9 +3,10 @@
 Privacy is what makes variance safe. A private member is invisible outside its class, so it cannot
 be used to tell two specializations apart — which is what lets a covariant class hold a mutable
 field of its type parameter. The flip side is that a widened view of the class learns nothing about
-that member: through any receiver but the class's own it keeps its declared type instead of picking
-up the receiver's arguments, so a write must supply a real `T` and a read gets back only `T`'s
-bound.
+that member: it keeps its declared type instead of picking up the receiver's arguments, and through
+any receiver but the class's own — anything that is not the `self` the body was handed — that type
+is erased to what such a view knows. A read gets back `T`'s bound, and a write is accepted from
+nothing at all.
 
 ```toml
 [environment]
@@ -68,9 +69,12 @@ class A[out T]:
         self.t = other.t
 ```
 
-## a write through a widened view must supply a real `T`
+## a write through a widened view is accepted from nothing
 
-Privacy is what exempts `t` from constraining variance; the public `f` below still consumes a `T`,
+Storage is invariant in its own type, so a write has to be valid for every type the erased member
+could really have. Nothing is, which is why the write type is `Never`.
+
+Privacy is what exempts `t` from constraining variance; the public `g` below still consumes a `T`,
 so the class is separately reported for not honouring its own `out`.
 
 ```by
@@ -78,16 +82,54 @@ so the class is separately reported for not honouring its own `out`.
 class A[out T]:
     private t: T
 
-    def f(self: A[object], t: T):
-        self.t = t
+    def f(self, other: A[object]):
+        # error: [invalid-assignment] "Object of type `1` is not assignable to attribute `t` of type `Never`"
+        other.t = 1
 
-    def g(self: A[object]):
+    def g(self, other: A[object], t: T):
+        # a real `T` gets no further: it is `self`'s parameter, and says nothing about the one
+        # `other` is hiding
+        # error: [invalid-assignment] "Object of type `T@A` is not assignable to attribute `t` of type `Never`"
+        other.t = t
+```
+
+## …including through a receiver the body constructed itself
+
+`a` below is an `A[object]` and its storage has nothing to do with `self`'s `T`.
+
+```by
+# error: [invalid-generic-class] "Variance of type variable `T` is incompatible with its usage in `A`"
+class A[out T]:
+    private t: T
+
+    def f(self, t: T):
+        a = A[object]()
+        # error: [invalid-assignment] "Object of type `1` is not assignable to attribute `t` of type `Never`"
+        a.t = 1
+        # error: [invalid-assignment] "Object of type `T@A` is not assignable to attribute `t` of type `Never`"
+        a.t = t
+```
+
+## the class's own receiver is `self`, however it is annotated
+
+An explicitly widened `self` is still the receiver the call site had, and the class's type
+parameters are that receiver's — so the member keeps its declared type, un-erased, and a real `T`
+can be written to it. This holds through a capture in a nested function too.
+
+```by
+# error: [invalid-generic-class] "Variance of type variable `T` is incompatible with its usage in `A`"
+class A[out T]:
+    private t: T
+
+    def f(self: A[object], t: T):
+        reveal_type(self.t)  # revealed: T@A
+        self.t = t
         # error: [invalid-assignment] "Object of type `"asdf"` is not assignable to attribute `t` of type `T@A`"
         self.t = "asdf"
 
-    def h(self, other: A[object]):
-        # error: [invalid-assignment] "Object of type `1` is not assignable to attribute `t` of type `T@A`"
-        other.t = 1
+    def g(self: A[object], t: T):
+        def inner():
+            self.t = t
 ```
 
 ## an unspecialized construction is a widened view too
@@ -99,7 +141,7 @@ class A[T]:
     private t: T
 
     def f(self):
-        # error: [invalid-assignment] "Object of type `1` is not assignable to attribute `t` of type `T@A`"
+        # error: [invalid-assignment] "Object of type `1` is not assignable to attribute `t` of type `Never`"
         A().t = 1
 ```
 
@@ -272,14 +314,15 @@ class A[T]:
 
 class C[U](A[U]):
     def f(self, other: C[object]):
-        # error: [invalid-assignment] "Object of type `1` is not assignable to attribute `t` of type `U@C`"
+        # error: [invalid-assignment] "Object of type `1` is not assignable to attribute `t` of type `Never`"
         other.t = 1
 ```
 
 ## a nested occurrence is erased soundly
 
-`list` is invariant, so the erasure has to be the top materialization rather than a naive
-substitution of the bound.
+`list` is invariant, so the erasure has to be a materialization rather than a naive substitution of
+the bound. Neither materialization can say more than "some list" about an invariant occurrence, so
+the erased element stays gradual and a write is neither precise nor rejected.
 
 ```by
 class A[T]:
@@ -287,4 +330,23 @@ class A[T]:
 
 def f(a: A[int]):
     reveal_type(a.items)  # revealed: list[*]
+    a.items = [1]
+```
+
+## a union of two specializations is a widened view of each
+
+A write to a union has to be valid for every element, and no element accepts anything. The public
+`produce` is what keeps the two specializations from collapsing into each other: without it `T` is
+bivariant and `A[int] | A[str]` is just `A[int]`.
+
+```by
+class A[out T]:
+    private t: T
+
+    def produce(self) -> T:
+        raise NotImplementedError
+
+def f(a: A[int] | A[str]):
+    # error: [invalid-assignment] "Object of type `1` is not assignable to attribute `t` on type `A[int] | A[str]`"
+    a.t = 1
 ```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -201,6 +201,7 @@ pub(crate) mod reified_infer;
 pub(crate) mod relation;
 mod relation_error;
 mod restricted;
+mod safe_variance;
 mod set_theoretic;
 mod signatures;
 pub mod soundness;

--- a/crates/ty_python_semantic/src/types/attribute_write.rs
+++ b/crates/ty_python_semantic/src/types/attribute_write.rs
@@ -11,6 +11,7 @@ use ty_module_resolver::KnownModule;
 
 use super::call::CallArguments;
 use super::callable::CallableTypeKind;
+use super::safe_variance::private_member_write_type;
 use super::{KnownClass, KnownInstanceType, MemberLookupPolicy, Type, TypeQualifiers};
 use crate::Db;
 use crate::place::{DefinedPlace, Definedness, Place, PlaceAndQualifiers, builtins_symbol};
@@ -485,6 +486,13 @@ fn explicit_attribute_write_requirement<'db>(
     attr_ty: Type<'db>,
     qualifiers: TypeQualifiers,
 ) -> ExplicitAttributeWriteRequirement<'db> {
+    // basedpython safe variance: a private member does not specialize, so a widened view of the
+    // class knows nothing about it — not even whether it is a descriptor whose `__set__` would
+    // govern the write. There is nothing such a view can supply
+    if let Some(ty) = private_member_write_type(db, object_ty, attribute) {
+        return ExplicitAttributeWriteRequirement::AssignableTo { ty, qualifiers };
+    }
+
     if let Place::Defined(DefinedPlace { ty: setter_ty, .. }) = attr_ty
         .class_member_with_policy(db, "__set__", MemberLookupPolicy::REQUIRE_CONCRETE)
         .place
@@ -521,9 +529,14 @@ fn instance_fallback_write_requirement<'db>(
     else {
         return FallbackAttributeWriteRequirement::PossiblyMissing;
     };
-    let ty = ty.bind_self_typevars(db, object_ty);
+    // basedpython safe variance: a private member does not specialize, and a widened view of the
+    // class has nothing to write to it — see `explicit_attribute_write_requirement`
+    let ty = private_member_write_type(db, object_ty, attribute).unwrap_or_else(|| {
+        let ty = ty.bind_self_typevars(db, object_ty);
+        effective_write_type(db, object_ty, attribute, ty)
+    });
     FallbackAttributeWriteRequirement::AssignableTo {
-        ty: effective_write_type(db, object_ty, attribute, ty),
+        ty,
         qualifiers,
         possibly_missing: definedness == Definedness::PossiblyUndefined,
     }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -12561,11 +12561,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             value_type = super_value_type;
         }
 
-        // basedpython safe variance: a private member does not specialize. Through a
-        // receiver carrying anything but the class's own type parameters, the read is
-        // erased to what such a view actually knows — the parameter's bound
-        if let Some(view) = private_member_view(db, value_type, attr.as_str()) {
-            let read_type = view.read_type(db);
+        // basedpython safe variance: a private member does not specialize. It keeps the type it
+        // was declared with, and through any receiver but the class's own that type is erased to
+        // what such a view actually knows — the parameter's bound
+        if let Some(view) =
+            crate::types::safe_variance::private_member_view(db, value_type, attr.as_str())
+        {
+            let read_type = if self.is_own_receiver_attribute(attribute) {
+                view.declared_ty
+            } else {
+                view.read_type(db)
+            };
             return self.basedpython_chain_result(attribute, read_type, none_chain_was_optional);
         }
 
@@ -15220,112 +15226,6 @@ fn attribute_has_covariant_projected_typevar<'db>(
         } else {
             false
         }
-    })
-}
-
-/// basedpython safe variance: a private member seen through a view of its class that is
-/// not the class's own.
-///
-/// The `attribute` is private, its declared type names one or more of the class's
-/// *non-invariant* type parameters, and the receiver substitutes something else for them.
-struct PrivateMemberView<'db> {
-    /// The class's own view of itself — the receiver the member is declared against.
-    own_view: Type<'db>,
-    /// The member's declared type on that view, with the type parameters left intact.
-    declared_ty: Type<'db>,
-    /// The non-invariant type parameters the receiver substituted something else for.
-    substituted: Box<[BoundTypeVarInstance<'db>]>,
-}
-
-impl<'db> PrivateMemberView<'db> {
-    /// The type a *read* through this view yields.
-    ///
-    /// The receiver's own type argument says nothing about what the object really holds —
-    /// that is what its being widened means — so every substituted parameter is erased to
-    /// its top materialization. The value can be treated as its bound, but it is no longer
-    /// a `T`, so it can never be funnelled back into the `T`-typed storage it came from.
-    fn read_type(&self, db: &'db dyn crate::Db) -> Type<'db> {
-        self.substituted
-            .iter()
-            .fold(self.declared_ty, |ty, typevar| {
-                ty.substitute_one_typevar(db, *typevar, Type::any())
-            })
-            .top_materialization(db)
-    }
-}
-
-/// basedpython safe variance: a private member does not specialize.
-///
-/// Privacy is what makes variance safe. A private member is invisible outside its class, so
-/// it cannot be used to tell two specializations apart — which is what lets a covariant
-/// class hold a mutable field of its type parameter. The flip side is that a widened view
-/// of the class learns nothing about that member: through any receiver but the class's own,
-/// the member keeps its declared type rather than picking up the receiver's arguments, so a
-/// write must supply a real `T` and a read gets back only `T`'s bound.
-///
-/// A type parameter that is *invariant* is left alone. No specialization of the class is
-/// assignable to another, so every receiver's argument is exact and ordinary specialization
-/// is already sound.
-fn private_member_view<'db>(
-    db: &'db dyn crate::Db,
-    object_ty: Type<'db>,
-    attribute: &str,
-) -> Option<PrivateMemberView<'db>> {
-    let instance = object_ty.as_nominal_instance()?;
-    let crate::types::ClassType::Generic(alias) = instance.class(db) else {
-        return None;
-    };
-    let specialization = alias.specialization(db);
-    let class = ClassLiteral::Static(alias.origin(db));
-
-    // the substituted type parameters, cheapest first: a receiver that carries the class's
-    // own parameters *is* the class's own view of every member, so there is nothing to do.
-    // this is the whole of the hot path — `self.x` inside the class's own methods — and it
-    // settles without a member lookup
-    let generic_context = specialization.generic_context(db);
-    let substituted = || {
-        generic_context
-            .variables(db)
-            .zip(specialization.types(db))
-            .filter(|(typevar, argument)| **argument != Type::TypeVar(*typevar))
-            .map(|(typevar, _)| typevar)
-    };
-    substituted().next()?;
-
-    // look the member up on the class's own identity specialization, so its declared type
-    // still names the class's type parameters rather than the receiver's arguments. a
-    // `__getattr__` result is not a declared member of anything, so it is never private
-    // however its name is spelled
-    let own_view = Type::instance(db, class.identity_specialization(db));
-    let member =
-        own_view.member_lookup_with_policy(db, attribute, MemberLookupPolicy::NO_GETATTR_LOOKUP);
-    let declared_ty = member.place.ignore_possibly_undefined()?;
-    if !crate::types::is_private_member(db, attribute, member.qualifiers, declared_ty) {
-        return None;
-    }
-
-    let substituted: Box<[_]> = substituted()
-        .filter(|typevar| {
-            let identity = typevar.identity(db);
-            let mentions_typevar = crate::types::any_over_type(
-                db,
-                declared_ty,
-                false,
-                |ty| matches!(ty, Type::TypeVar(other) if other.identity(db) == identity),
-            );
-            // an invariant parameter is checked last: inferring variance is expensive, and
-            // it re-enters the class body this access may itself be inside of
-            mentions_typevar && typevar.variance(db) != TypeVarVariance::Invariant
-        })
-        .collect();
-    if substituted.is_empty() {
-        return None;
-    }
-
-    Some(PrivateMemberView {
-        own_view,
-        declared_ty,
-        substituted,
     })
 }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
@@ -13,6 +13,7 @@ use crate::types::diagnostic::{
     INVALID_ASSIGNMENT, INVALID_ATTRIBUTE_ACCESS, UNRESOLVED_ATTRIBUTE, report_bad_dunder_set_call,
     report_bool_as_int, report_invalid_attribute_assignment, report_possibly_missing_attribute,
 };
+use crate::types::safe_variance::private_member_view;
 use crate::types::{CallDunderError, MemberLookupPolicy, Type, TypeContext, TypeQualifiers};
 
 impl<'db> TypeInferenceBuilder<'db, '_> {
@@ -52,16 +53,19 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             return false;
         }
 
-        // basedpython safe variance: a private member does not specialize, so the write is
-        // required against the class's own view of it. The only value a widened receiver
-        // can supply soundly is a real `T` — not whatever it claims the parameter is.
-        // Everything else about the write (`Final`, `ClassVar`, descriptors, a property
-        // setter) is unchanged, which is why this swaps the receiver rather than
-        // short-circuiting the requirement
-        let write_receiver = super::private_member_view(db, object_ty, attribute)
-            .map_or(object_ty, |view| view.own_view);
+        // basedpython safe variance: a private member does not specialize, and the class's own
+        // receiver is the implicit `self` however it is annotated — so the write is required
+        // against the class's own view of itself, not the one `self` was widened to. Swapping the
+        // receiver rather than the requirement keeps `Final`, `ClassVar`, descriptors and property
+        // setters working. Every other receiver is a widened view, and `attribute_write_requirement`
+        // erases those itself
+        let write_receiver = if self.is_own_receiver_attribute(target) {
+            private_member_view(db, object_ty, attribute).map_or(object_ty, |view| view.own_view)
+        } else {
+            object_ty
+        };
 
-        let requirement = attribute_write_requirement(self.db(), write_receiver, attribute);
+        let requirement = attribute_write_requirement(db, write_receiver, attribute);
         let mut evaluator = AssignmentAttributeWriteEvaluator {
             builder: self,
             target,

--- a/crates/ty_python_semantic/src/types/infer/builder/final_attribute.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/final_attribute.rs
@@ -176,6 +176,18 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         .then_some(receiver_scope_id)
     }
 
+    /// basedpython: whether this attribute is reached through the enclosing method's implicit
+    /// receiver, from its own body or a function nested in it.
+    ///
+    /// `self` is bound to whatever receiver the call site had, so the class's type parameters are
+    /// that receiver's however `self` is annotated — see [`crate::types::safe_variance`].
+    pub(super) fn is_own_receiver_attribute(&self, target: &ast::ExprAttribute) -> bool {
+        target
+            .value
+            .as_name_expr()
+            .is_some_and(|receiver| self.receiver_method_scope(receiver).is_some())
+    }
+
     pub(super) fn invalid_assignment_to_final_attribute(
         &self,
         object_ty: Type<'db>,

--- a/crates/ty_python_semantic/src/types/safe_variance.rs
+++ b/crates/ty_python_semantic/src/types/safe_variance.rs
@@ -1,0 +1,148 @@
+//! basedpython safe variance: a private member does not specialize.
+//!
+//! Privacy is what makes variance safe. A private member is invisible outside its class, so it
+//! cannot be used to tell two specializations apart — which is what lets a covariant class hold a
+//! mutable field of its type parameter. The flip side is that a widened view of the class learns
+//! nothing about that member: through any receiver but the class's own, the member is erased to
+//! what such a view actually knows.
+//!
+//! The class's own receiver is the implicit `self`, whatever it is annotated as. `self` is bound
+//! to the receiver the call site had, so the class's type parameters are that receiver's — a
+//! widening annotation on it does not make the body another view of the class.
+
+use super::{
+    BoundTypeVarInstance, ClassLiteral, MemberLookupPolicy, Type, TypeVarVariance, any_over_type,
+    is_private_member,
+};
+use crate::Db;
+
+/// basedpython safe variance: a private member seen through a view of its class that is
+/// not the class's own.
+///
+/// The `attribute` is private, its declared type names one or more of the class's
+/// *non-invariant* type parameters, and the receiver substitutes something else for them.
+pub(super) struct PrivateMemberView<'db> {
+    /// The class's own view of itself — the receiver the member is declared against.
+    pub(super) own_view: Type<'db>,
+    /// The member's declared type on that view, with the type parameters left intact.
+    pub(super) declared_ty: Type<'db>,
+    /// The non-invariant type parameters the receiver substituted something else for.
+    substituted: Box<[BoundTypeVarInstance<'db>]>,
+}
+
+impl<'db> PrivateMemberView<'db> {
+    /// The declared type with every substituted parameter replaced by the unknown it really is.
+    ///
+    /// The receiver's own type argument says nothing about what the object holds — that is what
+    /// its being widened means.
+    fn erased(&self, db: &'db dyn Db) -> Type<'db> {
+        self.substituted
+            .iter()
+            .fold(self.declared_ty, |ty, typevar| {
+                ty.substitute_one_typevar(db, *typevar, Type::any())
+            })
+    }
+
+    /// The type a *read* through this view yields.
+    ///
+    /// A read observes the member at its most general, so the erasure's top materialization is
+    /// everything such a view can know: `t: T` reads as `object`. The value can be treated as its
+    /// bound, but it is no longer a `T`, so it can never be funnelled back into the `T`-typed
+    /// storage it came from.
+    pub(super) fn read_type(&self, db: &'db dyn Db) -> Type<'db> {
+        self.erased(db).top_materialization(db)
+    }
+
+    /// The type a *write* through this view has to supply.
+    ///
+    /// Storage is invariant in its own type, so a write has to be valid for every type the member
+    /// could really have — the erasure's bottom materialization. For a plain `T` that is `Never`:
+    /// a view that knows nothing about a member cannot write to it, whatever it holds.
+    fn write_type(&self, db: &'db dyn Db) -> Type<'db> {
+        self.erased(db).bottom_materialization(db)
+    }
+}
+
+/// basedpython safe variance: the type a write to `attribute` has to supply, when `object_ty` is a
+/// widened view of a class that declares `attribute` privately.
+///
+/// `None` leaves the write to ordinary specialization.
+pub(super) fn private_member_write_type<'db>(
+    db: &'db dyn Db,
+    object_ty: Type<'db>,
+    attribute: &str,
+) -> Option<Type<'db>> {
+    Some(private_member_view(db, object_ty, attribute)?.write_type(db))
+}
+
+/// basedpython safe variance: a private member does not specialize.
+///
+/// Through any receiver but the class's own, the member keeps its declared type rather than
+/// picking up the receiver's arguments, and that type is erased to what a widened view knows: a
+/// read yields the parameter's bound, a write accepts nothing.
+///
+/// A type parameter that is *invariant* is left alone. No specialization of the class is
+/// assignable to another, so every receiver's argument is exact and ordinary specialization
+/// is already sound.
+pub(super) fn private_member_view<'db>(
+    db: &'db dyn Db,
+    object_ty: Type<'db>,
+    attribute: &str,
+) -> Option<PrivateMemberView<'db>> {
+    let instance = object_ty.as_nominal_instance()?;
+    let super::ClassType::Generic(alias) = instance.class(db) else {
+        return None;
+    };
+    let specialization = alias.specialization(db);
+    let class = ClassLiteral::Static(alias.origin(db));
+
+    // the substituted type parameters, cheapest first: a receiver that carries the class's
+    // own parameters *is* the class's own view of every member, so there is nothing to do.
+    // this is the whole of the hot path — `self.x` inside the class's own methods — and it
+    // settles without a member lookup
+    let generic_context = specialization.generic_context(db);
+    let substituted = || {
+        generic_context
+            .variables(db)
+            .zip(specialization.types(db))
+            .filter(|(typevar, argument)| **argument != Type::TypeVar(*typevar))
+            .map(|(typevar, _)| typevar)
+    };
+    substituted().next()?;
+
+    // look the member up on the class's own identity specialization, so its declared type
+    // still names the class's type parameters rather than the receiver's arguments. a
+    // `__getattr__` result is not a declared member of anything, so it is never private
+    // however its name is spelled
+    let own_view = Type::instance(db, class.identity_specialization(db));
+    let member =
+        own_view.member_lookup_with_policy(db, attribute, MemberLookupPolicy::NO_GETATTR_LOOKUP);
+    let declared_ty = member.place.ignore_possibly_undefined()?;
+    if !is_private_member(db, attribute, member.qualifiers, declared_ty) {
+        return None;
+    }
+
+    let substituted: Box<[_]> = substituted()
+        .filter(|typevar| {
+            let identity = typevar.identity(db);
+            let mentions_typevar = any_over_type(
+                db,
+                declared_ty,
+                false,
+                |ty| matches!(ty, Type::TypeVar(other) if other.identity(db) == identity),
+            );
+            // an invariant parameter is checked last: inferring variance is expensive, and
+            // it re-enters the class body this access may itself be inside of
+            mentions_typevar && typevar.variance(db) != TypeVarVariance::Invariant
+        })
+        .collect();
+    if substituted.is_empty() {
+        return None;
+    }
+
+    Some(PrivateMemberView {
+        own_view,
+        declared_ty,
+        substituted,
+    })
+}

--- a/docs/basedpython/features/safe-variance.md
+++ b/docs/basedpython/features/safe-variance.md
@@ -9,7 +9,7 @@ class A[out T]:
     private t: T      # mutable field under `out T` — sound because it is private
 
     def f(self, other: A[object]):
-        other.t = 1   # error: `int` is not a `T`
+        other.t = 1   # error: a widened view cannot write what it cannot see
 ```
 
 a [covariant](variance.md) type parameter (`out T`) is only sound while `T`
@@ -31,10 +31,11 @@ checker leans on this in three places
 ## private members do not specialize
 
 a private member is invisible outside its class, so a *widened* view of the
-class learns nothing about it. that is the whole rule: through any receiver but
-the class's own, a private member keeps its declared type instead of picking up
-the receiver's type arguments. a write has to supply a real `T`, and a read gets
-back only what such a view actually knows — `T`'s bound
+class learns nothing about it. that is the whole rule: a private member keeps
+its declared type instead of picking up the receiver's type arguments, and
+through any receiver but the class's own — anything that is not the `self` the
+body was handed — that type is erased to what such a view actually knows. a
+read gets back `T`'s bound; a write is accepted from nothing
 
 ```by
 class A[out T]:
@@ -47,37 +48,49 @@ class A[out T]:
         reveal_type(self.t)    # T@A — `self` carries `A`'s own parameter
         reveal_type(other.t)   # object — a widened view knows only the bound
 
-        other.t = t            # ok — a real `T`
-        other.t = 1            # error: `int` is not a `T`
+        other.t = 1            # error: nothing is assignable to `Never`
+        other.t = t            # error: `self`'s `T` is not `other`'s
         self.t = other.t       # error: `object` is not a `T`
 ```
 
-nothing here needs its own diagnostic. the member's type simply never picks up
-`object`, so an ordinary assignability check does the work, and the erased read
-cannot be funnelled back into `T`-typed storage — which is the only operation
-that could corrupt the field
+storage is invariant in its own type, so a write has to be valid for whatever
+the object really holds — and a widened view does not know. not even a real `T`
+gets through: the `T` the body is written against belongs to `self`, and says
+nothing about the parameter `other` is hiding. the write type is the erasure's
+*bottom* materialization, `Never`, the same one a `private def consume(self, t: T)`
+reached through a widened view takes
 
-an explicitly widened `self` is a widened view like any other, but it is still a
-receiver you may write a `T` to:
+nothing here needs its own diagnostic. the member's type simply never picks up
+the receiver's argument, so an ordinary assignability check does the work, and
+the erased read cannot be funnelled back into `T`-typed storage — which is the
+only operation that could corrupt the field
+
+writing to a private member is a thing you do through `self`, and `self` is
+never a widened view of its own class, whatever it is annotated as — it is
+bound to the receiver the call site had, so `A`'s type parameters are that
+receiver's. through it the member keeps its declared type, un-erased:
 
 ```by
 class A[out T]:
     private t: T
 
     def f(self: A[object], t: T):   # the `t: T` parameter is reported, as above
-        self.t = t             # ok — `t` is a real `T`
+        reveal_type(self.t)    # T@A — not `object`, however `self` is annotated
+        self.t = t             # ok — a real `T`
         self.t = "asdf"        # error: `str` is not a `T`
 ```
 
-and so is a construction: inside `A`'s own body `A()` is an `A[Unknown]`, not
-the `A[T]` the body is written against
+a `Self` or `A[T]` parameter next to `self` is the class's own view for the same
+reason — it carries the class's own arguments. a *construction* is not: inside
+`A`'s own body `A()` is an `A[Unknown]`, not the `A[T]` the body is written
+against
 
 ```by
 class A[T]:
     private t: T
 
     def f(self):
-        A().t = 1              # error: `int` is not a `T`
+        A().t = 1              # error: `A()` is not the `A[T]` we are inside
 ```
 
 without this rule the field would have to be invariant (`A[int]` not
@@ -107,8 +120,9 @@ erasure applies to a private *method*: a `private def consume(self, t: T)`
 reached through a widened view takes a `Never`, so nothing can be passed to it,
 while a `private def produce(self) -> T` still returns the bound
 
-the erasure is the type's top materialization, not a naive swap of the bound, so
-it stays sound where the parameter is nested in an invariant position:
+the erasure is a materialization of the type — the top for a read, the bottom
+for a write — not a naive swap of the bound, so it stays sound where the
+parameter is nested in an invariant position:
 
 ```by
 class A[T]:
@@ -117,6 +131,11 @@ class A[T]:
 def f(a: A[int]):
     reveal_type(a.items)       # list[*]
 ```
+
+neither materialization can say more than "some list" about an invariant
+occurrence, so `list[T]` erases to a gradual element either way: an `a.items`
+write is neither precise nor rejected, exactly as a read of `a.items[0]` is
+neither
 
 ### an invariant type parameter specializes as usual
 
@@ -242,8 +261,8 @@ not part of the type's observable interface, so:
 
 1. it may be a mutable field under `out T`, because a widened view of the class
     never learns what its type parameter is — the member does not specialize, so
-    only a real `T` can be written to it and only the bound can be read back
-    (section 1)
+    only the bound can be read back through such a view and nothing at all can
+    be written (section 1)
 1. it may be the sink for a `SafeVariance[T]` parameter's value — except the
     body is handed only the bound, so the sink stays unreachable in practice
     (section 2)


### PR DESCRIPTION
the write requirement was computed against the class's own view, so the `T` an enclosing class body holds satisfied it — `a = A[object](); a.t = t` passed even though `a`'s parameter has nothing to do with `self`'s. a write is now the erasure's bottom materialization, the dual of the erased read
