### PR TITLE
fixed the ecosystem round-trip comment job

### DIFF
--- a/.github/workflows/by-ecosystem-roundtrip.yaml
+++ b/.github/workflows/by-ecosystem-roundtrip.yaml
@@ -180,8 +180,9 @@ jobs:
           pattern: roundtrip-shard-*
           merge-multiple: true
 
-      # the round-trip findings (regressions/changed/error-changed) are reported
-      # in the PR comment for humans to review — they don't fail the job. the job
+      # the round-trip findings (regressions/changed/error-changed), and the
+      # projects that fail to round-trip on both base and head, are reported in
+      # the PR comment for humans to review — none of them fail the job. the job
       # fails only if the harness itself fails (a non-zero exit here is a crash,
       # not a finding)
       - name: Render report

--- a/.github/workflows/by-ecosystem-roundtrip_comment.yaml
+++ b/.github/workflows/by-ecosystem-roundtrip_comment.yaml
@@ -63,7 +63,19 @@ jobs:
               return;
             }
 
-            const body = fs.readFileSync("comment.md", "utf8");
+            // the renderer already fits the report under this, but it reads
+            // untrusted-ish output from a fork build — never let an oversized
+            // body turn into a hard 422 that fails the job
+            const LIMIT = 65536;
+            let body = fs.readFileSync("comment.md", "utf8");
+            const chars = Array.from(body);
+            if (chars.length > LIMIT) {
+              const notice =
+                "\n\n_report truncated to fit GitHub's comment size limit; " +
+                "see the `comment.md` artifact of the run for the full text._\n";
+              body = chars.slice(0, LIMIT - notice.length).join("") + notice;
+            }
+
             const prNumber = parseInt(fs.readFileSync("pr-number.txt", "utf8").trim(), 10);
             if (!Number.isInteger(prNumber)) {
               core.info("no PR number; nothing to post");

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -623,6 +623,11 @@ jobs:
           ./scripts/add_plugin.py test --url https://pypi.org/project/-test/0.1.0/ --prefix TST
           ./scripts/add_rule.py --name FirstRule --prefix TST --code 001 --linter test
       - run: cargo check
+      # The round-trip report has to fit GitHub's comment size limit, and has to
+      # not report a project as changed just because two binaries produced the
+      # same failure. Both are only observable in a `pull_request` run, so they
+      # are covered by unit tests instead.
+      - run: uv run --no-project --with pytest pytest scripts/test_check_ecosystem_roundtrip.py
       # Lint/format/type-check py-fuzzer
       # (dogfooding with ty is done in a separate job)
       - run: uv run --directory=./python/py-fuzzer mypy

--- a/scripts/check_ecosystem_roundtrip.py
+++ b/scripts/check_ecosystem_roundtrip.py
@@ -32,6 +32,10 @@ that fails the check. Output that merely *changed*, or a project that now builds
 when it used to fail, is surfaced in the report but does not fail — those want a
 human's eyes, not a red build.
 
+A project that fails the same way on *both* binaries is not a regression and
+does not fail the check either, but it is still reported: the check is blind to
+that project, and saying nothing would let the corpus rot silently.
+
 Modes:
 
 * ``check_ecosystem_roundtrip.py <by-new> --baseline <by-old>`` — diff the
@@ -60,6 +64,7 @@ import difflib
 import json
 import logging
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -132,6 +137,28 @@ COMMENT_MARKER = "<!-- by-ecosystem-roundtrip -->"
 # label used for a whole-project build failure (no single file owns it)
 BUILD_PATH = Path("<build>")
 
+# GitHub rejects an issue comment body over 65536 characters, and truncates a
+# step summary over 1MB. Stay under both with room for the omission notice.
+COMMENT_CHAR_LIMIT = 65_536
+_COMMENT_BUDGET = 60_000
+
+# per-finding cap, so one project's enormous diagnostic dump can't crowd every
+# other finding out of the total budget. shared out over the findings, within
+# these bounds: a report with three findings can afford to show far more of
+# each than one with two hundred
+_MAX_DETAIL_CHARS = 12_000
+_MIN_DETAIL_CHARS = 1_500
+
+# the `<details>`/fence scaffolding wrapped around each detail, and room for the
+# omission notice — both come out of the budget before it is shared out
+_ENTRY_OVERHEAD = 120
+_NOTICE_RESERVE = 250
+
+# a project that fails identically on both binaries gets one line, not a dump
+_SUMMARY_CHARS = 200
+
+_SKIPPED_HEADING = "### ⏭️ skipped"
+
 # directories that aren't first-party source (skipped when sizing a project)
 _NON_SOURCE_DIRS = frozenset(
     {
@@ -183,7 +210,7 @@ class ProjectOutcome(NamedTuple):
 
 class FileDiff(NamedTuple):
     path: Path
-    # "broken" | "fixed" | "changed" | "error-changed"
+    # "broken" | "fixed" | "changed" | "error-changed" | "error-unchanged"
     kind: str
     detail: str
 
@@ -334,6 +361,46 @@ def _unified_diff(old: bytes, new: bytes, rel: Path) -> str:
     )
 
 
+# a panic header carries the thread's id: `thread 'main' (4094) panicked at ...`.
+# not anchored: the harness prefixes the phase, as `reverse: thread 'main' ...`
+_THREAD_ID_RE = re.compile(r"\b(thread '[^']*') \(\d+\)")
+
+# `by`'s diagnostic footer names the binary and the commit it was built from,
+# so it can never match between the base and head binaries
+_VERSION_RE = re.compile(r"^info: Version: .*$", re.MULTILINE)
+_ARGS_RE = re.compile(r"^info: Args: .*$", re.MULTILINE)
+
+# salsa's opaque interning handles, in both panic messages and `Query stack:`
+# entries. the query *names* are the signal; the ids shift whenever interning
+# order does, which any unrelated change can cause
+_SALSA_ID_RE = re.compile(r"\bId\([0-9a-f]+\)")
+
+# everything from `stack backtrace:` to the trailing `note:` (or to the end).
+# frame indices, source line numbers and recursion depth all move under edits
+# that leave the panic itself untouched
+_BACKTRACE_RE = re.compile(
+    r"^stack backtrace:\n.*?(?=^note: Some details are omitted|\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+
+
+def canonical_error(msg: str) -> str:
+    """Strip the parts of a build failure that differ between two runs of the
+    *same* failure.
+
+    The base and head binaries are separate processes built from separate
+    commits, so a raw stderr comparison never matches once a project fails
+    under both: the thread id, the version/argv footer and every backtrace line
+    number differ by construction. That reported every erroring project as
+    `error-changed` on every PR. Compare what identifies the failure — the
+    panic message and the diagnostics — not the run that produced it."""
+    msg = _THREAD_ID_RE.sub(r"\1", msg)
+    msg = _VERSION_RE.sub("info: Version: <elided>", msg)
+    msg = _ARGS_RE.sub("info: Args: <elided>", msg)
+    msg = _SALSA_ID_RE.sub("Id(<elided>)", msg)
+    return _BACKTRACE_RE.sub("stack backtrace: <elided>\n", msg)
+
+
 def classify_project(
     name: str, old: ProjectOutcome, new: ProjectOutcome
 ) -> ProjectDiff:
@@ -342,7 +409,7 @@ def classify_project(
 
     if old.error is not None or new.error is not None:
         if old.error is not None and new.error is not None:
-            if old.error != new.error:
+            if canonical_error(old.error) != canonical_error(new.error):
                 diffs.append(
                     FileDiff(
                         BUILD_PATH,
@@ -350,6 +417,10 @@ def classify_project(
                         f"base: {old.error}\nhead: {new.error}",
                     )
                 )
+            else:
+                # not a change, so not a finding — but the check is blind to
+                # this project, and saying nothing reads as "all good"
+                diffs.append(FileDiff(BUILD_PATH, "error-unchanged", new.error))
         elif new.error is not None:  # built on base, fails on head
             diffs.append(FileDiff(BUILD_PATH, "broken", new.error))
         else:  # failed on base, builds on head
@@ -448,91 +519,180 @@ async def setup_primer_project(name: str, parent: Path) -> AsyncIterator[Path]:
     yield target
 
 
+def _detail_cap(n_findings: int) -> int:
+    """How much of each finding we can afford to show. Aims at 90% of the
+    budget so the usual report fits whole and nothing has to be dropped."""
+    if n_findings <= 0:
+        return _MAX_DETAIL_CHARS
+    share = (_COMMENT_BUDGET * 9 // 10) // n_findings - _ENTRY_OVERHEAD
+    return max(_MIN_DETAIL_CHARS, min(_MAX_DETAIL_CHARS, share))
+
+
+def _truncate_detail(detail: str, cap: int) -> str:
+    """Cap one finding's body, keeping both ends: a panic is identified by its
+    header and topmost frames, a failed build by where it finally gave up."""
+    if len(detail) <= cap:
+        return detail
+    marker = "\n... {} characters elided ...\n"
+    head_budget = cap * 3 // 4
+    tail_budget = max(0, cap - head_budget - len(marker) - 12)
+    # snap both cuts to a line boundary so neither end starts or ends mid-line
+    head = detail[:head_budget].rsplit("\n", 1)[0]
+    tail = detail[len(detail) - tail_budget :].split("\n", 1)[-1] if tail_budget else ""
+    out = head + marker.format(len(detail) - len(head) - len(tail)) + tail
+    return out if len(out) <= cap else out[:cap]
+
+
+def _one_line(text: str) -> str:
+    """Flatten a multi-line reason so it renders as a single list item."""
+    s = " ".join(text.split()).replace("`", "")
+    return s[: _SUMMARY_CHARS - 1] + "…" if len(s) > _SUMMARY_CHARS else s
+
+
+def _error_summary(err: str) -> str:
+    """One line naming how a project failed. A project that fails the same way
+    on both binaries isn't a finding, so it gets a line rather than a dump."""
+    phase, _, rest = err.partition(": ")
+    m = re.search(r"panicked at ([^\n]*?):\n([^\n]*)", err)
+    if m:
+        summary = f"panicked at {m.group(1).rsplit('/', 1)[-1]}: {m.group(2)}"
+    else:
+        summary = next((x for x in rest.splitlines() if x.strip()), rest)
+    return _one_line(f"{phase}: {summary}")
+
+
+def _details_entry(
+    name: str, path: Path, detail: str, cap: int, fence: str = ""
+) -> str:
+    return "\n".join(
+        [
+            f"<details><summary>{name} — {path}</summary>",
+            "",
+            f"```{fence}",
+            _truncate_detail(detail, cap).rstrip(),
+            "```",
+            "",
+            "</details>",
+        ]
+    )
+
+
+def _assemble(header: list[str], sections: list[tuple[str, list[str]]]) -> str:
+    """Join the report under GitHub's comment size limit, dropping whole
+    findings rather than cutting the report off mid-sentence.
+
+    Sections are consumed in severity order, so what gets dropped first is the
+    least important thing in the report — never a regression."""
+    out = list(header)
+    used = sum(len(line) + 1 for line in out) + _NOTICE_RESERVE
+    dropped = 0
+    for heading, entries in sections:
+        placed = False
+        pending = [heading, ""]
+        pending_cost = sum(len(line) + 1 for line in pending)
+        for entry in entries:
+            cost = len(entry) + 1
+            if used + (0 if placed else pending_cost) + cost > _COMMENT_BUDGET:
+                dropped += 1
+                continue
+            if not placed:
+                out.extend(pending)
+                used += pending_cost
+                placed = True
+            out.append(entry)
+            used += cost
+        if placed:
+            out.append("")
+            used += 1
+    if dropped:
+        out.append(
+            f"_{dropped} finding(s) omitted to fit GitHub's "
+            f"{COMMENT_CHAR_LIMIT}-character comment limit. The full report is "
+            f"the `comment.md` artifact of this run._"
+        )
+    return "\n".join(out).rstrip() + "\n"
+
+
 def render_diff_report(
     results: list[ProjectDiff], old_label: str, new_label: str
 ) -> tuple[str, bool]:
-    broken = [(r, d) for r in results for d in r.diffs if d.kind == "broken"]
-    fixed = [(r, d) for r in results for d in r.diffs if d.kind == "fixed"]
-    changed = [(r, d) for r in results for d in r.diffs if d.kind == "changed"]
-    error_changed = [
-        (r, d) for r in results for d in r.diffs if d.kind == "error-changed"
-    ]
-    skipped = [r for r in results if r.skipped is not None]
+    # sorted, not in shard-completion order: the report is read by diffing it
+    # against the last run, and a stable order is what makes new entries visible
+    def of_kind(kind: str) -> list[tuple[ProjectDiff, FileDiff]]:
+        return sorted(
+            ((r, d) for r in results for d in r.diffs if d.kind == kind),
+            key=lambda rd: (rd[0].name, rd[1].path),
+        )
+
+    broken = of_kind("broken")
+    fixed = of_kind("fixed")
+    changed = of_kind("changed")
+    error_changed = of_kind("error-changed")
+    failing = of_kind("error-unchanged")
+    skipped = sorted(
+        (r for r in results if r.skipped is not None), key=lambda r: r.name
+    )
     total_files = sum(r.files_checked for r in results)
     n_projects = len(results) - len(skipped)
 
     lines: list[str] = ["## by ecosystem round-trip", "", COMMENT_MARKER, ""]
 
-    if not broken and not fixed and not changed and not error_changed:
+    skipped_section = (
+        _SKIPPED_HEADING,
+        [f"- `{r.name}`: {_one_line(r.skipped or '')}" for r in skipped],
+    )
+
+    if broken or fixed or changed or error_changed:
+        lines.append(f"base: `{old_label}` → head: `{new_label}`")
+        lines.append("")
+        lines.append(
+            f"regressions: {len(broken)}, changed: {len(changed)}, "
+            f"improvements: {len(fixed)}, error changes: {len(error_changed)} "
+            f"(across {total_files} files in {n_projects} projects)"
+        )
+    else:
         lines.append(
             f"✅ no round-trip differences between `{old_label}` and `{new_label}` "
             f"across {total_files} files in {n_projects} projects."
         )
-        if skipped:
-            lines.append("")
-            lines.append(_render_skipped(skipped))
-        return "\n".join(lines).rstrip() + "\n", True
 
-    lines.append(f"base: `{old_label}` → head: `{new_label}`")
-    lines.append("")
-    lines.append(
-        f"regressions: {len(broken)}, changed: {len(changed)}, "
-        f"improvements: {len(fixed)}, error changes: {len(error_changed)} "
-        f"(across {total_files} files in {n_projects} projects)"
-    )
+    # never silent: a project failing on both binaries is not a regression, but
+    # the check is blind to it, and the count belongs in the header where
+    # nothing can drop it
+    if failing:
+        lines.append("")
+        lines.append(
+            f"⚠️ {len(failing)} project(s) fail to round-trip on both base and "
+            f"head, so this check says nothing about them."
+        )
     lines.append("")
 
-    if broken:
-        lines.append("### ❌ regressions (built on base, now fails)")
-        lines.append("")
-        for r, d in broken:
-            lines.append(f"- `{r.name}` `{d.path}`: {d.detail}")
-        lines.append("")
+    cap = _detail_cap(len(broken) + len(changed) + len(error_changed))
+    sections = [
+        (
+            "### ❌ regressions (built on base, now fails)",
+            [_details_entry(r.name, d.path, d.detail, cap) for r, d in broken],
+        ),
+        (
+            "### ℹ️ changed round-trip output",  # noqa: RUF001
+            [_details_entry(r.name, d.path, d.detail, cap, "diff") for r, d in changed],
+        ),
+        (
+            "### ⚠️ build error changed (failed before and after)",
+            [_details_entry(r.name, d.path, d.detail, cap) for r, d in error_changed],
+        ),
+        (
+            "### 💥 fails to round-trip (unchanged from base)",
+            [f"- `{r.name}`: {_error_summary(d.detail)}" for r, d in failing],
+        ),
+        (
+            "### ✅ improvements (failed on base, now builds)",
+            [f"- `{r.name}` `{d.path}`" for r, d in fixed],
+        ),
+        skipped_section,
+    ]
 
-    if changed:
-        lines.append("### ℹ️ changed round-trip output")  # noqa: RUF001
-        lines.append("")
-        for r, d in changed:
-            lines.append(f"<details><summary>{r.name} — {d.path}</summary>")
-            lines.append("")
-            lines.append("```diff")
-            lines.append(d.detail.rstrip())
-            lines.append("```")
-            lines.append("")
-            lines.append("</details>")
-        lines.append("")
-
-    if error_changed:
-        lines.append("### ⚠️ build error changed (failed before and after)")
-        lines.append("")
-        for r, d in error_changed:
-            lines.append(f"<details><summary>{r.name} — {d.path}</summary>")
-            lines.append("")
-            lines.append("```")
-            lines.append(d.detail.rstrip())
-            lines.append("```")
-            lines.append("")
-            lines.append("</details>")
-        lines.append("")
-
-    if fixed:
-        lines.append("### ✅ improvements (failed on base, now builds)")
-        lines.append("")
-        for r, d in fixed:
-            lines.append(f"- `{r.name}` `{d.path}`")
-        lines.append("")
-
-    if skipped:
-        lines.append(_render_skipped(skipped))
-        lines.append("")
-
-    return "\n".join(lines).rstrip() + "\n", not broken
-
-
-def _render_skipped(skipped: list[ProjectDiff]) -> str:
-    parts = ["### ⏭️ skipped", ""]
-    parts.extend(f"- `{r.name}`: {r.skipped}" for r in skipped)
-    return "\n".join(parts)
+    return _assemble(lines, sections), not broken
 
 
 def _project_diff_to_dict(p: ProjectDiff) -> dict:

--- a/scripts/test_check_ecosystem_roundtrip.py
+++ b/scripts/test_check_ecosystem_roundtrip.py
@@ -1,0 +1,324 @@
+"""Tests for the round-trip report renderer and its error comparison.
+
+Run with::
+
+    uv run --no-project --with pytest pytest scripts/test_check_ecosystem_roundtrip.py
+
+The fixtures below reproduce the shapes seen in a real CI run: a salsa panic
+with a full `RUST_BACKTRACE=1` dump, and a build that failed with thousands of
+unresolved-import diagnostics.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from check_ecosystem_roundtrip import (
+    _COMMENT_BUDGET,
+    BUILD_PATH,
+    COMMENT_CHAR_LIMIT,
+    FileDiff,
+    ProjectDiff,
+    ProjectOutcome,
+    _detail_cap,
+    _truncate_detail,
+    canonical_error,
+    classify_project,
+    render_diff_report,
+)
+
+
+def panic(*, thread: int, first_line: int, frames: int) -> str:
+    """A salsa cycle panic, as `by` writes it to stderr under RUST_BACKTRACE=1."""
+    body = [
+        f"reverse: thread 'main' ({thread}) panicked at "
+        f"/root/.cargo/registry/src/salsa-0.28.1/src/function/execute.rs:731:9:",
+        "infer_statement_types_impl(Id(398)): execute: too many cycle iterations",
+        "Query stack:",
+        "[",
+        "    infer_scope_types_impl(Id(206)),",
+        "]",
+        "stack backtrace:",
+    ]
+    for i in range(frames):
+        body.append(f"  {i}: some_frame_{i}")
+        body.append(
+            f"             at ./crates/ty_python_semantic/src/x.rs:{first_line + i}:9"
+        )
+    body.append(
+        "note: Some details are omitted, run with `RUST_BACKTRACE=full` "
+        "for a verbose backtrace."
+    )
+    return "\n".join(body)
+
+
+def diagnostics(*, binary: str, sha: str, count: int) -> str:
+    """A `by build` that bailed out with unresolved third-party imports."""
+    body = ["build: error[unresolved-import]: Cannot resolve imported module `x`"]
+    for i in range(count):
+        body.append(f"error[unresolved-import]: Cannot resolve module `dep{i}`")
+        body.append("info: Searched in the following paths during module resolution:")
+        body.append("info:   1. /tmp/proj (first-party code)")
+    body.append(f"info: Version: unknown ({sha} 2026-08-09)")
+    body.append(f'info: Args: ["/work/{binary}", "build", "--min-version", "3.15"]')
+    return "\n".join(body)
+
+
+class TestCanonicalError:
+    def test_thread_id_is_not_a_difference(self):
+        assert canonical_error(panic(thread=4094, first_line=10, frames=3)) == (
+            canonical_error(panic(thread=9999, first_line=10, frames=3))
+        )
+
+    def test_backtrace_line_numbers_are_not_a_difference(self):
+        # an unrelated edit above the frame shifts every `at ...:LINE:COL`
+        assert canonical_error(panic(thread=1, first_line=1289, frames=3)) == (
+            canonical_error(panic(thread=1, first_line=1304, frames=3))
+        )
+
+    def test_backtrace_depth_is_not_a_difference(self):
+        # the same cycle panic, unwound a few frames deeper
+        assert canonical_error(panic(thread=1, first_line=10, frames=3)) == (
+            canonical_error(panic(thread=1, first_line=10, frames=40))
+        )
+
+    def test_version_and_argv_footer_is_not_a_difference(self):
+        # the two binaries are built from different commits, by construction
+        assert canonical_error(
+            diagnostics(binary="by-base", sha="de1d05d", count=2)
+        ) == (canonical_error(diagnostics(binary="by-pr", sha="4dbc1ae", count=2)))
+
+    def test_salsa_ids_are_not_a_difference(self):
+        a = "panicked: asserts_guard_targets(Id(5c80)) at Id(2e5)"
+        b = "panicked: asserts_guard_targets(Id(9f11)) at Id(0aa)"
+        assert canonical_error(a) == canonical_error(b)
+
+    def test_a_different_panic_message_is_a_difference(self):
+        a = panic(thread=1, first_line=10, frames=3)
+        b = a.replace("too many cycle iterations", "dependency graph cycle")
+        assert canonical_error(a) != canonical_error(b)
+
+    def test_a_different_diagnostic_set_is_a_difference(self):
+        assert canonical_error(diagnostics(binary="by-base", sha="a", count=2)) != (
+            canonical_error(diagnostics(binary="by-pr", sha="b", count=3))
+        )
+
+    def test_query_stack_names_survive(self):
+        a = panic(thread=1, first_line=10, frames=3)
+        b = a.replace("infer_scope_types_impl", "infer_definition_types")
+        assert canonical_error(a) != canonical_error(b)
+
+
+class TestClassifyProject:
+    def test_same_failure_under_both_binaries_is_reported_but_not_changed(self):
+        old = ProjectOutcome(
+            error=panic(thread=4094, first_line=10, frames=3), outputs={}
+        )
+        new = ProjectOutcome(
+            error=panic(thread=4104, first_line=25, frames=9), outputs={}
+        )
+        (diff,) = classify_project("mypy", old, new).diffs
+        assert diff.kind == "error-unchanged"
+
+    def test_a_genuinely_changed_failure_is_reported(self):
+        old = ProjectOutcome(error=panic(thread=1, first_line=10, frames=3), outputs={})
+        new = ProjectOutcome(error="build: something else entirely", outputs={})
+        (diff,) = classify_project("mypy", old, new).diffs
+        assert diff.kind == "error-changed"
+        assert diff.path == BUILD_PATH
+
+    def test_a_new_failure_is_still_a_regression(self):
+        old = ProjectOutcome(error=None, outputs={"a.py": b"x"})
+        new = ProjectOutcome(error=panic(thread=1, first_line=10, frames=3), outputs={})
+        (diff,) = classify_project("mypy", old, new).diffs
+        assert diff.kind == "broken"
+
+    def test_a_resolved_failure_is_still_an_improvement(self):
+        old = ProjectOutcome(error=panic(thread=1, first_line=10, frames=3), outputs={})
+        new = ProjectOutcome(error=None, outputs={"a.py": b"x"})
+        (diff,) = classify_project("mypy", old, new).diffs
+        assert diff.kind == "fixed"
+
+
+class TestTruncateDetail:
+    def test_short_detail_is_untouched(self):
+        assert _truncate_detail("a\nb\nc", 2_000) == "a\nb\nc"
+
+    def test_long_detail_keeps_both_ends(self):
+        detail = panic(thread=1, first_line=10, frames=4000)
+        out = _truncate_detail(detail, 2_000)
+        assert len(out) <= 2_000
+        assert "too many cycle iterations" in out
+        assert "characters elided" in out
+        assert out.endswith("for a verbose backtrace.")
+
+    def test_a_detail_of_few_enormous_lines_is_still_capped(self):
+        assert len(_truncate_detail("x" * 500_000, 2_000)) <= 2_000
+
+    def test_cuts_land_on_line_boundaries(self):
+        # neither end may be left holding half a line
+        out = _truncate_detail("\n".join(f"line{i}" for i in range(10_000)), 2_000)
+        body = [x for x in out.splitlines() if x and "characters elided" not in x]
+        assert all(re.fullmatch(r"line\d+", x) for x in body)
+
+    def test_more_findings_means_a_smaller_share_each(self):
+        caps = [_detail_cap(n) for n in (1, 5, 25, 200)]
+        assert caps == sorted(caps, reverse=True)
+        assert caps[0] > caps[-1]
+
+    def test_the_cap_never_collapses_to_nothing(self):
+        assert _detail_cap(100_000) >= 1_000
+        assert _detail_cap(0) > 0
+
+
+def project(name: str, kind: str, detail: str) -> ProjectDiff:
+    return ProjectDiff(name, 10, [FileDiff(BUILD_PATH, kind, detail)], None)
+
+
+class TestRenderDiffReport:
+    def test_the_real_world_blowup_fits(self):
+        # 23 error-changed findings, one of them the 4MB strawberry dump: the
+        # exact input that 422'd the comment job
+        results = [
+            project(
+                f"proj{i}", "error-changed", panic(thread=i, first_line=1, frames=900)
+            )
+            for i in range(22)
+        ]
+        results.append(
+            project(
+                "strawberry",
+                "error-changed",
+                diagnostics(binary="by-pr", sha="a", count=40_000),
+            )
+        )
+        body, clean = render_diff_report(results, "base", "head")
+        assert len(body) < COMMENT_CHAR_LIMIT
+        assert clean is True  # error changes don't fail the check
+        assert "<!-- by-ecosystem-roundtrip -->" in body
+        assert "error changes: 23" in body
+        # a report this size fits whole — nothing should need dropping
+        assert "finding(s) omitted" not in body
+        assert "strawberry" in body
+
+    def test_regressions_are_never_dropped_for_lesser_findings(self):
+        results = [
+            project(
+                f"noise{i}", "error-changed", panic(thread=i, first_line=1, frames=900)
+            )
+            for i in range(200)
+        ]
+        results.append(project("critical", "broken", "build: boom"))
+        body, clean = render_diff_report(results, "base", "head")
+        assert len(body) <= _COMMENT_BUDGET
+        assert clean is False
+        assert "critical" in body
+        assert "finding(s) omitted" in body
+
+    def test_counts_reflect_everything_even_when_entries_are_dropped(self):
+        results = [
+            project(
+                f"noise{i}", "error-changed", panic(thread=i, first_line=1, frames=900)
+            )
+            for i in range(200)
+        ]
+        body, _ = render_diff_report(results, "base", "head")
+        assert "error changes: 200" in body
+        assert "finding(s) omitted" in body
+
+    def test_a_small_report_is_not_truncated(self):
+        body, _ = render_diff_report(
+            [project("a", "error-changed", "base: x\nhead: y")], "base", "head"
+        )
+        assert "finding(s) omitted" not in body
+        assert "base: x" in body
+
+    def test_a_clean_report_lists_skipped_projects(self):
+        results = [ProjectDiff("spack", 0, [], "skipped: known to OOM the runner")]
+        body, clean = render_diff_report(results, "base", "head")
+        assert clean is True
+        assert "no round-trip differences" in body
+        assert "spack" in body
+        assert "known to OOM" in body
+
+    def test_a_multiline_skip_reason_stays_one_list_item(self):
+        reason = "setup failed:\nCloning into '/tmp/x'...\nresolved 40 packages\n"
+        results = [ProjectDiff("AutoSplit", 0, [], reason)]
+        body, _ = render_diff_report(results, "base", "head")
+        (item,) = [x for x in body.splitlines() if x.startswith("- `AutoSplit`")]
+        assert "Cloning into" in item  # the whole reason is on the one line
+
+    def test_a_project_failing_on_both_is_named_but_does_not_fail_the_job(self):
+        results = [
+            project(
+                "mypy", "error-unchanged", panic(thread=1, first_line=1, frames=900)
+            )
+        ]
+        body, clean = render_diff_report(results, "base", "head")
+        assert clean is True  # not a regression: it failed on base too
+        assert "1 project(s) fail to round-trip" in body
+        assert "- `mypy`: reverse: panicked at execute.rs:731:9: " in body
+        # one line, not a 100KB backtrace dump
+        assert "stack backtrace" not in body
+
+    def test_a_clean_run_with_failures_does_not_read_as_all_good(self):
+        results = [
+            project(
+                f"p{i}", "error-unchanged", panic(thread=i, first_line=1, frames=900)
+            )
+            for i in range(22)
+        ]
+        body, clean = render_diff_report(results, "base", "head")
+        assert clean is True
+        assert "22 project(s) fail to round-trip" in body
+        assert (
+            "no round-trip differences" in body
+        )  # true, and no longer the whole story
+
+    def test_the_failure_count_survives_even_if_the_entries_are_dropped(self):
+        results = [
+            project(
+                f"noise{i}", "error-changed", panic(thread=i, first_line=1, frames=900)
+            )
+            for i in range(400)
+        ]
+        results += [
+            project(
+                f"dead{i}", "error-unchanged", panic(thread=i, first_line=1, frames=900)
+            )
+            for i in range(30)
+        ]
+        body, _ = render_diff_report(results, "base", "head")
+        assert len(body) <= _COMMENT_BUDGET
+        assert "30 project(s) fail to round-trip" in body
+
+    def test_an_unchanged_failure_is_not_counted_as_an_error_change(self):
+        results = [project("a", "error-unchanged", "reverse: boom")]
+        body, _ = render_diff_report(results, "base", "head")
+        assert "error changes:" not in body
+
+    def test_summarises_a_non_panic_failure_too(self):
+        results = [
+            project(
+                "strawberry",
+                "error-unchanged",
+                diagnostics(binary="by-pr", sha="a", count=900),
+            )
+        ]
+        body, _ = render_diff_report(results, "base", "head")
+        assert "- `strawberry`: build: error[unresolved-import]" in body
+
+    def test_entries_are_ordered_by_project_not_by_shard(self):
+        results = [project(n, "error-unchanged", "reverse: boom") for n in "dbca"]
+        body, _ = render_diff_report(results, "base", "head")
+        names = [x.split("`")[1] for x in body.splitlines() if x.startswith("- `")]
+        assert names == ["a", "b", "c", "d"]
+
+    def test_changed_output_renders_as_a_diff_fence(self):
+        results = [
+            ProjectDiff("a", 1, [FileDiff(Path("m.py"), "changed", "-old\n+new")], None)
+        ]
+        body, _ = render_diff_report(results, "base", "head")
+        assert "```diff" in body
+        assert "+new" in body


### PR DESCRIPTION
the report embedded both binaries' raw stderr, so a run produced a 5.6MB comment.md and the post job 422'd on github's 65536-character limit.

the volume was noise: comparing raw stderr means the thread id, the version/argv footer and every backtrace line number differ between two separate binaries by construction, so every project that failed under both reported as error-changed. all 23 findings of the last run collapse to 0 under canonical_error.

the renderer now shares a budget out over the findings and drops whole entries least-severe-first, and the poster truncates as a backstop

the workflow comment now names the new report category

report projects that fail to round-trip, without failing the job

a project that fails the same way on base and head isn't a regression, so it produced no diff and vanished from the report entirely — the comment then said "no round-trip differences" while 23 of 148 projects were crashing.

they now get their own section, one line each naming the panic, and a count in the header where the size budget can't drop it. the job still passes: only a genuine regression fails the check.

also sorted every section by project name (shard-completion order made the list impossible to diff between runs) and flattened multi-line skip reasons, which were breaking out of their markdown list items