### PR TITLE
converge on a recursive inferred return type

### DIFF
--- a/crates/ty/src/by_commands.rs
+++ b/crates/ty/src/by_commands.rs
@@ -690,13 +690,27 @@ fn cmd_transpile_dir(dir: &Path, reverse: bool, config: &Config) -> anyhow::Resu
 /// deleting the original. Reverse transforms are single-file, so no project db
 /// is needed.
 ///
-/// A source the transpiler cannot read is reported and skipped rather than
-/// taking the project down with it — the same way ruff reports an unreadable
-/// file as an `IOError` diagnostic and lints the rest. Each file's original is
-/// removed only once its replacement is on disk, so nothing is ever left both
-/// deleted and unconverted.
-#[allow(clippy::print_stderr)]
+/// A source the transpiler cannot read, cannot convert, or that panics the
+/// checker underneath it is reported and skipped rather than taking the project
+/// down with it — the same way ruff reports an unreadable file as an `IOError`
+/// diagnostic and lints the rest, and the same way `by check` turns a panic
+/// while checking one file into a diagnostic against that file. Converting a
+/// tree is not all-or-nothing: one file the transpiler chokes on must not cost
+/// the caller every other file's conversion. Each file's original is removed
+/// only once its replacement is on disk, so nothing is ever left both deleted
+/// and unconverted.
 fn reverse_dir(dir: &Path, config: &Config) -> anyhow::Result<ExitStatus> {
+    reverse_dir_converting(dir, config, by_transforms::reverse_transpile)
+}
+
+/// [`reverse_dir`], with the conversion of a single source given by the caller so
+/// a test can supply one that fails or panics on demand.
+#[allow(clippy::print_stderr)]
+fn reverse_dir_converting(
+    dir: &Path,
+    config: &Config,
+    convert: impl Fn(&str, &Config) -> Result<String, String> + std::panic::RefUnwindSafe,
+) -> anyhow::Result<ExitStatus> {
     let files = py_source_files(dir);
     if files.is_empty() {
         eprintln!("no .py files found");
@@ -722,8 +736,18 @@ fn reverse_dir(dir: &Path, config: &Config) -> anyhow::Result<ExitStatus> {
             is_stub,
             ..config.clone()
         };
-        let output = by_transforms::reverse_transpile(&source, &file_config)
-            .map_err(|e| anyhow::anyhow!("{}: {e}", py.display()))?;
+        let converted = ruff_db::panic::catch_unwind(|| convert(&source, &file_config));
+        let output = match converted {
+            Ok(Ok(output)) => output,
+            Ok(Err(e)) => {
+                skipped.push((py.as_path(), e));
+                continue;
+            }
+            Err(panic) => {
+                skipped.push((py.as_path(), panic.to_string()));
+                continue;
+            }
+        };
         let by = py.with_extension(if is_stub { "byi" } else { "by" });
         fs::write(&by, output).with_context(|| format!("{}", by.display()))?;
         fs::remove_file(py).with_context(|| format!("{}", py.display()))?;
@@ -1242,7 +1266,7 @@ pub(crate) fn cmd_version_by(output_format: crate::args::HelpFormat) -> ExitStat
 
 #[cfg(test)]
 mod tests {
-    use super::{is_hidden_within, module_relative_path, reverse_dir};
+    use super::{is_hidden_within, module_relative_path, reverse_dir, reverse_dir_converting};
     use crate::ExitStatus;
     use by_transforms::config::Config;
     use std::path::{Path, PathBuf};
@@ -1318,6 +1342,55 @@ mod tests {
         // untouched: neither converted nor deleted
         assert!(latin1.is_file());
         assert!(!dir.path().join("latin_1.by").exists());
+        Ok(())
+    }
+
+    /// a source whose conversion the transpiler gives up on is skipped the same
+    /// way an unreadable one is, rather than costing every other file in the tree
+    /// its conversion
+    #[test]
+    fn a_source_the_transpiler_rejects_is_skipped_not_fatal() -> anyhow::Result<()> {
+        let dir = tempfile::TempDir::new()?;
+        std::fs::write(dir.path().join("good.py"), "x = 1\n")?;
+        let bad = dir.path().join("bad.py");
+        std::fs::write(&bad, "y = 2\n")?;
+
+        let status = reverse_dir_converting(dir.path(), &Config::default(), |source, _| {
+            if source.starts_with('y') {
+                Err("nope".to_string())
+            } else {
+                Ok(source.to_string())
+            }
+        })?;
+
+        assert!(matches!(status, ExitStatus::Failure));
+        assert!(dir.path().join("good.by").is_file());
+        assert!(bad.is_file());
+        assert!(!dir.path().join("bad.by").exists());
+        Ok(())
+    }
+
+    /// the checker underneath the transpiler can panic on one file — a salsa cycle
+    /// that will not converge, say. that must cost the caller that file, not the
+    /// whole tree, exactly as `by check` reports a panic against the file it was
+    /// checking and carries on
+    #[test]
+    fn a_source_that_panics_the_checker_is_skipped_not_fatal() -> anyhow::Result<()> {
+        let dir = tempfile::TempDir::new()?;
+        std::fs::write(dir.path().join("good.py"), "x = 1\n")?;
+        let exploding = dir.path().join("exploding.py");
+        std::fs::write(&exploding, "y = 2\n")?;
+
+        let status = reverse_dir_converting(dir.path(), &Config::default(), |source, _| {
+            assert!(!source.starts_with('y'), "boom");
+            Ok(source.to_string())
+        })?;
+
+        assert!(matches!(status, ExitStatus::Failure));
+        assert!(dir.path().join("good.by").is_file());
+        // left exactly as it was found: neither converted nor deleted
+        assert!(exploding.is_file());
+        assert!(!dir.path().join("exploding.by").exists());
         Ok(())
     }
 }

--- a/crates/ty_project/src/db.rs
+++ b/crates/ty_project/src/db.rs
@@ -717,16 +717,35 @@ pub(crate) mod testing {
     }
 
     impl TestDb {
+        /// A database that does not record salsa events.
+        ///
+        /// The transpiler builds one of these per file it converts, so this is not
+        /// only a test fixture. Recording every salsa event costs a mutex and a push
+        /// per event and retains them all in an unbounded `Vec`, which is a large
+        /// price for something only [`Self::with_salsa_events`]'s callers read.
+        /// Worse, it turns a query that fails to converge into an out-of-memory kill
+        /// rather than a slow one, which hides what actually went wrong.
         pub fn new(project: ProjectMetadata) -> Self {
+            Self::build(project, false)
+        }
+
+        /// A database that records every salsa event, for tests that assert on which
+        /// queries ran. Read the events back with [`Self::take_salsa_events`].
+        #[cfg(any(test, feature = "testing"))]
+        pub fn with_salsa_events(project: ProjectMetadata) -> Self {
+            Self::build(project, true)
+        }
+
+        fn build(project: ProjectMetadata, record_events: bool) -> Self {
             let events = Events::default();
             let mut db = Self {
-                storage: salsa::Storage::new(Some(Box::new({
+                storage: salsa::Storage::new(record_events.then(|| {
                     let events = events.clone();
-                    move |event| {
+                    Box::new(move |event| {
                         let mut events = events.lock().unwrap();
                         events.push(event);
-                    }
-                }))),
+                    }) as _
+                })),
                 system: TestSystem::default(),
                 vendored: ty_vendored::file_system().clone(),
                 files: Files::default(),

--- a/crates/ty_project/src/files.rs
+++ b/crates/ty_project/src/files.rs
@@ -323,7 +323,7 @@ mod tests {
     #[test]
     fn cancelled_file_indexing_recovers_file_set() -> anyhow::Result<()> {
         let metadata = ProjectMetadata::new("test", SystemPathBuf::from("/test"));
-        let mut db = TestDb::new(metadata);
+        let mut db = TestDb::with_salsa_events(metadata);
         db.write_files((0..10_000).map(|index| (format!("/test/test_{index}.py"), "")))?;
         db.take_salsa_events();
 

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -989,7 +989,7 @@ mod tests {
     #[test]
     fn check_file_skips_type_checking_when_file_cant_be_read() -> ruff_db::system::Result<()> {
         let project = ProjectMetadata::new("test", SystemPathBuf::from("/"));
-        let mut db = TestDb::new(project);
+        let mut db = TestDb::with_salsa_events(project);
         let path = SystemPath::new("test.py");
 
         db.write_file(path, "x = 10")?;

--- a/crates/ty_python_semantic/resources/mdtest/cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle.md
@@ -515,3 +515,64 @@ def shallow_nesting() -> None:
     boxed: list[list[list[int]]] = [[[1]]]
     reveal_type(boxed)  # revealed: list[list[list[int]]]
 ```
+
+## a function whose return value nests itself widens rather than diverging
+
+An unannotated function can hand back a container built out of its own return value. Inferring its
+signature then asks what it returns in order to answer what it returns, and each round buries the
+answer one level deeper: `Box[Never]`, then `Box[Box[Never]]`, and so on. Nothing in the program
+says where that recursion stops, so the rounds never settle.
+
+The recovery is the same as for a container nested in a loop, but the growth has to be recognized
+first: by the first round the divergence marker has been solved away — `Box[Divergent]` comes back
+as `Box[Never]` — leaving nothing for the usual collapse to find. What gives the round away is that
+it added nothing but depth: its answer is the previous answer with one more layer around it. Once
+the marker is put back the nesting collapses and the iteration settles on the recursive type.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Callable
+
+class Box[T]:
+    def __init__(self, make: Callable[[], T]) -> None:
+        self.make = make
+
+def factory():
+    return Box(factory)
+
+reveal_type(factory())  # revealed: Box[Divergent]
+
+# the binding that observes it is one construction further out, and stays finite
+outer = Box(factory)
+reveal_type(outer)  # revealed: Box[Box[Divergent]]
+
+# an unannotated factory that is not recursive is unaffected, and still inferred exactly
+def plain():
+    return 1
+
+def holder():
+    return Box(plain)
+
+reveal_type(holder())  # revealed: Box[Literal[1]]
+```
+
+## the recursive `defaultdict` factory converges
+
+The same shape reaches ty through the standard library, where it is a common idiom for a tree of
+arbitrary depth.
+
+```py
+from collections import defaultdict
+
+def tree():
+    return defaultdict(tree)
+
+reveal_type(tree())  # revealed: defaultdict[Unknown, Divergent]
+
+nested = defaultdict(tree)
+reveal_type(nested)  # revealed: defaultdict[Unknown, defaultdict[Unknown, Divergent]]
+```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1906,6 +1906,162 @@ impl<'db> Type<'db> {
         }
         .recursive_type_normalized_impl_with_cycle(db, env, cycle)
         .without_growing_tuple_lengths(db, env, previous)
+        .without_growing_self_nesting(db, env, previous, cycle)
+    }
+
+    /// basedpython: `self`, with a class nested inside itself that the fixed-point iteration
+    /// is burying one level deeper every round given up.
+    ///
+    /// An unannotated function whose return value is built out of its own return value gains a
+    /// level of nesting on every round:
+    ///
+    /// ```python
+    /// def factory():
+    ///     return Box(factory)
+    /// ```
+    ///
+    /// is inferred `Box[Never]`, then `Box[Box[Never]]`, then `Box[Box[Box[Never]]]`, and so on.
+    /// That depth is the iteration's own artefact — a round is only deeper because the round
+    /// before it was, and nothing in the program says where the recursion stops — so the rounds
+    /// never settle and the query runs until salsa gives up, or until the machine does.
+    ///
+    /// This is the same shape [`Self::without_growing_tuple_lengths`] handles for tuple lengths;
+    /// the dimension that grows here is how deeply a class sits inside itself. Cycle recovery
+    /// already knows how to collapse such a nesting, but only when it can *see* it: it looks for
+    /// the cycle's own `Divergent` marker, and by the first round that marker has been solved
+    /// away (`Box[Divergent]` comes back as `Box[Never]`), leaving nothing to recognize. So when
+    /// a round is seen to add nothing but depth, the marker is put back where it starts. The next
+    /// round then sees `Box[Divergent]` again, [`Self::recursive_type_normalized`] collapses it,
+    /// and the iteration converges on `Box[Divergent]` — the recursive type the program means.
+    fn without_growing_self_nesting(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        previous: Self,
+        cycle: &salsa::Cycle,
+    ) -> Self {
+        let Some(div) = cycle.head_ids().next().map(Type::divergent) else {
+            return self;
+        };
+        // deeper than last round is not on its own evidence of anything: an ordinary nested type
+        // is built up a level at a time too, and `list[dict[str, list[int] | int]]` is a type a
+        // program writes. what gives divergence away is that the round added *nothing but* depth
+        // — this round's answer is last round's answer with one more layer wrapped around it, so
+        // the round learned only what the round before it had already said
+        if self.self_nesting_depth(db, &mut Vec::new())
+            <= previous.self_nesting_depth(db, &mut Vec::new())
+            || !self.wraps(db, previous)
+        {
+            return self;
+        }
+        // one level is kept: collapsing `Box[…]` itself would throw away the class the program
+        // does name, not just the depth it doesn't
+        self.truncate_self_nesting(db, env, div, 1, &mut Vec::new())
+    }
+
+    /// Whether `inner` sits somewhere strictly inside `self`, as `Box[Never]` does in
+    /// `Box[Box[Never]]`.
+    fn wraps(self, db: &'db dyn Db, inner: Self) -> bool {
+        let mut parts: Vec<Type<'db>> = if let Type::Union(_) = self {
+            self.union_elements(db).collect()
+        } else {
+            vec![self]
+        };
+        while let Some(part) = parts.pop() {
+            if part != self && part == inner {
+                return true;
+            }
+            if let Type::Union(_) = part {
+                parts.extend(part.union_elements(db).filter(|element| *element != part));
+            } else if let Some((_, specialization)) = part.generic_instance_parts(db) {
+                parts.extend(specialization.types(db).iter().copied());
+            }
+        }
+        false
+    }
+
+    /// How many times any one class is nested inside itself along the deepest path through
+    /// `self`, e.g. 2 for `Box[Box[int]]` and 1 for `Box[list[int]]`.
+    ///
+    /// `ancestors` is the classes enclosing `self`, innermost last.
+    fn self_nesting_depth(
+        self,
+        db: &'db dyn Db,
+        ancestors: &mut Vec<StaticClassLiteral<'db>>,
+    ) -> usize {
+        if let Type::Union(_) = self {
+            return self
+                .union_elements(db)
+                .map(|element| element.self_nesting_depth(db, ancestors))
+                .max()
+                .unwrap_or(0);
+        }
+        let Some((origin, specialization)) = self.generic_instance_parts(db) else {
+            return 0;
+        };
+        let here = ancestors.iter().filter(|seen| **seen == origin).count() + 1;
+        ancestors.push(origin);
+        let deepest = specialization
+            .types(db)
+            .iter()
+            .map(|argument| argument.self_nesting_depth(db, ancestors))
+            .max()
+            .unwrap_or(0);
+        ancestors.pop();
+        here.max(deepest)
+    }
+
+    /// `self` with any class nested inside itself more than `budget` times replaced by `div`.
+    fn truncate_self_nesting(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        div: Type<'db>,
+        budget: usize,
+        ancestors: &mut Vec<StaticClassLiteral<'db>>,
+    ) -> Self {
+        if let Type::Union(_) = self {
+            let elements: Vec<_> = self
+                .union_elements(db)
+                .map(|element| element.truncate_self_nesting(db, env, div, budget, ancestors))
+                .collect();
+            return UnionType::from_elements_cycle_recovery(db, env, elements);
+        }
+        let (Type::NominalInstance(instance), Some((origin, specialization))) =
+            (self, self.generic_instance_parts(db))
+        else {
+            return self;
+        };
+        if ancestors.iter().filter(|seen| **seen == origin).count() >= budget {
+            return div;
+        }
+        ancestors.push(origin);
+        let arguments: Box<[_]> = specialization
+            .types(db)
+            .iter()
+            .map(|argument| argument.truncate_self_nesting(db, env, div, budget, ancestors))
+            .collect();
+        ancestors.pop();
+        if arguments.as_ref() == specialization.types(db) {
+            return self;
+        }
+        let truncated = specialization.with_types(db, arguments);
+        match instance.with_specialization(db, truncated) {
+            Some(instance) => Type::NominalInstance(instance),
+            None => self,
+        }
+    }
+
+    /// The class and specialization of `self` when it is an instance of a generic class whose
+    /// specialization can be swapped on its own.
+    fn generic_instance_parts(
+        self,
+        db: &'db dyn Db,
+    ) -> Option<(StaticClassLiteral<'db>, Specialization<'db>)> {
+        match self {
+            Type::NominalInstance(instance) => instance.generic_parts(db),
+            _ => None,
+        }
     }
 
     /// The elements of `self` when it is a union, and `self` itself otherwise.

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1780,6 +1780,18 @@ impl<'db> Specialization<'db> {
         )
     }
 
+    /// `self` with its type arguments replaced by `types`, everything else kept.
+    pub(super) fn with_types(self, db: &'db dyn Db, types: Box<[Type<'db>]>) -> Self {
+        Self::new(
+            db,
+            self.generic_context(db),
+            types,
+            self.materialization_kind(db),
+            self.tuple_inner(db),
+            self.projections(db).to_vec().into_boxed_slice(),
+        )
+    }
+
     pub(super) fn recursive_type_normalized_impl(
         self,
         db: &'db dyn Db,

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -14,12 +14,12 @@ use super::{
     MaterializationKind, SubclassOfType, Type, TypeAliasType, TypeVarVariance,
 };
 use crate::place::PlaceAndQualifiers;
-use crate::types::class::DynamicNamedTupleAnchor;
+use crate::types::class::{DynamicNamedTupleAnchor, GenericAlias, StaticClassLiteral};
 use crate::types::constraints::{
     ConstraintSet, ConstraintSetBuilder, IteratorConstraintsExtension, OwnedConstraintSet,
 };
 use crate::types::enums::is_single_member_enum;
-use crate::types::generics::walk_specialization;
+use crate::types::generics::{Specialization, walk_specialization};
 use crate::types::protocol_class::{
     ProtocolClass, has_all_protocol_members_defined, walk_protocol_instance_member,
     walk_protocol_interface,
@@ -520,6 +520,44 @@ impl<'db> NominalInstanceType<'db> {
             stop: to_u32(stop)?,
             step: to_u32(step)?,
         })
+    }
+
+    /// The generic class this is an instance of and the specialization it was made with,
+    /// when swapping that specialization would lose nothing else the instance carries.
+    ///
+    /// Restricted to the plain non-tuple case on purpose. A tuple, a regex match or
+    /// `sys.version_info` answers with more than the class and its arguments, and asking
+    /// any of them for their class runs a query — which a cycle recovery function, the only
+    /// caller of this, must not do: salsa rejects a recovery that takes a new dependency.
+    pub(super) fn generic_parts(
+        self,
+        db: &'db dyn Db,
+    ) -> Option<(StaticClassLiteral<'db>, Specialization<'db>)> {
+        let NominalInstanceInner::NonTuple(class) = self.0 else {
+            return None;
+        };
+        let ClassType::Generic(alias) = class.class(db) else {
+            return None;
+        };
+        Some((alias.origin(db), alias.specialization(db)))
+    }
+
+    /// This instance with the specialization from [`Self::generic_parts`] replaced.
+    pub(super) fn with_specialization(
+        self,
+        db: &'db dyn Db,
+        specialization: Specialization<'db>,
+    ) -> Option<Self> {
+        let NominalInstanceInner::NonTuple(class) = self.0 else {
+            return None;
+        };
+        let ClassType::Generic(alias) = class.class(db) else {
+            return None;
+        };
+        Some(Self(NominalInstanceInner::NonTuple(class.with_class(
+            db,
+            ClassType::Generic(GenericAlias::new(db, alias.origin(db), specialization)),
+        ))))
     }
 
     pub(super) fn recursive_type_normalized_impl(


### PR DESCRIPTION
an unannotated function whose return value is built out of its own return value gains a level of nesting on every fixpoint round -- `Box[Never]`, then `Box[Box[Never]]` -- so the rounds never settle. depending on where the cycle is entered that showed up as salsa's "too many cycle iterations", as a 900s timeout, or, because the transpiler's db was recording every salsa event into an unbounded vec, as an out-of-memory kill

cycle recovery already collapses such a nesting, but only when it can see the cycle's own divergent marker, and by the first round that marker has been solved away. what gives the round away instead is that it added nothing but depth: its answer is the previous answer with one more layer around it

11 of the 13 primer projects that failed to round-trip now round-trip cleanly

also: one file that panics the checker no longer costs `transpile --reverse` every other file in the tree, and the transpiler's db no longer records salsa events (~34% of its peak memory, and what turned the hang above into an OOM)