### PR TITLE
added a run.main config option for the project entry point

### DIFF
--- a/crates/ty/docs/cli.md
+++ b/crates/ty/docs/cli.md
@@ -228,12 +228,12 @@ Transpile and run a module with `python -m <module>`
 <h3 class="cli-reference">Usage</h3>
 
 ```
-by run [OPTIONS] <MODULE> [ARGS]...
+by run [OPTIONS] [MODULE] [ARGS]...
 ```
 
 <h3 class="cli-reference">Arguments</h3>
 
-<dl class="cli-reference"><dt id="by-run--module"><a href="#by-run--module"><code>MODULE</code></a></dt><dd><p>module to run (e.g. <code>by run main</code> looks for main.by)</p>
+<dl class="cli-reference"><dt id="by-run--module"><a href="#by-run--module"><code>MODULE</code></a></dt><dd><p>module to run (e.g. <code>by run main</code> looks for main.by) [default: the <code>run.main</code> entry point configured for the project]</p>
 </dd><dt id="by-run--args"><a href="#by-run--args"><code>ARGS</code></a></dt><dd><p>arguments forwarded to the program, as <code>sys.argv[1:]</code></p>
 </dd></dl>
 

--- a/crates/ty/docs/configuration.md
+++ b/crates/ty/docs/configuration.md
@@ -1378,6 +1378,42 @@ def narrow_match(x: str) -> None:
 
 ---
 
