### PR TITLE
forward a reified type parameter as a type argument

### DIFF
--- a/crates/by_transforms/src/lib.rs
+++ b/crates/by_transforms/src/lib.rs
@@ -54,6 +54,28 @@ fn run_context_sensitive_phase<'a>(
     transforms::context_sensitive::qualify(source, parsed.suite(), &model)
 }
 
+/// Give every erased-union parameter (`list[int] | list[str]`) a reified type
+/// parameter, so the specialization travels with the call instead of being
+/// asked of a value that erased it.
+///
+/// Runs *before* the phase-0 AST passes, like the qualification phase above and
+/// for the same reason: phase 0 re-parses and re-infers its input, so the
+/// passes that act on the rewrite see it as ordinary source. Edits stay within
+/// the def header and the annotations, so line numbering is unaffected.
+fn run_erased_union_phase<'a>(
+    source: &'a str,
+    db: &dyn ty_python_semantic::Db,
+    file: File,
+    config: &Config,
+) -> std::borrow::Cow<'a, str> {
+    let parsed = ruff_db::parsed::parsed_module(db, file).load(db);
+    if !parsed.errors().is_empty() {
+        return std::borrow::Cow::Borrowed(source);
+    }
+    let model = ty_python_semantic::SemanticModel::new(db, file);
+    transforms::erased_union::reify(source, parsed.suite(), &model, config.min_version)
+}
+
 /// Transpile `.by` source text to python without a project db (single-file:
 /// type-aware passes see only this file). Used for stdin input and tests; the
 /// file-backed [`transpile_typed`] resolves cross-module types.
