### PR TITLE
a decorated function's unannotated parameters take their declared types

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/basedpython_decorator_keyword.md
+++ b/crates/ty_python_semantic/resources/mdtest/basedpython_decorator_keyword.md
@@ -52,6 +52,21 @@ def h() -> None: ...
 reveal_type(trace(h))  # revealed: int
 ```
 
+## the decorated function's unannotated parameters take their declared types
+
+a decoration hands the function to the decorator, so the callable the declaration says it accepts is
+type context for the decorated function's parameters. this is the same context that types the
+parameters of a lambda passed to `d` directly, and it is not particular to `decorator def` — see
+`bidirectional.md`
+
+```by
+decorator def d(fn: (int) -> None)
+
+@d
+def f(i):
+    reveal_type(i)  # revealed: int
+```
+
 ## multiple options
 
 ```by

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -1875,6 +1875,138 @@ _: list[int | str] = f12()  # error: [invalid-assignment]
 reveal_type(f12)  # revealed: () -> list[int]
 ```
 
+## Decorated function definitions
+
+A decoration hands the undecorated function to the decorator, so the callable that the decorator
+declares it accepts is type context for the function's parameters — the same context a lambda
+written at that argument position would be inferred under.
+
+### Basic
+
+```py
+from typing import Callable
+
+def d(fn: Callable[[int], object]) -> None: ...
+@d
+def f(i):
+    reveal_type(i)  # revealed: int
+
+d(lambda i: reveal_type(i))  # revealed: int
+```
+
+### An annotation the author wrote wins
+
+The declared callable is only consulted for a parameter that has no annotation of its own. A
+parameter it disagrees with is reported at the decoration, as any other argument would be.
+
+```py
+from typing import Callable
+
+def d(fn: Callable[[int], None]) -> None: ...
+
+# error: [invalid-argument-type] "Argument to function `d` is incorrect: Expected `(int, /) -> None`, found `def f(i: str)`"
+@d
+def f(i: str):
+    reveal_type(i)  # revealed: str
+```
+
+### Parameters correspond by position
+
+Parameters line up with the declared callable positionally, so a function that takes more parameters
+than the callable declares leaves the surplus ones untyped.
+
+```py
+from typing import Callable
+
+def d(fn: Callable[[int], None]) -> None: ...
+
+# error: [invalid-argument-type]
+@d
+def f(i, j):
+    reveal_type(i)  # revealed: int
+    reveal_type(j)  # revealed: j@f
+```
+
+### A callback protocol declares keyword-only parameters
+
+A `Callable` annotation can only declare positional parameters. A callback protocol can declare
+keyword-only ones too, and those correspond by name.
+
+```py
+from typing import Protocol
+
+class Handler(Protocol):
+    def __call__(self, request: int, *, verbose: str) -> None: ...
+
+def route(fn: Handler) -> None: ...
+@route
+def home(request, *, verbose):
+    reveal_type(request)  # revealed: int
+    reveal_type(verbose)  # revealed: str
+
+# error: [invalid-argument-type]
+@route
+def away(request, *, quiet):
+    reveal_type(quiet)  # revealed: quiet@away
+```
+
+### A decorator that accepts any callable says nothing
+
+A decorator declared over `Callable[..., T]`, or over a `ParamSpec`, accepts a function of any shape
+and so says nothing about any particular parameter.
+
+```py
+from typing import Callable
+
+def any_shape(fn: Callable[..., object]) -> None: ...
+@any_shape
+def f(i):
+    reveal_type(i)  # revealed: i@f
+
+def same_shape[**P, R](fn: Callable[P, R]) -> Callable[P, R]:
+    return fn
+
+@same_shape
+def g(i):
+    reveal_type(i)  # revealed: i@g
+```
+
+### Only the innermost decorator sees the undecorated function
+
+Decorators apply from the bottom up, so the parameters are typed by the one written closest to the
+`def`. The decorators above it see whatever the one below them returned.
+
+```py
+from typing import Callable
+
+def inner(fn: Callable[[int], None]) -> Callable[[str], None]:
+    return lambda s: None
+
+def outer(fn: Callable[[str], None]) -> None: ...
+@outer
+@inner
+def f(i):
+    reveal_type(i)  # revealed: int
+```
+
+### A decorator recorded as a flag is not a decoration
+
+`@overload`, `@final`, `@override` and `@staticmethod` leave the function's type as it was, so they
+do not stand between the function and the decorator that does decorate it.
+
+```py
+from typing import Callable, final
+
+def d(fn: Callable[[int], None]) -> None: ...
+
+class C:
+    @d
+    @final
+    @staticmethod
+    def m(i):
+        reveal_type(i)  # revealed: int
+```
+
 ## Unified call inference
 
 Generic call arguments are inferred under fixpoint iteration, allowing constraints from call

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -82,7 +82,9 @@ use crate::types::diagnostic::{
 };
 use crate::types::display::DisplaySettings;
 use crate::types::generics::{ApplySpecialization, GenericContext, typing_self};
-use crate::types::infer::{infer_definition_types, nearest_enclosing_class, original_class_type};
+use crate::types::infer::{
+    function_known_decorators, infer_definition_types, nearest_enclosing_class, original_class_type,
+};
 use crate::types::inferred_signature::inferred_return_type;
 use crate::types::known_instance::DeprecatedInstance;
 use crate::types::list_members::all_members;
@@ -1114,6 +1116,18 @@ impl<'db> OverloadLiteral<'db> {
             raw_signature.return_ty = base_return;
         }
 
+        // basedpython: `@d` on `def f(i)` hands `f` straight to `d`, so a parameter left
+        // unannotated takes its type from the callable `d` declares it accepts — the same context
+        // that types the parameters of `d(lambda i: ...)`. this runs after the sources that say
+        // something about this parameter in particular (a sibling overload, an overridden base)
+        // and before the anonymous hole, which stands in only where nothing else answered
+        if !function_stmt_node.is_trailing_lambda
+            && raw_signature.has_inherited_annotations_to_fill(false)
+            && let Some(expected) = self.decorated_as_signature(db, env, function_stmt_node)
+        {
+            raw_signature.inherit_unannotated_from_callable(db, env, &expected);
+        }
+
         // basedpython: a parameter nothing else typed opens an anonymous type parameter, so
         // that what a call passes in stays connected to what it gets back
         if infers_unannotated_signatures(db, self.file(db)) {
@@ -1142,6 +1156,94 @@ impl<'db> OverloadLiteral<'db> {
         }
 
         raw_signature
+    }
+
+    /// basedpython: the callable that the innermost applied decorator declares this function to
+    /// be.
+    ///
+    /// `@d` on `def f(...)` hands the undecorated `f` to `d`, so the parameter that `d` receives it
+    /// as says what shape the function it is given is expected to have. Only the innermost
+    /// decorator sees the undecorated function; the ones outside it see whatever the one below
+    /// returned.
+    ///
+    /// `None` whenever nothing usable is declared: the decorator is overloaded or not inspectable,
+    /// the parameter it receives the function as is not a plain positional one, or the type of that
+    /// parameter is not a single non-overloaded callable.
+    fn decorated_as_signature(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        function_stmt_node: &ast::StmtFunctionDef,
+    ) -> Option<Signature<'db>> {
+        let decorator = self.innermost_applied_decorator(db, function_stmt_node)?;
+        let decorator_callable = decorator.try_upcast_to_callable(db, env)?.exactly_one()?;
+        // an overloaded decorator would take the function as a different parameter depending on
+        // how it is called, and which overload a call picks is decided by the very type this is
+        // trying to fill in
+        let [decorator_signature] = decorator_callable.signatures(db).overloads.as_slice() else {
+            return None;
+        };
+        let decorated = decorator_signature.parameters().iter().next()?;
+        if !decorated.is_positional() {
+            return None;
+        }
+        let expected = match decorated.annotated_type() {
+            // a callback protocol describes a function shape just as directly as a callable type
+            // does, and is the only one of the two that can spell a keyword-only parameter
+            expected @ (Type::ProtocolInstance(_) | Type::NominalInstance(_)) => {
+                expected.try_upcast_to_callable(db, env)?.exactly_one()?
+            }
+            // the parameter is often declared optional — `property`'s `fget` is
+            // `Callable[[Any], Any] | None` — and what a decoration passes it is the callable
+            expected => expected
+                .filter_union(db, Type::is_callable_type)
+                .as_callable()?,
+        };
+        let [expected_signature] = expected.signatures(db).overloads.as_slice() else {
+            return None;
+        };
+        Some(expected_signature.clone())
+    }
+
+    /// basedpython: the type of the innermost decorator that is applied to this function.
+    ///
+    /// A basedpython modifier keyword (`private def f()`) parses as a synthetic decorator that is
+    /// not a decoration at all, and a decorator that is recorded as a flag instead of being applied
+    /// (`@overload`, `@final`, `@staticmethod`) leaves the function's type as it was. Neither
+    /// changes what the decorator written above it is handed, so neither stands between this
+    /// function and the decorator that does decorate it.
+    fn innermost_applied_decorator(
+        self,
+        db: &'db dyn Db,
+        function_stmt_node: &ast::StmtFunctionDef,
+    ) -> Option<Type<'db>> {
+        let decorators = function_known_decorators(db, self.definition(db));
+        for decorator in function_stmt_node.decorator_list.iter().rev() {
+            let decorator_ty = decorators.expression_type(&decorator.expression)?;
+
+            // a synthetic marker is a keyword rather than a reference to anything, and resolves to
+            // `Unknown` for that reason. `Unknown` on a written `@…` is a decorator that could not
+            // be resolved, and what *that* hands on is anyone's guess, so it does hide the
+            // decorator above it
+            let is_marker =
+                matches!(&decorator.expression, ast::Expr::Name(name) if name.ctx.is_invalid());
+            if is_marker && decorator_ty.is_unknown() {
+                continue;
+            }
+
+            // the static-property marker is the one flag that is also applied: the flag says only
+            // how the getter's receiver is typed, while the descriptor it resolves to is the
+            // member's actual type
+            if !FunctionDecorators::from_decorator_type(db, decorator_ty)
+                .difference(FunctionDecorators::BY_STATIC_PROPERTY)
+                .is_empty()
+            {
+                continue;
+            }
+
+            return Some(decorator_ty);
+        }
+        None
     }
 
     /// basedpython: the return type this function would have if its return annotation were

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1347,6 +1347,71 @@ impl<'db> Signature<'db> {
         }
     }
 
+    /// basedpython: fill in every parameter still without a type of its own from `expected` — the
+    /// callable that something declares the function itself to be.
+    ///
+    /// Positional parameters correspond by position and keyword-only parameters by name, the same
+    /// way a call binds arguments to them. A `*args` or `**kwargs` stands for a run of arguments
+    /// rather than one, so nothing corresponds to it and it keeps whatever type it had.
+    ///
+    /// Nothing is inherited from a parameter list that describes a run of arguments rather than a
+    /// parameter per position — `Callable[..., T]`, a `ParamSpec`, a `Concatenate` — since there is
+    /// nothing to line up against. A type variable is bound to the scope that declared it, so
+    /// copying one here would silently rebind it, and those parameters are left alone too.
+    pub(crate) fn inherit_unannotated_from_callable(
+        &mut self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        expected: &Signature<'db>,
+    ) {
+        if !expected.parameters().is_standard() {
+            return;
+        }
+
+        let mut expected_positional = expected
+            .parameters()
+            .iter()
+            .take_while(|parameter| parameter.is_positional());
+
+        for parameter in &mut Arc::make_mut(&mut self.parameters.data).value {
+            // advance the positional correspondence even for a parameter that is not going to be
+            // filled in, so that the parameters after it still line up
+            let corresponding = if parameter.is_positional() {
+                expected_positional.next()
+            } else if parameter.is_keyword_only() {
+                expected.parameters().iter().find(|candidate| {
+                    candidate.is_keyword_only() && candidate.name() == parameter.name()
+                })
+            } else {
+                None
+            };
+
+            // skip explicit annotations, and any parameter that already has a resolved type
+            // (e.g. `self`/`cls` after `add_implicit_self_annotation`)
+            if !parameter.inferred_annotation || !parameter.annotated_type.is_unknown() {
+                continue;
+            }
+            let Some(corresponding) = corresponding else {
+                continue;
+            };
+            if corresponding.inferred_annotation {
+                continue;
+            }
+            let inherited = corresponding.annotated_type;
+            // a gradual type says no more about the parameter than leaving it unannotated already
+            // did, and taking it would displace what a later source — the anonymous hole — has to
+            // say: `Callable[[Any], Any]` is how a callback that cannot be spelled out is written
+            if inherited.is_dynamic()
+                || inherited.has_typevar(db, env)
+                || inherited.has_unspecialized_type_var(db, env)
+            {
+                continue;
+            }
+            parameter.annotated_type = inherited;
+            parameter.inferred_annotation = false;
+        }
+    }
+
     /// basedpython: under `sound-types`, open an anonymous type parameter for every parameter
     /// still without a type of its own.
     ///

--- a/docs/basedpython/features/decorated-parameters.md
+++ b/docs/basedpython/features/decorated-parameters.md
@@ -1,0 +1,98 @@
+# decorated function parameters
+
+a decoration hands the function to the decorator, so the callable the decorator declares it
+accepts gives the decorated function's unannotated parameters their types
+
+```by
+decorator def route(fn: (int) -> None)
+
+@route
+def home(request):
+    reveal_type(request)  # int
+```
+
+it is the same context a lambda written at that argument position is inferred under —
+`route(lambda (request): None)` types `request` the same way
+
+## any decorator declares it
+
+nothing about this is specific to [`decorator def`](decorator-keyword.md); an ordinary function
+used as a decorator declares the same thing
+
+```by
+def route(fn: (int) -> None): ...
+
+@route
+def home(request):
+    reveal_type(request)  # int
+```
+
+parameters correspond by position, so a function that takes more parameters than the declared
+callable leaves the surplus ones untyped — and the decoration itself is an
+`invalid-argument-type`, since a function of that shape is not what the decorator accepts
+
+a parameter that carries its own annotation keeps it, and is checked against the declared
+callable like any other argument
+
+```by
+@route
+def home(request: str): ...   # error: invalid-argument-type
+```
+
+a callback protocol is read the same way, and is the only spelling that can declare a keyword-only
+parameter. those correspond by name rather than by position
+
+```by
+protocol Handler:
+    def __call__(self, request: int, *, verbose: str): ...
+
+def route(fn: Handler): ...
+
+@route
+def home(request, *, verbose):
+    reveal_type(request)  # int
+    reveal_type(verbose)  # str
+```
+
+## when nothing is declared
+
+a decorator that accepts a function of any shape says nothing about any particular parameter, and
+the parameter falls back to what it would have been undecorated — under
+[sound types](sound-types.md), an anonymous type parameter
+
+```by
+def log[**P, R](fn: (**P) -> R) -> (**P) -> R:
+    return fn
+
+@log
+def home(request):
+    reveal_type(request)  # request@home
+```
+
+this covers the gradual `(...) -> T`, a parameter pack, and any declared parameter type written in
+terms of the decorator's own type variables — a type variable belongs to the scope that declared
+it, so it cannot stand as a parameter type here
+
+an overloaded decorator declares nothing either: which overload a decoration picks depends on the
+shape of the function, which is the very thing being inferred
+
+## more than one decorator
+
+decorators apply from the bottom up, so the parameters are typed by the one written closest to the
+`def` — the decorators above it see whatever the one below them returned
+
+```by
+def inner(fn: (int) -> None) -> (str) -> None:
+    return lambda (s): None
+
+def outer(fn: (str) -> None): ...
+
+@outer
+@inner
+def home(request):
+    reveal_type(request)  # int
+```
+
+a decorator that only marks the function — `@overload`, [`final`, `override`,
+`static`](modifiers.md) — leaves its type as it was, so it is not what decorates it and the
+decorator above it still declares the parameters

--- a/docs/basedpython/features/index.md
+++ b/docs/basedpython/features/index.md
@@ -148,6 +148,7 @@ the forms a class, function or binding can take
 - [main function](main-function.md)
 - [`sentinel` declarations](sentinel.md)
 - [decorator keyword](decorator-keyword.md)
+- [decorated function parameters](decorated-parameters.md)
 
 </div>
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -156,6 +156,7 @@ features = [
     { "main function" = "features/main-function.md" },
     { "sentinel declarations" = "features/sentinel.md" },
     { "decorator keyword" = "features/decorator-keyword.md" },
+    { "decorated function parameters" = "features/decorated-parameters.md" },
   ] },
   { "expressions and statements" = [
     { "context-sensitive resolution" = "features/context-sensitive-resolution.md" },


### PR DESCRIPTION
`@d` on `def f(i)` hands `f` to `d`, so the callable `d` declares it accepts types `f`'s parameters — the context that already types `d(lambda i: ...)`