+## `run`
+
+### `main`
+
+The module `by run` executes when no module is given on the command line.
+
+This is the project's entry point: with it set, `by run` alone transpiles the project and
+runs `python -m <main>`, exactly as if the module had been named on the command line. A
+module named explicitly always wins.
+
+The value is a module path, not a file path — `app.cli`, not `app/cli.by`.
+
+Defaults to `null`, in which case `by run` requires a module argument.
+
+**Default value**: `null`
+
+**Type**: `str`
+
+**Example usage**:
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.ty.run]
+    main = "app.cli"
+    ```
+
+=== "ty.toml"
+
+    ```toml
+    [run]
+    main = "app.cli"
+    ```
+
+---
+
 ## `src`
 
 ### `exclude`

--- a/crates/ty/src/args.rs
+++ b/crates/ty/src/args.rs
@@ -68,7 +68,8 @@ pub(crate) enum Command {
     /// Transpile and run a module with `python -m <module>`.
     Run {
         /// module to run (e.g. `by run main` looks for main.by)
-        module: String,
+        /// [default: the `run.main` entry point configured for the project]
+        module: Option<String>,
         /// arguments forwarded to the program, as `sys.argv[1:]`
         #[arg(
             trailing_var_arg = true,

--- a/crates/ty/src/by_commands.rs
+++ b/crates/ty/src/by_commands.rs
@@ -81,7 +81,7 @@ impl LoweringArgs {
 
 #[allow(clippy::exit, clippy::print_stderr)]
 pub(crate) fn cmd_run(
-    module: &str,
+    module: Option<&str>,
     args: &[String],
     min_version: Option<&str>,
     lowering: &LoweringArgs,
@@ -124,6 +124,21 @@ pub(crate) fn cmd_run(
     }
 
     let (db, handles) = build_project_db(&cwd, &files)?;
+
+    // an explicit module always wins; otherwise the project's configured entry
+    // point stands in for it. resolving before the (much slower) check means a
+    // project with neither fails immediately rather than after transpiling
+    let module = match module {
+        Some(module) => module.to_owned(),
+        None => match configured_main(&db) {
+            Some(main) => main,
+            None => anyhow::bail!(
+                "no module given and no entry point configured — \
+                 name a module (`by run main`) or set `run.main` in the project configuration"
+            ),
+        },
+    };
+
     // each generated `.py` paired with its source `.by` and the line table that
     // lifts generated line numbers back to `.by` lines (for traceback rewriting)
     let mut traceback_entries: Vec<TracebackEntry> = Vec::new();
@@ -153,7 +168,7 @@ pub(crate) fn cmd_run(
 
     let status = Command::new(&python)
         .arg(BY_RUNNER_FILENAME)
-        .arg(module)
+        .arg(&module)
         .args(args)
         .current_dir(tmp.path())
         .status()
@@ -164,6 +179,13 @@ pub(crate) fn cmd_run(
     // exiting while it's still in scope would leak the directory
     drop(tmp);
     std::process::exit(code);
+}
+
+/// The project's `run.main` entry point, if one is configured.
+fn configured_main(db: &ProjectDatabase) -> Option<String> {
+    let options = db.project().metadata(db).options();
+    let main = options.run.as_ref()?.main.as_ref()?;
+    Some((**main).clone())
 }
 
 /// Probe `python`'s `major.minor` version (e.g. `3.9`) so `run` can target the

--- a/crates/ty/src/lib.rs
+++ b/crates/ty/src/lib.rs
@@ -84,7 +84,7 @@ where
             args,
             min_version,
             lowering,
-        } => by_commands::cmd_run(&module, &args, min_version.as_deref(), &lowering),
+        } => by_commands::cmd_run(module.as_deref(), &args, min_version.as_deref(), &lowering),
         Command::Build {
             min_version,
             lowering,

--- a/crates/ty/tests/by_e2e.rs
+++ b/crates/ty/tests/by_e2e.rs
@@ -143,6 +143,126 @@ fn run_invokes_async_main_via_asyncio() {
     );
 }
 
+#[test]
+fn run_uses_the_configured_entry_point() {
+    // `run.main` names the module `by run` executes when none is given
+    let dir = tempfile::tempdir().expect("tempdir");
+    fs::write(dir.path().join("ty.toml"), "[run]\nmain = \"app\"\n").unwrap();
+    fs::write(dir.path().join("app.by"), "print('ran the entry point')\n").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_by"))
+        .arg("run")
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to spawn by");
+
+    assert!(
+        output.status.success(),
+        "by run failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "ran the entry point"
+    );
+}
+
+#[test]
+fn run_reads_the_entry_point_from_pyproject() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fs::write(
+        dir.path().join("pyproject.toml"),
+        "[project]\nname = \"demo\"\nversion = \"0.1.0\"\n\n[tool.ty.run]\nmain = \"pkg.cli\"\n",
+    )
+    .unwrap();
+    fs::create_dir(dir.path().join("pkg")).unwrap();
+    fs::write(dir.path().join("pkg/__init__.by"), "").unwrap();
+    fs::write(dir.path().join("pkg/cli.by"), "print('ran pkg.cli')\n").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_by"))
+        .arg("run")
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to spawn by");
+
+    assert!(
+        output.status.success(),
+        "by run failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "ran pkg.cli"
+    );
+}
+
+#[test]
+fn run_prefers_an_explicit_module_over_the_configured_entry_point() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fs::write(dir.path().join("ty.toml"), "[run]\nmain = \"app\"\n").unwrap();
+    fs::write(dir.path().join("app.by"), "print('configured')\n").unwrap();
+    fs::write(dir.path().join("other.by"), "print('explicit')\n").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_by"))
+        .args(["run", "other"])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to spawn by");
+
+    assert!(
+        output.status.success(),
+        "by run failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "explicit");
+}
+
+#[test]
+fn run_forwards_arguments_to_the_named_entry_point() {
+    // arguments belong to the module, so reaching the configured entry point's
+    // parameters means naming it: the first positional is always the module
+    let dir = tempfile::tempdir().expect("tempdir");
+    fs::write(dir.path().join("ty.toml"), "[run]\nmain = \"app\"\n").unwrap();
+    fs::write(
+        dir.path().join("app.by"),
+        "def main(name: str):\n    print(name)\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_by"))
+        .args(["run", "app", "--name", "asdf"])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to spawn by");
+
+    assert!(
+        output.status.success(),
+        "by run failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "asdf");
+}
+
+#[test]
+fn run_without_a_module_or_entry_point_reports_both_ways_out() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fs::write(dir.path().join("main.by"), "print('unreached')\n").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_by"))
+        .arg("run")
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to spawn by");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("no module given and no entry point configured"),
+        "stderr:\n{stderr}"
+    );
+    assert!(stderr.contains("run.main"), "stderr:\n{stderr}");
+}
+
 /// write `source` as `main.by`, run it with `args`, and return
 /// `(stdout, stderr, exit code)`
 fn run_main_with_args(source: &str, args: &[&str]) -> (String, String, i32) {

--- a/crates/ty/tests/cli/config_option.rs
+++ b/crates/ty/tests/cli/config_option.rs
@@ -128,7 +128,7 @@ fn cli_config_args_invalid_option() -> anyhow::Result<()> {
       |
     1 | bad-option=true
       | ^^^^^^^^^^
-    unknown field `bad-option`, expected one of `environment`, `src`, `rules`, `terminal`, `analysis`, `overrides`
+    unknown field `bad-option`, expected one of `environment`, `src`, `rules`, `terminal`, `analysis`, `run`, `overrides`
 
 
     Usage: by <COMMAND>

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -100,6 +100,11 @@ pub struct Options {
     #[option_group]
     pub analysis: Option<AnalysisOptions>,
 
+    /// Configures how `by run` executes the project.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option_group]
+    pub run: Option<RunOptions>,
+
     /// Override configurations for specific file patterns.
     ///
     /// Each override specifies include/exclude patterns and rule configurations
@@ -1456,6 +1461,42 @@ pub struct TerminalOptions {
         "#
     )]
     pub error_on_warning: Option<bool>,
+}
+
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    Eq,
+    PartialEq,
+    Hash,
+    Combine,
+    Serialize,
+    Deserialize,
+    OptionsMetadata,
+    get_size2::GetSize,
+)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct RunOptions {
+    /// The module `by run` executes when no module is given on the command line.
+    ///
+    /// This is the project's entry point: with it set, `by run` alone transpiles the project and
+    /// runs `python -m <main>`, exactly as if the module had been named on the command line. A
+    /// module named explicitly always wins.
+    ///
+    /// The value is a module path, not a file path — `app.cli`, not `app/cli.by`.
+    ///
+    /// Defaults to `null`, in which case `by run` requires a module argument.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"null"#,
+        value_type = "str",
+        example = r#"
+            main = "app.cli"
+        "#
+    )]
+    pub main: Option<RangedValue<String>>,
 }
 
 #[derive(

--- a/docs/basedpython/cli-reference.md
+++ b/docs/basedpython/cli-reference.md
@@ -22,11 +22,23 @@ in addition to the cli provided by `ty`, `by` includes:
 
 ```sh
 by run MODULE [ARGS...]             # transpile + run with `python -m MODULE`