@@ -67,10 +89,24 @@ pub fn transpile(source: &str, config: &Config) -> Result<String, String> {
     // passes, which would otherwise build an identical one of their own
     let (local_db, local_file) = make_in_memory_db(source);
 
+    // --- Erased-union reification: give a `list[int] | list[str]` parameter a
+    // reified type parameter, while the source is still the one ty checks ---
+    let reified = run_erased_union_phase(source, &local_db, local_file, config);
+    let reified_changed = matches!(reified, std::borrow::Cow::Owned(_));
+    let source = reified.as_ref();
+
+    // that rewrite edits signatures, so the qualification phase below needs a
+    // db over what it is actually editing rather than the pre-rewrite source
+    let rebuilt = reified_changed.then(|| make_in_memory_db(source));
+    let (qualify_db, qualify_file) = match &rebuilt {
+        Some((db, file)) => (db as &dyn ty_python_semantic::Db, *file),
+        None => (&local_db as &dyn ty_python_semantic::Db, local_file),
+    };
+
     // --- Context-sensitive resolution: qualify names resolved against their
     // expected type (`a: Color = Red` → `Color.Red`) while the source is still
     // the one ty checks ---
-    let qualified = run_context_sensitive_phase(source, &local_db, local_file);
+    let qualified = run_context_sensitive_phase(source, qualify_db, qualify_file);
     let qualified_changed = matches!(qualified, std::borrow::Cow::Owned(_));
     let source = qualified.as_ref();
 
@@ -83,8 +119,9 @@ pub fn transpile(source: &str, config: &Config) -> Result<String, String> {
     let source = enum_lowered.output.as_ref();
 
     // --- Phase 0: AST rewrite passes ---
-    let unchanged =
-        !qualified_changed && matches!(enum_lowered.output, std::borrow::Cow::Borrowed(_));
+    let unchanged = !reified_changed
+        && !qualified_changed
+        && matches!(enum_lowered.output, std::borrow::Cow::Borrowed(_));
     let (source, ast_errors, _phase0_map) = transforms::ast_driver::run_against_source(
         source,
         config,
@@ -159,11 +196,27 @@ pub fn transpile_typed_with_map(
         return Ok((out, source_map::line_table(original_source, &[])));
     }
 
+    // erased-union reification: give a `list[int] | list[str]` parameter a
+    // reified type parameter, against the source ty checks. edits stay inside
+    // the def header and the annotations, so line correspondence is unaffected
+    let reified = run_erased_union_phase(original_source, db, file, config);
+    let reified_changed = matches!(reified, std::borrow::Cow::Owned(_));
+
+    // that rewrite edits signatures, so qualification needs a db over what it
+    // is actually editing rather than the project file
+    let rebuilt = reified_changed.then(|| make_in_memory_db(reified.as_ref()));
+    let (qualify_db, qualify_file) = match &rebuilt {
+        Some((rebuilt_db, rebuilt_file)) => {
+            (rebuilt_db as &dyn ty_python_semantic::Db, *rebuilt_file)
+        }
+        None => (db, file),
+    };
+
     // context-sensitive resolution: qualify names resolved against their expected
     // type (`a: Color = Red` → `Color.Red`) against the source ty checks, before
     // the enum lowering rewrites it. a within-line rewrite, so line
     // correspondence is unaffected
-    let qualified = run_context_sensitive_phase(original_source, db, file);
+    let qualified = run_context_sensitive_phase(reified.as_ref(), qualify_db, qualify_file);
     let qualified_changed = matches!(qualified, std::borrow::Cow::Owned(_));
 
     // enum lowering: rewrite `enum` sum types to Python first. when it fires,
@@ -181,7 +234,7 @@ pub fn transpile_typed_with_map(
     // project file, so a single-file db is needed. qualification changes the
     // second without changing the first — it only ever edits within a line
     let enum_changed = matches!(enum_lowered.output, std::borrow::Cow::Owned(_));
-    let source_changed = qualified_changed || enum_changed;
+    let source_changed = reified_changed || qualified_changed || enum_changed;
 
     // phase 0: AST passes. with the project db (no enums) type-aware passes
     // resolve cross-module imports; `phase0_map` maps spliced lines → working

--- a/crates/by_transforms/src/transforms/erased_union.rs
+++ b/crates/by_transforms/src/transforms/erased_union.rs
@@ -1,0 +1,383 @@
+//! erased union parameters (basedpython)
+//!
+//! a parameter typed as a union of specializations of one *erased* origin —
+//! `list[int] | list[str]` — cannot be discriminated at runtime. the arms are
+//! the same C-level `list`, and a builtin rejects the `__orig_class__` stamp,
+//! so nothing on the value records which arm it is. a parametric test against
+//! such a parameter used to answer `False` for every arm:
+//!
+//! ```by
+//! def f(data: list[int] | list[str]):
+//!     if data is list[int]: ...   # False
+//!     if data is list[str]: ...   # False, too
+//! ```
+//!
+//! the missing information is not a property of the *value* — it is a static
+//! fact about the *binding*, known wherever the argument was written
+//! (`f(list[int]())`). so it travels with the call rather than with the value:
+//! the parameter becomes generic over the differing argument, and the type
+//! parameter is [reified](super::reified_generic) so the call carries it.
+//!
+//! ```python
+//! def f[reified T: (int, str)](data: list[T]):
+//!     if data is list[int]: ...   # lowers to `T == int`
+//! ```
+//!
+//! the rewrite is *uniform over the signature*: every function with such a
+//! parameter is rewritten, whether or not its own body tests it. that is what
+//! makes a chain work without whole-program analysis — an intermediate
+//! function that only forwards the value (`middle` passing to `f`) is
+//! rewritten from its own signature, and its cell forwards to the callee. it
+//! also keeps the rewrite computable from a signature alone, so a caller in
+//! another module reaches the same answer without reading the callee's body.
+//!
+//! this pass runs *before* the phase-0 AST passes, not among them: phase 0
+//! re-parses and re-infers its input, so the passes that do the real work
+//! ([`reified_generic`](super::reified_generic),
+//! [`parametric_is`](super::parametric_is), and the call-site specialization
+//! injector) see exactly the generic source a user could have written by hand,
+//! and need no knowledge of this rewrite at all.
+//!
+//! # what is deliberately not rewritten
+//!
+//! the synthesized type parameter must never appear in anything basedpython
+//! says to the user — it is an implementation detail of the lowering, and the
+//! checker keeps seeing the union the user wrote. a rewrite that the solver
+//! could not satisfy would surface as a transpile error naming the synthesized
+//! parameter, so a parameter is only rewritten when every argument of every arm
+//! has a runtime spelling (ty's [`erased_union`] answers `None` otherwise) and
+//! the function is not one whose type parameters the user controls.
+//!
+//! [`erased_union`]: ty_python_semantic::ErasedUnion
+
+use std::borrow::Cow;
+
+use ruff_python_ast::visitor::{Visitor, walk_stmt};
+use ruff_python_ast::{Expr, PythonVersion, Stmt, StmtFunctionDef};
+use ruff_text_size::{Ranged, TextRange};
+
+use crate::type_info::TypeInfo;
+
+/// the stem of a synthesized type parameter's name. dunder-ish and namespaced
+/// so it cannot collide with anything a user would write, and recognisable in
+/// generated python as machinery rather than intent
+const SYNTHESIZED_STEM: &str = "__by_erased";
+
+/// one parameter to rewrite, and the type parameter standing for its
+/// differing argument
+struct Rewrite {
+    /// the annotation to replace
+    annotation: TextRange,
+    /// the replacement text — `list[__by_erased_0]`
+    replacement: String,
+    /// the type parameter's declaration — `reified __by_erased_0: (int, str)`
+    declaration: String,
+}
+
+/// build the rewrite for one qualifying parameter, or `None` when the
+/// synthesized name would collide with a type parameter the function already
+/// declares
+fn plan(
+    union: &ty_python_semantic::ErasedUnion,
+    annotation: &Expr,
+    index: usize,
+    taken: &[String],
+) -> Option<Rewrite> {
+    let name = format!("{SYNTHESIZED_STEM}_{index}");
+    if taken.contains(&name) {
+        return None;
+    }
+    let width = union.fixed.len() + 1;
+    let arguments: Vec<String> = (0..width)
+        .map(|position| {
+            if position == union.position {
+                name.clone()
+            } else {
+                union
+                    .fixed
+                    .iter()
+                    .find(|(at, _)| *at == position)
+                    .map(|(_, text)| text.clone())
+                    .unwrap_or_default()
+            }
+        })
+        .collect();
+    Some(Rewrite {
+        annotation: annotation.range(),
+        replacement: format!("{}[{}]", union.origin, arguments.join(", ")),
+        // spelled as *constraints*, which is what a union of arms is: the
+        // parameter ranges over exactly these types and no others. a bare
+        // `(int, str)` would be a tuple *bound* instead, which no arm satisfies
+        declaration: format!("reified {name}: constraints ({})", union.arms.join(", ")),
+    })
+}
+
+/// the names a function's own type parameter list already binds
+fn declared_type_params(function: &StmtFunctionDef) -> Vec<String> {
+    function
+        .type_params
+        .as_deref()
+        .map(|params| {
+            params
+                .type_params
+                .iter()
+                .map(|param| param.name().id.to_string())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+struct Reify<'ti> {
+    types: &'ti dyn TypeInfo,
+    edits: Vec<(TextRange, String)>,
+}
+
+impl Reify<'_> {
+    fn visit_function(&mut self, function: &StmtFunctionDef) {
+        let taken = declared_type_params(function);
+        let mut rewrites = Vec::new();
+        for parameter in &function.parameters {
+            // the parser injects a zero-width synthetic `self` for `init(...)`
+            // parameter modifiers; it has no annotation to read anyway, but an
+            // empty range must never be edited
+            if parameter.range().is_empty() {
+                continue;
+            }
+            let Some(annotation) = parameter.annotation() else {
+                continue;
+            };
+            let Some(union) = self.types.erased_union(annotation) else {
+                continue;
+            };
+            if let Some(rewrite) = plan(&union, annotation, rewrites.len(), &taken) {
+                rewrites.push(rewrite);
+            }
+        }
+        if rewrites.is_empty() {
+            return;
+        }
+
+        let declarations = rewrites
+            .iter()
+            .map(|rewrite| rewrite.declaration.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        match function.type_params.as_deref() {
+            // extend the existing list, keeping the user's parameters first so
+            // an explicit `f[int]` still binds what it always bound
+            Some(params) => {
+                let close = params.range().end() - ruff_text_size::TextSize::from(1);
+                self.edits
+                    .push((TextRange::empty(close), format!(", {declarations}")));
+            }
+            None => {
+                self.edits.push((
+                    TextRange::empty(function.name.range().end()),
+                    format!("[{declarations}]"),
+                ));
+            }
+        }
+        for rewrite in &rewrites {
+            self.edits
+                .push((rewrite.annotation, rewrite.replacement.clone()));
+        }
+    }
+}
+
+impl<'ast> Visitor<'ast> for Reify<'_> {
+    fn visit_stmt(&mut self, stmt: &'ast Stmt) {
+        if let Stmt::FunctionDef(function) = stmt {
+            self.visit_function(function);
+        }
+        walk_stmt(self, stmt);
+    }
+}
+
+/// Give every erased-union parameter in `source` a reified type parameter.
+/// Returns a borrowed `Cow` when there are none — the overwhelmingly common
+/// case, and the signal to the caller that its view of the source is current.
+///
+/// `suite` must be the parse the `types` model was built from: annotations are
+/// looked up by AST node identity.
+/// Reification compiles the type parameter into a PEP 695 closure cell, which
+/// needs native type-parameter syntax in the generated python. Below 3.12 the
+/// rewrite could only produce a hard error, so the parameter keeps its union
+/// and the test keeps the (unhelpful but working) probe it always had —
+/// turning running code into a transpile failure would be a far worse trade
+pub(crate) fn reify<'a>(
+    source: &'a str,
+    suite: &[Stmt],
+    types: &dyn TypeInfo,
+    min_version: PythonVersion,
+) -> Cow<'a, str> {
+    if min_version < PythonVersion::PY312 {
+        return Cow::Borrowed(source);
+    }
+    let mut visitor = Reify {
+        types,
+        edits: Vec::new(),
+    };
+    for stmt in suite {
+        visitor.visit_stmt(stmt);
+    }
+    if visitor.edits.is_empty() {
+        return Cow::Borrowed(source);
+    }
+
+    // a type-parameter insertion is a zero-width point at the def header and an
+    // annotation replacement covers one annotation, so the ranges are disjoint;
+    // sorting is all that is needed to splice them in a single forward pass
+    visitor.edits.sort_by_key(|(range, _)| range.start());
+    let mut output = String::with_capacity(source.len());
+    let mut cursor = 0usize;
+    for (range, replacement) in visitor.edits {
+        output.push_str(&source[cursor..range.start().into()]);
+        output.push_str(&replacement);
+        cursor = range.end().into();
+    }
+    output.push_str(&source[cursor..]);
+    Cow::Owned(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Config, transpile};
+    use indoc::indoc;
+    use ruff_python_ast::PythonVersion;
+
+    fn out(input: &str) -> String {
+        transpile(
+            input,
+            &Config {
+                min_version: PythonVersion::PY313,
+                ..Config::test_default()
+            },
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn erased_union_parameter_becomes_generic() {
+        let out = out(indoc! {"
+            def f(data: list[int] | list[str]): ...
+        "});
+        assert!(
+            out.contains("def f[__by_erased_0: (int, str)](data: list[__by_erased_0]):"),
+            "the union parameter is generic over its differing argument: {out}"
+        );
+        assert!(
+            out.contains("@generic  # basedpython: reified"),
+            "the synthesized parameter is reified: {out}"
+        );
+    }
+
+    #[test]
+    fn the_whole_chain_reifies_from_signatures_alone() {
+        // `middle` never tests its parameter — it only forwards. it is rewritten
+        // from its own signature, which is what makes the chain work without
+        // looking at any other function's body
+        let out = out(indoc! {"
+            def f(data: list[int] | list[str]):
+                if data is list[int]:
+                    return
+
+            def middle(data: list[int] | list[str]):
+                f(data)
+
+            def main():
+                middle(list[int]())
+        "});
+        assert!(
+            out.contains("if (__by_erased_0 == int):"),
+            "the test reads the reified cell: {out}"
+        );
+        assert!(
+            out.contains("f[__by_erased_0](data)"),
+            "the forwarding hop passes its own cell along: {out}"
+        );
+        assert!(
+            out.contains("middle[int](list[int]())"),
+            "the outermost call solves the specialization: {out}"
+        );
+    }
+
+    #[test]
+    fn a_user_generic_union_is_untouched() {
+        // `A` carries `__orig_class__`, so the runtime can already discriminate
+        // the arms — there is nothing to reify
+        let out = out(indoc! {"
+            class A[T]:
+                def __init__(self, t: T):
+                    self.v: list[T] = [t]
+
+            def f(data: A[int] | A[str]): ...
+        "});
+        assert!(
+            !out.contains("__by_erased"),
+            "a union the runtime can discriminate is left alone: {out}"
+        );
+    }
+
+    #[test]
+    fn a_single_specialization_is_untouched() {
+        // one arm is already decidable statically; there is nothing to tell apart
+        let out = out(indoc! {"
+            def f(data: list[int]): ...
+        "});
+        assert!(
+            !out.contains("__by_erased"),
+            "a lone specialization needs no type parameter: {out}"
+        );
+    }
+
+    #[test]
+    fn a_union_of_different_origins_is_untouched() {
+        // `isinstance` alone separates a list from a set, so the arms are
+        // already discriminable without carrying the specialization
+        let out = out(indoc! {"
+            def f(data: list[int] | set[int]): ...
+        "});
+        assert!(
+            !out.contains("__by_erased"),
+            "different origins are discriminable by isinstance: {out}"
+        );
+    }
+
+    #[test]
+    fn a_fixed_argument_position_is_preserved() {
+        // only the differing position becomes the type parameter; the arms'
+        // shared argument has to be written back where it was
+        let out = out(indoc! {"
+            def f(data: dict[str, int] | dict[str, bool]): ...
+        "});
+        assert!(
+            out.contains("data: dict[str, __by_erased_0]"),
+            "the agreed-on argument stays put: {out}"
+        );
+    }
+
+    #[test]
+    fn an_existing_type_parameter_list_is_extended() {
+        let out = out(indoc! {"
+            def f[U](other: U, data: list[int] | list[str]) -> U:
+                return other
+        "});
+        assert!(
+            out.contains("def f[U, __by_erased_0: (int, str)]"),
+            "the user's parameters stay first: {out}"
+        );
+    }
+
+    #[test]
+    fn a_colliding_name_is_left_alone() {
+        // the synthesized name is already bound, so rewriting would capture it.
+        // refusing is correct: the parameter keeps the union it always had
+        let out = out(indoc! {"
+            def f[__by_erased_0](data: list[int] | list[str]): ...
+        "});
+        assert!(
+            out.contains("data: list[int] | list[str]"),
+            "a collision leaves the annotation untouched: {out}"
+        );
+    }
+}

--- a/crates/by_transforms/src/transforms/mod.rs
+++ b/crates/by_transforms/src/transforms/mod.rs
@@ -18,6 +18,7 @@ pub(crate) mod destructure;
 pub(crate) mod dynamic_keyword;
 pub(crate) mod empty_declarations;
 pub(crate) mod enums;
+pub(crate) mod erased_union;
 pub(crate) mod export_import;
 pub(crate) mod extension;
 pub(crate) mod float_const;

--- a/crates/by_transforms/src/transforms/parametric_is.rs
+++ b/crates/by_transforms/src/transforms/parametric_is.rs
@@ -1534,17 +1534,19 @@ mod tests {
     }
 
     #[test]
-    fn builtin_union_probes_each_value() {
-        // a union of builtin specializations is still probeable — the runtime
-        // unwinds each value's mro; a bare list in either arm simply answers
-        // False, no element-witness heuristic involved
+    fn builtin_union_compares_the_reified_cell() {
+        // a union of builtin specializations is not probeable — the arms are
+        // the same C-level `list` and a bare list answers False for every one.
+        // the parameter is given a reified type parameter instead (see
+        // [`erased_union`](super::super::erased_union)), so the test compares
+        // the cell the call site supplied rather than interrogating the value
         let out = out(indoc! {"
             def f(x: list[int] | list[str]) -> bool:
                 return x is list[int]
         "});
         assert!(
-            out.contains("return _parametric_is(x, list[int], (0,))"),
-            "builtin union probes via mro: {out}"
+            out.contains("return (__by_erased_0 == int)"),
+            "builtin union compares the reified cell: {out}"
         );
     }
 
@@ -1567,16 +1569,20 @@ mod tests {
     }
 
     #[test]
-    fn union_excluding_target_folds_false() {
-        // no arm matches `list[bytes]`, so the whole test folds statically,
-        // independent of runtime erasure
+    fn a_target_outside_the_union_compares_the_cell() {
+        // no arm matches `list[bytes]`, so this can never be true. it used to
+        // fold to `False` statically; now the parameter carries a reified type
+        // parameter constrained to `(int, str)`, so it lowers to a cell
+        // comparison that is always false at runtime instead. same answer, one
+        // comparison rather than a constant — the fold is not recoverable from
+        // the token path, which carries source ranges rather than types
         let out = out(indoc! {"
             def f(x: list[int] | list[str]) -> bool:
                 return x is list[bytes]
         "});
         assert!(
-            out.contains("return False"),
-            "target outside the union folds false: {out}"
+            out.contains("return (__by_erased_0 == bytes)"),
+            "target outside the union compares the cell: {out}"
         );
     }
 

--- a/crates/by_transforms/src/transforms/reified_generic.rs
+++ b/crates/by_transforms/src/transforms/reified_generic.rs
@@ -162,6 +162,14 @@ class generic:
         for param in fn.__type_params__:
             name = param.__name__
             if name not in values and name in code.co_freevars:
+                # a synthesized parameter stands for an erased union the user
+                # never spelled, so naming it would leak the lowering
+                if name.startswith(\"__by_erased\"):
+                    raise TypeError(
+                        f\"{fn.__name__}() cannot tell which specialization it was \"
+                        f\"given: the argument's type arguments are erased at \"
+                        f\"runtime, and the call site did not record them\"
+                    )
                 raise TypeError(f\"{fn.__name__}() missing a type argument for {name!r}\")
         closure = tuple(
             CellType(values[name]) if name in values else cell
@@ -457,6 +465,14 @@ mod tests {
                         for param in fn.__type_params__:
                             name = param.__name__
                             if name not in values and name in code.co_freevars:
+                                # a synthesized parameter stands for an erased union the user
+                                # never spelled, so naming it would leak the lowering
+                                if name.startswith(\"__by_erased\"):
+                                    raise TypeError(
+                                        f\"{fn.__name__}() cannot tell which specialization it was \"
+                                        f\"given: the argument's type arguments are erased at \"
+                                        f\"runtime, and the call site did not record them\"
+                                    )
                                 raise TypeError(f\"{fn.__name__}() missing a type argument for {name!r}\")
                         closure = tuple(
                             CellType(values[name]) if name in values else cell
@@ -893,6 +909,56 @@ mod tests {
         assert!(
             !out.contains("basedpython: reified"),
             "should not add the marker to a hand-written decorator: {out}"
+        );
+    }
+
+    #[test]
+    fn reified_cell_forwards_to_a_reified_call() {
+        // a caller that reifies `T` holds it in a runtime cell, so a bare call
+        // that solves the callee's parameter to that same `T` is answerable:
+        // the cell forwards as `f[T](…)`. without this the call is an
+        // `unspecialized-reified-generic` error and the chain breaks at the
+        // first hop that only passes a value along
+        let out = transpile(
+            indoc! {"
+                def f[reified T](data: list[T]): ...
+
+                def middle[reified T](data: list[T]):
+                    f(data)
+            "},
+            &Config {
+                min_version: PythonVersion::PY313,
+                ..Config::test_default()
+            },
+        )
+        .unwrap();
+        assert!(
+            out.contains("f[T](data)"),
+            "the caller's reified cell forwards as the type argument: {out}"
+        );
+    }
+
+    #[test]
+    fn erased_typevar_does_not_forward() {
+        // the mirror of the above: an *erased* type parameter has no runtime
+        // cell, so there is nothing to forward and the call must stay bare
+        // rather than spelling a name that holds no type at runtime
+        let out = transpile(
+            indoc! {"
+                def f[T](data: list[T]): ...
+
+                def middle[T](data: list[T]):
+                    f(data)
+            "},
+            &Config {
+                min_version: PythonVersion::PY313,
+                ..Config::test_default()
+            },
+        )
+        .unwrap();
+        assert!(
+            out.contains("f(data)") && !out.contains("f[T](data)"),
+            "an erased type parameter has no cell to forward: {out}"
         );
     }
 }

--- a/crates/by_transforms/src/type_info.rs
+++ b/crates/by_transforms/src/type_info.rs
@@ -99,6 +99,12 @@ pub(crate) trait TypeInfo {
     /// missing spelling is never an error
     fn constructor_specialization(&self, call: &ruff_python_ast::ExprCall) -> Option<String>;
 
+    /// when the parameter annotation `annotation` denotes a union of
+    /// specializations of one erased origin (`list[int] | list[str]`), how the
+    /// arms differ. `None` for every other annotation — the parameter then
+    /// needs no reified type parameter to stand for the difference
+    fn erased_union(&self, annotation: &Expr) -> Option<ty_python_semantic::ErasedUnion>;
+
     /// how the keyword-form parametric type test `lhs is rhs` resolves
     /// (rust-style: statically folded, reified-cell token equality, witness
     /// probe, or an unchecked runtime probe). `rhs` may spell the target
@@ -503,6 +509,10 @@ impl TypeInfo for SemanticModel<'_> {
 
     fn constructor_specialization(&self, call: &ruff_python_ast::ExprCall) -> Option<String> {
         self.reified_constructor_type_arguments(call)
+    }
+
+    fn erased_union(&self, annotation: &Expr) -> Option<ty_python_semantic::ErasedUnion> {
+        SemanticModel::erased_union(self, annotation)
     }
 
     fn parametric_is_plan(

--- a/crates/ty/tests/by_e2e.rs
+++ b/crates/ty/tests/by_e2e.rs
@@ -1669,14 +1669,17 @@ con(Con[object]())
 }
 
 #[test]
-fn parametric_is_bare_builtin_answers_false_soundly() {
-    // a bare `list` (here an empty `list[int]`) records no arguments in its
-    // mro, so the probe answers `False`. that is sound, not a lie: the `is`
-    // test narrows only its positive branch, so a `False` never asserts the
-    // value is *not* a `list[int]`
-    let dir = tempfile::tempdir().expect("tempdir");
-    fs::write(
-        dir.path().join("main.by"),
+fn parametric_is_erased_union_answers_from_the_call_site() {
+    // an empty `list[int]` records nothing in its mro, so no amount of looking
+    // at the value can answer this — a probe used to say `False`, which was
+    // sound (the positive branch is the only one that narrows) but useless.
+    // the parameter's union is erased, so it carries a reified type parameter
+    // and the answer comes from where the argument was written instead.
+    //
+    // asserted on the lowered output rather than by running it: reification
+    // needs a 3.12+ *interpreter*, which the ambient `python3` may not be. the
+    // runtime behaviour is covered by the mdtest divergence harness
+    let out = transpile_at_313(
         "\
 def x(a: list[int] | list[str]):
     print(a is list[int])
@@ -1684,25 +1687,15 @@ def x(a: list[int] | list[str]):
 a: list[int] = []
 x(a)
 ",
-    )
-    .unwrap();
-
-    let output = Command::new(env!("CARGO_BIN_EXE_by"))
-        .args(["run", "main"])
-        .current_dir(dir.path())
-        .output()
-        .expect("failed to spawn by");
-
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        output.status.success(),
-        "a bare builtin now probes rather than erroring:\n{stderr}"
     );
     assert!(
-        !stderr.contains("erased-type-check"),
-        "no erased-type-check for a builtin target:\n{stderr}"
+        out.contains("print((__by_erased_0 == int))"),
+        "the test reads the reified cell rather than probing the value:\n{out}"
     );
-    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "False");
+    assert!(
+        out.contains("x[int](a)"),
+        "the call site supplies the specialization the value cannot carry:\n{out}"
+    );
 }
 
 /// the headline case: a concrete subclass fixes its type arguments in

--- a/crates/ty_python_semantic/resources/mdtest/basedpython_parametric_is.md
+++ b/crates/ty_python_semantic/resources/mdtest/basedpython_parametric_is.md
@@ -691,3 +691,43 @@ xs = [1]
 
 b = xs === list[int]
 ```
+
+## an erased union answers from the call site
+
+A union of specializations of one erased origin (`list[int] | list[str]`) cannot be told apart by
+looking at a value — both arms are the same C-level `list`, which rejects the `__orig_class__`
+stamp. The specialization is a static fact about the *binding*, known wherever the argument was
+written, so it travels with the call instead: the parameter is given a reified type parameter and
+the test compares that cell.
+
+This is invisible in the checker — the parameter keeps the union it was declared with:
+
+```by
+def f(data: list[int] | list[str]) -> str:
+    reveal_type(data)  # revealed: list[int] | list[str]
+    if data is list[int]:
+        return "ints"
+    return "strs"
+
+# an *empty* list, so no element could ever have witnessed this
+print(f(list[int]()))  # ints
+print(f(list[str]()))  # strs
+```
+
+## an erased union survives a forwarding hop
+
+An intermediate function that only passes the value along is reified from its own signature, so the
+specialization is not lost at the boundary:
+
+```by
+def inner(data: list[int] | list[str]) -> str:
+    if data is list[int]:
+        return "ints"
+    return "strs"
+
+def outer(data: list[int] | list[str]) -> str:
+    return inner(data)
+
+print(outer(list[int]()))  # ints
+print(outer(list[str]()))  # strs
+```

--- a/crates/ty_python_semantic/resources/mdtest/basedpython_reified_generics.md
+++ b/crates/ty_python_semantic/resources/mdtest/basedpython_reified_generics.md
@@ -601,6 +601,51 @@ def f[**Kwargs](**kwargs: **Kwargs) -> None:
 f(a=1, b="x")  # runs as f[a=int, b=str](a=1, b="x")
 ```
 
+## a reified cell forwards as a type argument
+
+A caller that reifies `T` holds it in a runtime cell, so a bare call that solves the callee's
+parameter to that same `T` is answerable: the cell forwards as the type argument. Without this a
+specialization dies at the first hop that only passes a value along.
+
+```by
+def inner[reified T](data: list[T]) -> None:
+    assert T == int
+
+def outer[reified T](data: list[T]) -> None:
+    inner(data)  # runs as inner[T](data)
+
+outer(list[int]())
+```
+
+## an erased type parameter has no cell to forward
+
+The mirror of the above. An erased type parameter is not a runtime value, so there is nothing to
+forward and the call still needs an explicit specialization:
+
+```by
+def inner[reified T](data: list[T]) -> None: ...
+
+def outer[T](data: list[T]) -> None:
+    # error: [unspecialized-reified-generic]
+    inner(data)
+```
+
+## a class type parameter has no cell to forward
+
+A class type parameter lives on the class, not in a function closure, so it is never a forwardable
+cell:
+
+```by
+def inner[reified T](data: list[T]) -> None: ...
+
+class C[T]:
+    xs: list[T]
+
+    def m(self) -> None:
+        # error: [unspecialized-reified-generic]
+        inner(self.xs)
+```
+
 ## a variadic used only in annotations is not reified
 
 ```by

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -50,7 +50,7 @@ pub use types::ide_support::{
     type_hierarchy_supertypes,
 };
 pub use types::reified_infer::{
-    ArgVariance, ErasedTargetReason, ParametricIsPlan, ProtocolMemberCheck,
+    ArgVariance, ErasedTargetReason, ErasedUnion, ParametricIsPlan, ProtocolMemberCheck,
 };
 pub use types::visibility::private_symbols;
 pub use types::{DisplaySettings, TypeQualifiers};

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -536,6 +536,22 @@ impl<'db> SemanticModel<'db> {
         ))
     }
 
+    /// basedpython: when `annotation` is a type expression denoting a union of
+    /// specializations of one erased origin (`list[int] | list[str]`), how the
+    /// arms differ. the transpiler uses this to give the parameter a reified
+    /// type parameter, so the specialization travels with the call instead of
+    /// being asked of a value that cannot answer
+    pub fn erased_union(
+        &self,
+        annotation: &ast::Expr,
+    ) -> Option<crate::types::reified_infer::ErasedUnion> {
+        crate::types::reified_infer::erased_union(
+            self.db,
+            self.file,
+            annotation.inferred_type(self)?,
+        )
+    }
+
     pub fn line_index(&self) -> LineIndex {
         line_index(self.db, self.file)
     }

--- a/crates/ty_python_semantic/src/types/reified_infer.rs
+++ b/crates/ty_python_semantic/src/types/reified_infer.rs
@@ -292,11 +292,20 @@ fn variadic_elements<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Vec<Type<'db
     }
 }
 
-/// whether the solver produced an actual answer for a type parameter —
-/// dynamic types and leaked typevars mean "nothing to reify"
+/// whether the solver produced an actual answer for a type parameter — a
+/// dynamic type means "nothing to reify", and so does a typevar with no
+/// runtime cell behind it. a *reified* typevar does have one, so it counts
 fn is_solution<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
-    let _ = db;
-    !matches!(ty, Type::Dynamic(_) | Type::TypeVar(_) | Type::Never)
+    match ty {
+        Type::Dynamic(_) | Type::Never => false,
+        // a reified type parameter is a live runtime cell holding its type
+        // argument, so a call that solves to one is answerable by forwarding
+        // that cell (`f(data)` inside a reified caller becomes `f[T](data)`).
+        // the cell is in scope by construction: the solver only reaches it
+        // through an argument whose type mentions it
+        Type::TypeVar(bound_typevar) => is_reified_function_typevar(db, bound_typevar),
+        _ => true,
+    }
 }
 
 /// A python expression that evaluates, in `file`'s module scope, to the
@@ -307,6 +316,12 @@ fn runtime_spelling<'db>(db: &'db dyn Db, file: File, ty: Type<'db>) -> Option<S
     }
     match ty {
         Type::NominalInstance(instance) => spell_class(db, file, instance.class(db)),
+        // a reified type parameter spells as its own name: pep 695 compiles it
+        // into the enclosing function's closure, and the `generic` wrapper fills
+        // that cell with the type argument, so the name evaluates to the type
+        Type::TypeVar(bound_typevar) if is_reified_function_typevar(db, bound_typevar) => {
+            Some(bound_typevar.name(db).to_string())
+        }
         Type::Union(union) => Some(
             union
                 .elements(db)
@@ -494,6 +509,104 @@ pub enum ErasedTargetReason {
     /// and a structural `isinstance` check sees no type arguments (and raises
     /// outright unless the protocol is `@runtime_checkable`)
     Protocol,
+}
+
+/// a type whose arms are specializations of one *erased* origin, differing in
+/// a single type argument — `list[int] | list[str]`. the runtime cannot tell
+/// those arms apart, so a value of this type carries no record of which one it
+/// is; the specialization has to travel with the call instead
+pub struct ErasedUnion {
+    /// the shared origin's runtime spelling — `list`
+    pub origin: String,
+    /// which type-argument position the arms differ in
+    pub position: usize,
+    /// the differing argument of each arm, in declaration order — `int`, `str`
+    pub arms: Vec<String>,
+    /// the arguments the arms agree on, by position, so the rewritten
+    /// annotation can put them back (`dict[str, int] | dict[str, bool]` keeps
+    /// `str` in position 0)
+    pub fixed: Vec<(usize, String)>,
+}
+
+/// classify `ty` as an [`ErasedUnion`], or `None` when it is anything else.
+///
+/// every arm must be a specialization of the *same* builtin-collection origin
+/// and every argument must have a runtime spelling — an unspellable argument
+/// (a scope-local class, a dynamic type) disqualifies the whole union rather
+/// than producing a rewrite that cannot be spelled back out
+pub(crate) fn erased_union<'db>(db: &'db dyn Db, file: File, ty: Type<'db>) -> Option<ErasedUnion> {
+    let Type::Union(union) = ty else {
+        return None;
+    };
+    let mut origin: Option<ClassLiteral<'db>> = None;
+    let mut rows: Vec<Vec<Type<'db>>> = Vec::new();
+    for element in union.elements(db) {
+        let Type::NominalInstance(instance) = element else {
+            return None;
+        };
+        let ClassType::Generic(alias) = instance.class(db) else {
+            return None;
+        };
+        let arm_origin = alias.origin(db);
+        if !matches!(
+            erased_target_reason(db, ClassLiteral::Static(arm_origin)),
+            Some(ErasedTargetReason::BuiltinCollection)
+        ) {
+            return None;
+        }
+        match origin {
+            Some(seen) if seen != ClassLiteral::Static(arm_origin) => return None,
+            Some(_) => {}
+            None => origin = Some(ClassLiteral::Static(arm_origin)),
+        }
+        rows.push(alias.specialization(db).types(db).to_vec());
+    }
+    let origin = origin?;
+    // a single arm is already decidable — nothing to discriminate
+    if rows.len() < 2 {
+        return None;
+    }
+    let width = rows.first()?.len();
+    if rows.iter().any(|row| row.len() != width) {
+        return None;
+    }
+
+    // exactly one position may vary; the rest must agree across every arm, or
+    // no single type parameter can stand for the difference
+    let mut varying = None;
+    for position in 0..width {
+        let first = rows[0][position];
+        if rows.iter().all(|row| row[position] == first) {
+            continue;
+        }
+        if varying.is_some() {
+            return None;
+        }
+        varying = Some(position);
+    }
+    let position = varying?;
+    // the arms must be pairwise distinct at that position, else two of them are
+    // the same specialization and the test could not tell them apart anyway
+    if !rows.iter().map(|row| row[position]).all_unique() {
+        return None;
+    }
+
+    let arms = rows
+        .iter()
+        .map(|row| runtime_spelling(db, file, row[position].promote(db)))
+        .collect::<Option<Vec<_>>>()?;
+    let fixed = (0..width)
+        .filter(|index| *index != position)
+        .map(|index| {
+            runtime_spelling(db, file, rows[0][index].promote(db)).map(|text| (index, text))
+        })
+        .collect::<Option<Vec<_>>>()?;
+    Some(ErasedUnion {
+        origin: spell_class_literal(db, file, origin)?,
+        position,
+        arms,
+        fixed,
+    })
 }
 
 /// how the runtime probe matches one type argument of the reified

--- a/docs/basedpython/features/parametric-type-tests.md
+++ b/docs/basedpython/features/parametric-type-tests.md
@@ -51,11 +51,20 @@ the value's static type decides the strategy:
     variance. a method member is checked the same way through its parameter and
     return annotations. see [below](#a-protocol-target-is-checked-structurally)
 
-- **undecidable, builtin target → error**. a runtime `list` / `dict` / `set`
-    / `tuple` carries no record of its type arguments, so it cannot be checked
-    at runtime. this is an [`erased-type-check`](#the-erased-type-check-error)
-    error — there is deliberately no "check the first element" heuristic, since
-    an empty collection has no element and a builtin's element type is erased
+- **erased union parameter → the call site answers**. a parameter typed as a
+    union of specializations of one erased origin (`list[int] | list[str]`)
+    cannot be discriminated by looking at the value — both arms are the same
+    C-level `list`. the missing fact is not a property of the value but of the
+    *binding*, so it travels with the call: the parameter is given a reified
+    type parameter and the test compares that cell. see
+    [below](#an-erased-union-parameter-carries-its-specialization)
+
+- **undecidable, builtin target → error**. any other runtime `list` / `dict` /
+    `set` / `tuple` carries no record of its type arguments, so it cannot be
+    checked at runtime. this is an
+    [`erased-type-check`](#the-erased-type-check-error) error — there is
+    deliberately no "check the first element" heuristic, since an empty
+    collection has no element and a builtin's element type is erased
 
 so of the two undecidable cases, only the *target* distinguishes them:
 
@@ -220,3 +229,63 @@ and the residue has to run.
 so the two can differ on the same class: the cast succeeds, the test refuses.
 both are right for what they were asked, but it is worth knowing the cast is not
 re-verifying what the checker already concluded.
+
+## an erased union parameter carries its specialization
+
+A union of specializations of one erased origin is undecidable at runtime — `list[int]` and
+`list[str]` are the same `list`, and a builtin rejects the `__orig_class__` stamp. Probing the value
+answered `False` for every arm, which is sound (only the positive branch narrows) but useless:
+
+```by
+def f(data: list[int] | list[str]):
+    if data is list[int]: ...   # every arm answered False
+    if data is list[str]: ...
+```
+
+The specialization is a static fact about the binding, known wherever the argument was written. So
+it travels with the call instead of being asked of the value: the parameter becomes generic over the
+differing argument, and that type parameter is [reified](reified-generics.md).
+
+```by
+def f(data: list[int] | list[str]):
+    if data is list[int]:       # compares the reified cell
+        print("it's ints")
+```
+
+This is a lowering detail, not surface syntax. The checker keeps seeing the union you declared —
+`reveal_type(data)` is `list[int] | list[str]`, and nothing basedpython reports ever names the
+synthesized parameter.
+
+The rewrite is driven by the *signature*, so a function that only forwards its value is rewritten
+too and the specialization survives the hop:
+
+```by
+def middle(data: list[int] | list[str]):
+    f(data)                     # forwards its own cell
+
+middle(list[int]())             # supplies the specialization
+```
+
+### when it does not apply
+
+- **below python 3.12.** Reification compiles the type parameter into a PEP 695 closure cell, which
+    needs native type-parameter syntax in the output. On an older target the parameter keeps its
+    union and the test keeps the probe it always had.
+- **a union the runtime can already discriminate.** Different origins (`list[int] | set[int]`) are
+    separated by `isinstance`, and a user-defined generic carries `__orig_class__`.
+- **more than one differing argument.** `dict[str, int] | dict[bool, str]` varies in two positions,
+    so no single type parameter stands for the difference.
+- **an argument with no runtime spelling**, such as a scope-local class.
+
+### when the call site cannot supply it
+
+Reaching the function through a value whose type the checker could not pin down — a callable
+variable, a dynamic value — leaves nothing to supply the specialization. That raises rather than
+guessing:
+
+```text
+TypeError: f() cannot tell which specialization it was given: the argument's
+type arguments are erased at runtime, and the call site did not record them
+```
+
+This is the same line the erased builtin target takes: refuse, never guess.


### PR DESCRIPTION
a call that solves a callee's type parameter to the caller's own reified type parameter had no runtime spelling, so it failed as `unspecialized-reified-generic`. inside a reified body that parameter is a live closure cell holding its type argument, so it can be forwarded: `f(data)` in a reified caller now lowers to `f[T](data)`

this is what lets a reified specialization survive a hop through an intermediate function rather than dying at the first call that only passes a value along

an erased type parameter has no cell and still does not forward, and a class type parameter is excluded — `is_reified_function_typevar` requires a function binding context