+by run                              # run the configured entry point
 by run MODULE --min-version 3.12    # target a specific runtime python version
 ```
 
 equivalent to `by build && python -m MODULE`, but only transpiles the
 modules required to import `MODULE`
+
+the module can be left out when the project configures an entry point:
+
+```toml
+[tool.ty.run]
+main = "app.cli"
+```
+
+`by run` then runs `app.cli`. a module named on the command line always wins,
+so `by run other` still runs `other`. the first positional argument is always
+the module — to reach the entry point's own arguments, name it: `by run app.cli --name asdf`
 
 everything after `MODULE` is forwarded to the program as `sys.argv[1:]`,
 including options — `by run main --name asdf` passes `--name asdf` on. the one

--- a/docs/basedpython/features/main-function.md
+++ b/docs/basedpython/features/main-function.md
@@ -97,6 +97,19 @@ positional-only parameter is still passed positionally to `main` even when the
 command line named it with `--`, and a keyword-only one never takes a
 positional slot.
 
+## the project entry point
+
+`main` makes a *module* runnable; `run.main` says which module that is for the
+project as a whole:
+
+```toml
+[tool.ty.run]
+main = "app.cli"
+```
+
+`by run` with no module then runs `app.cli`. see the
+[cli reference](../cli-reference.md#by-run)
+
 ## scope
 
 only a *top-level* function named `main` is recognized — a `main` method on a

--- a/docs/basedpython/getting-started.md
+++ b/docs/basedpython/getting-started.md
@@ -29,6 +29,13 @@ by run main
 
 `by run main` finds `main.by` in the current directory, transpiles it (and all other `.by` files in the project) to a temporary directory, then executes `python -m main` from there
 
+naming the module every time gets old once a project has an entry point. configure one and `by run` alone is enough:
+
+```toml
+[tool.ty.run]
+main = "main"
+```
+
 ## project layout
 
 a typical basedpython project looks like:

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -46,6 +46,17 @@
         }
       ]
     },
+    "run": {
+      "description": "Configures how `by run` executes the project.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/RunOptions"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "src": {
       "anyOf": [
         {
@@ -2046,6 +2057,23 @@
       "additionalProperties": {
         "$ref": "#/definitions/Level"
       }
+    },
+    "RunOptions": {
+      "type": "object",
+      "properties": {
+        "main": {
+          "description": "The module `by run` executes when no module is given on the command line.\n\nThis is the project's entry point: with it set, `by run` alone transpiles the project and\nruns `python -m <main>`, exactly as if the module had been named on the command line. A\nmodule named explicitly always wins.\n\nThe value is a module path, not a file path — `app.cli`, not `app/cli.by`.\n\nDefaults to `null`, in which case `by run` requires a module argument.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
     },
     "SrcOptions": {
       "type": "object",


### PR DESCRIPTION
`by run` with no module now runs the module named by `run.main`, so a project with an entry point doesn't have to repeat it on every invocation
