### PR TITLE
common aliases: np. completes as numpy, and writes the import

### DIFF
--- a/crates/ty/docs/configuration.md
+++ b/crates/ty/docs/configuration.md
@@ -808,6 +808,45 @@ Defaults to `false`.
 
 ---
 
+## `editor`
+
+### `common-aliases`
+
+The modules a name is a common alias of, keyed by the alias.
+
+A file that writes `np.` before importing anything almost always means numpy, because `np`
+is what numpy is conventionally imported as. The editor completes such a name as the module
+it names, and accepting one of those completions writes the `import numpy as np` that makes
+the name real.
+
+This adds aliases of your own to the ones ty already knows; an entry whose alias ty knows
+replaces it. An alias for a module the project does not have is never offered, so an entry
+for a module nobody installed costs nothing.
+
+Defaults to `{}`, which leaves ty's own aliases as they are.
+
+**Default value**: `{}`
+
+**Type**: `dict[str, str]`
+
+**Example usage**:
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.ty.editor.common-aliases]
+    npt = "numpy.typing"
+    ```
+
+=== "ty.toml"
+
+    ```toml
+    [editor.common-aliases]
+    npt = "numpy.typing"
+    ```
+
+---
+
 ## `environment`
 
 ### `extra-paths`

--- a/crates/ty/tests/cli/config_option.rs
+++ b/crates/ty/tests/cli/config_option.rs
@@ -123,7 +123,7 @@ fn cli_config_args_invalid_option() -> anyhow::Result<()> {
       |
     1 | bad-option=true
       | ^^^^^^^^^^
-    unknown field `bad-option`, expected one of `environment`, `src`, `rules`, `terminal`, `analysis`, `run`, `overrides`
+    unknown field `bad-option`, expected one of `environment`, `src`, `rules`, `terminal`, `analysis`, `run`, `editor`, `overrides`
 
 
     Usage: by <COMMAND>

--- a/crates/ty_ide/src/code_action.rs
+++ b/crates/ty_ide/src/code_action.rs
@@ -786,6 +786,40 @@ mod tests {
         "#);
     }
 
+    /// `dt` is a common alias of `datetime`, so an unresolved one offers the import that binds it.
+    #[test]
+    fn unresolved_common_alias() {
+        let test = CodeActionTest::with_source(
+            r#"
+            <START>dt<END>.timedelta(days=1)
+        "#,
+        );
+
+        assert_snapshot!(test.code_actions(&UNRESOLVED_REFERENCE), @"
+        info[code-action]: import datetime as dt
+         --> main.py:2:1
+          |
+        2 | dt.timedelta(days=1)
+          | ^^
+        help: This is a preferred code action
+          |
+        1 + import datetime as dt
+        2 |
+          |
+
+        info[code-action]: Ignore 'unresolved-reference' for this line
+         --> main.py:2:1
+          |
+        2 | dt.timedelta(days=1)
+          | ^^
+          |
+        1 |
+          - dt.timedelta(days=1)
+        2 + dt.timedelta(days=1)  # ty: ignore[unresolved-reference]
+          |
+        ");
+    }
+
     #[test]
     fn unresolved_deprecated_warnings_imported() {
         let test = CodeActionTest::with_source(

--- a/crates/ty_ide/src/common_aliases.rs
+++ b/crates/ty_ide/src/common_aliases.rs
@@ -1,0 +1,91 @@
+//! The names that are conventionally an alias of a module.
+//!
+//! A file that writes `np.` before importing anything almost always means numpy, because `np` is
+//! what numpy is written as everywhere numpy is written. Completions read that: `np.` offers
+//! numpy's members, and accepting one writes the `import numpy as np` the file was missing.
+//!
+//! A project adds aliases of its own through `[tool.ty.editor] common-aliases`, and an alias it
+//! spells replaces the one here.
+
+use ty_module_resolver::ModuleName;
+use ty_project::Db;
+
+/// The aliases that are conventions of the wider python ecosystem, sorted by alias.
+///
+/// Nothing is offered for a module the project does not have, so an entry here only ever reaches
+/// somebody who installed the library it names.
+static KNOWN_ALIASES: &[(&str, &str)] = &[
+    ("ET", "xml.etree.ElementTree"),
+    ("F", "torch.nn.functional"),
+    ("da", "dask.array"),
+    ("dd", "dask.dataframe"),
+    ("dt", "datetime"),
+    ("go", "plotly.graph_objects"),
+    ("gpd", "geopandas"),
+    ("jnp", "jax.numpy"),
+    ("mpl", "matplotlib"),
+    ("nn", "torch.nn"),
+    ("np", "numpy"),
+    ("npt", "numpy.typing"),
+    ("nx", "networkx"),
+    ("pa", "pyarrow"),
+    ("pd", "pandas"),
+    ("pl", "polars"),
+    ("plt", "matplotlib.pyplot"),
+    ("px", "plotly.express"),
+    ("sa", "sqlalchemy"),
+    ("sm", "statsmodels.api"),
+    ("sns", "seaborn"),
+    ("sp", "scipy"),
+    ("st", "streamlit"),
+    ("tf", "tensorflow"),
+    ("tk", "tkinter"),
+    ("ttk", "tkinter.ttk"),
+    ("xr", "xarray"),
+];
+
+/// The module `alias` names, when it is one of the names an alias is.
+///
+/// This does not say whether the project has that module — resolve the name to find that out.
+pub(crate) fn module_of(db: &dyn Db, alias: &str) -> Option<ModuleName> {
+    let configured = db.project().settings(db).editor().common_alias(alias);
+    let module = configured.or_else(|| {
+        KNOWN_ALIASES
+            .binary_search_by_key(&alias, |&(known, _)| known)
+            .ok()
+            .and_then(|found| KNOWN_ALIASES.get(found))
+            .map(|&(_, module)| module)
+    })?;
+    ModuleName::new(module)
+}
+
+/// Every alias, paired with the module it names.
+///
+/// A configured alias comes first, and replaces the known alias it spells.
+pub(crate) fn all(db: &dyn Db) -> impl Iterator<Item = (&str, &str)> {
+    let editor = db.project().settings(db).editor();
+    let known = KNOWN_ALIASES
+        .iter()
+        .filter(|(known, _)| editor.common_alias(known).is_none())
+        .map(|&(alias, module)| (alias, module));
+    editor.common_aliases().chain(known)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::KNOWN_ALIASES;
+
+    /// `module_of` finds an alias by binary search.
+    #[test]
+    fn known_aliases_are_sorted() {
+        let mut sorted: Vec<_> = KNOWN_ALIASES.iter().map(|&(alias, _)| alias).collect();
+        sorted.sort_unstable();
+        assert_eq!(
+            sorted,
+            KNOWN_ALIASES
+                .iter()
+                .map(|&(alias, _)| alias)
+                .collect::<Vec<_>>()
+        );
+    }
+}

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -35,10 +35,11 @@ use ty_python_semantic::{
     types::{CycleDetector, KnownClass, Type},
 };
 
+use crate::common_aliases;
 use crate::django_template::django_string_completions;
 use crate::docstring::Docstring;
 use crate::goto::Definitions;
-use crate::importer::{ImportRequest, Importer};
+use crate::importer::{ImportRequest, Importer, MembersInScope};
 use crate::symbols::QueryPattern;
 use crate::{Db, all_symbols, signature_help};
 use ruff_db::files::File;
@@ -129,11 +130,30 @@ pub fn completion<'db>(
                     capabilities,
                     &mut completions,
                 );
+                if settings.auto_import {
+                    add_aliased_module_completions(
+                        db,
+                        program_file,
+                        &parsed,
+                        &model,
+                        expr,
+                        &mut completions,
+                    );
+                }
             }
             CompletionTargetAst::Scoped(scoped) => {
                 let env = model.program_environment();
-                // only basedpython's implicit names have to know what the scope
-                // already carries, so nothing else pays for collecting it
+                // the aliases that could be offered here, which is usually none of them: a query
+                // is a subsequence of what it matches, so anything longer than a two- or
+                // three-letter alias rules every one of them out
+                let aliases: Vec<_> = if settings.auto_import {
+                    matching_aliases(db, &completions.query)
+                } else {
+                    Vec::new()
+                };
+                // only basedpython's implicit names and the aliases above have to know what the
+                // scope already carries, so nothing else pays for collecting it
+                let collect_in_scope = source_type.is_basedpython() || !aliases.is_empty();
                 let mut in_scope = FxHashSet::default();
                 for semantic_completion in model.scoped_completions(scoped.node) {
                     let module_dependency_kind = if semantic_completion.builtin {
@@ -141,7 +161,7 @@ pub fn completion<'db>(
                     } else {
                         ModuleDependencyKind::Current
                     };
-                    if source_type.is_basedpython() {
+                    if collect_in_scope {
                         in_scope.insert(semantic_completion.name.clone());
                     }
                     completions.add(
@@ -192,12 +212,27 @@ pub fn completion<'db>(
                     &context.cursor,
                     &mut completions,
                 );
-                if settings.auto_import {
+                // an import is only ever offered for something the user has begun to name: a
+                // query that matches everything would drag in every symbol of every module
+                if settings.auto_import && !completions.query.will_match_everything() {
+                    let stylist = Stylist::from_tokens(parsed.tokens(), source.as_str());
+                    let importer =
+                        Importer::new(db, &stylist, program_file, source.as_str(), &parsed);
+                    let members = importer.members_in_scope_at(scoped.node, scoped.node.start());
+                    add_alias_completions(
+                        db,
+                        program_file,
+                        &importer,
+                        &members,
+                        &aliases,
+                        &in_scope,
+                        &mut completions,
+                    );
                     add_unimported_completions(
                         db,
                         program_file,
-                        &parsed,
-                        scoped,
+                        &importer,
+                        &members,
                         context.cursor.is_in_type_expression(&model),
                         |module_name: &ModuleName, symbol: &str| {
                             ImportRequest::import_from(module_name.as_str(), symbol)
@@ -2676,17 +2711,21 @@ pub(crate) fn unresolved_fixes<'db>(
     node: AnyNodeRef,
 ) -> Vec<ImportEdit> {
     let mut results = Vec::new();
-    let scoped = ScopedTarget { node };
     let query = UserQuery::exactly(symbol);
     let ctx = CollectionContext::none();
+
+    let source = source_text(db, file.file(db));
+    let stylist = Stylist::from_tokens(parsed.tokens(), source.as_str());
+    let importer = Importer::new(db, &stylist, file, source.as_str(), parsed);
+    let members = importer.members_in_scope_at(node, node.start());
 
     // Request imports we could add to put the symbol in scope
     let mut completions = Completions::new(db, file, ctx.clone(), query.clone());
     add_unimported_completions(
         db,
         file,
-        parsed,
-        scoped,
+        &importer,
+        &members,
         // the name this fixes is unresolved, so it is not one of the names a
         // basedpython file has without an import — those resolve
         false,
@@ -2702,8 +2741,8 @@ pub(crate) fn unresolved_fixes<'db>(
     add_unimported_completions(
         db,
         file,
-        parsed,
-        scoped,
+        &importer,
+        &members,
         false,
         |module_name: &ModuleName, symbol: &str| {
             ImportRequest::import(module_name.as_str(), symbol).force()
@@ -2712,7 +2751,28 @@ pub(crate) fn unresolved_fixes<'db>(
     );
     results.extend(completions.into_qualifications(node.range()));
 
+    // an unresolved `np` is the name a common alias would have bound, so offer to write the
+    // import that binds it — the same one the completions above `np.` carry
+    results.extend(alias_import(db, file, &importer, &members, symbol));
+
     results
+}
+
+/// The import that would bind `symbol`, when it is a common alias of a module the project has.
+fn alias_import(
+    db: &dyn Db,
+    file: ProgramFile<'_>,
+    importer: &Importer<'_>,
+    members: &MembersInScope<'_>,
+    symbol: &str,
+) -> Option<ImportEdit> {
+    let module_name = common_aliases::module_of(db, symbol)?;
+    SemanticModel::new(db, file).resolve_module_name(&module_name)?;
+
+    let request = ImportRequest::module_as(module_name.as_str(), symbol);
+    let label = request.to_string();
+    let edit = importer.import(request, members).import()?.clone();
+    Some(ImportEdit { label, edit })
 }
 
 /// Adds completions derived from keywords.
@@ -3605,8 +3665,8 @@ fn add_string_literal_completions<'db>(
 fn add_unimported_completions<'db>(
     db: &'db dyn Db,
     file: ProgramFile<'db>,
-    parsed: &ParsedModuleRef,
-    scoped: ScopedTarget<'_>,
+    importer: &Importer<'_>,
+    members: &MembersInScope<'_>,
     // basedpython: whether a type is being written here, which is where some of
     // the names that need no import mean what they do
     in_type_expression: bool,
@@ -3615,17 +3675,13 @@ fn add_unimported_completions<'db>(
 ) {
     // This is redundant since `all_symbols` will also bail
     // when the query can match everything. But we bail here
-    // to avoid building an `Importer` and other plausibly
-    // costly work when we know we won't use it.
+    // to avoid other plausibly costly work when we know we
+    // won't use it.
     if completions.query.will_match_everything() {
         return;
     }
 
     let source_file = file.file(db);
-    let source = source_text(db, source_file);
-    let stylist = Stylist::from_tokens(parsed.tokens(), source.as_str());
-    let importer = Importer::new(db, &stylist, file, source.as_str(), parsed);
-    let members = importer.members_in_scope_at(scoped.node, scoped.node.start());
     let importing_file = ImportingFile::File(source_file, file.resolver_environment(db));
     let model = SemanticModel::new(db, file);
 
@@ -3656,7 +3712,7 @@ fn add_unimported_completions<'db>(
             continue;
         }
 
-        let import_action = importer.import(request, &members);
+        let import_action = importer.import(request, members);
 
         // N.B. We use `add_skip_query` here because `all_symbols`
         // already takes our query into account.
@@ -3674,6 +3730,125 @@ fn add_unimported_completions<'db>(
                     file.file(db),
                     symbol.module(),
                 )),
+        );
+    }
+}
+
+/// The aliases the user could be part-way through writing.
+///
+/// An alias is only ever offered as something to import, so this answers with nothing where
+/// auto-import would also answer with nothing: for a query that matches everything, the aliases
+/// would be twenty names nobody asked for.
+fn matching_aliases<'db>(db: &'db dyn Db, query: &UserQuery) -> Vec<(&'db str, ModuleName)> {
+    if query.will_match_everything() {
+        return Vec::new();
+    }
+    common_aliases::all(db)
+        .filter(|(alias, _)| query.is_match(alias))
+        .filter_map(|(alias, module)| Some((alias, ModuleName::new(module)?)))
+        .collect()
+}
+
+/// Adds a completion for each name that is an alias of a module the project has.
+///
+/// Accepting one writes the `import numpy as np` that binds the name, so this is the same offer
+/// auto-import makes for a symbol, for the module a name conventionally stands for.
+fn add_alias_completions<'db>(
+    db: &'db dyn Db,
+    file: ProgramFile<'db>,
+    importer: &Importer<'_>,
+    members: &MembersInScope<'_>,
+    aliases: &[(&str, ModuleName)],
+    in_scope: &FxHashSet<CompactString>,
+    completions: &mut Completions<'db>,
+) {
+    let model = SemanticModel::new(db, file);
+    // a name the scope already carries is not free for an alias to take, whether it is a local,
+    // an import, or a builtin
+    let aliases = aliases
+        .iter()
+        .filter(|(alias, _)| !in_scope.contains(*alias))
+        .filter_map(|(alias, module_name)| Some((*alias, model.resolve_module_name(module_name)?)));
+
+    for (alias, module) in aliases {
+        let module_name = module.name(db);
+        let import_action = importer.import(
+            ImportRequest::module_as(module_name.as_str(), alias),
+            members,
+        );
+        // N.B. `matching_aliases` already took the query into account.
+        completions.add_skip_query(
+            Completion::builder(alias)
+                .kind(CompletionKind::Module)
+                .insert(import_action.symbol_text())
+                .qualified(module_name.as_str())
+                .module_name(module_name)
+                .import(import_action.import().cloned())
+                .module_dependency_kind(ModuleDependencyKind::from_module(
+                    db,
+                    file.file(db),
+                    module,
+                )),
+        );
+    }
+}
+
+/// Adds the members of the module an unbound `np.` names.
+///
+/// `np` means numpy in a file that never imported it just as surely as in one that did, so this
+/// offers what an `import numpy as np` would have made available, and carries that import along
+/// with whatever the user accepts.
+fn add_aliased_module_completions<'db>(
+    db: &'db dyn Db,
+    file: ProgramFile<'db>,
+    parsed: &ParsedModuleRef,
+    model: &SemanticModel<'db>,
+    expr: &ast::ExprAttribute,
+    completions: &mut Completions<'db>,
+) {
+    let ast::Expr::Name(name) = &*expr.value else {
+        return;
+    };
+    let Some(module_name) = common_aliases::module_of(db, &name.id) else {
+        return;
+    };
+    // a name that already means something is not standing in for a module, whatever it is spelled
+    // like. an unbound one infers as `Unknown`, which is also what a binding of unknown type
+    // infers as, so the scope is asked about that case below
+    if expr
+        .value
+        .inferred_type(model)
+        .is_some_and(|ty| !ty.is_unknown())
+    {
+        return;
+    }
+    let Some(module) = model.resolve_module_name(&module_name) else {
+        return;
+    };
+
+    let source = source_text(db, file.file(db));
+    let stylist = Stylist::from_tokens(parsed.tokens(), source.as_str());
+    let importer = Importer::new(db, &stylist, file, source.as_str(), parsed);
+    let members = importer.members_in_scope_at(expr.into(), expr.start());
+    if members.find_member(&name.id).is_some() {
+        return;
+    }
+
+    let import_action = importer.import(
+        ImportRequest::module_as(module_name.as_str(), &name.id),
+        &members,
+    );
+    let Some(import) = import_action.import() else {
+        return;
+    };
+    let env = model.program_environment();
+    let module_dependency_kind = ModuleDependencyKind::from_module(db, file.file(db), module);
+    for semantic_completion in model.module_completions(&module_name) {
+        completions.add(
+            CompletionBuilder::from_semantic_completion(db, &env, semantic_completion)
+                .module_name(module.name(db))
+                .import(import.clone())
+                .module_dependency_kind(module_dependency_kind),
         );
     }
 }
@@ -4687,6 +4862,7 @@ mod tests {
     use ruff_python_parser::{Mode, ParseOptions};
     use ruff_text_size::{TextRange, TextSize};
     use ty_module_resolver::ModuleName;
+    use ty_project::metadata::options::{EditorOptions, Options};
 
     use crate::CompletionCapabilities;
     use crate::completion::{Completion, completion};
@@ -13541,6 +13717,153 @@ def f():
             builder.build().snapshot(),
             @"Thing :: <no import required> :: <no import edit>",
         );
+    }
+
+    /// `dt` is a common alias of `datetime`, so `dt.` offers what the module has even though
+    /// nothing has imported it. Accepting one of these writes the import that binds `dt`.
+    #[test]
+    fn common_alias_offers_the_modules_members() {
+        let builder = completion_test_builder(
+            "\
+dt.timed<CURSOR>
+",
+        )
+        .module_names()
+        .imports();
+        assert_snapshot!(
+            builder.build().snapshot(),
+            @"timedelta :: datetime :: import datetime as dt",
+        );
+    }
+
+    /// The alias itself completes too, as the module it names.
+    #[test]
+    fn common_alias_completes_as_a_name() {
+        let builder = completion_test_builder(
+            "\
+d<CURSOR>
+",
+        )
+        .module_names()
+        .imports()
+        .filter(|c| c.name == "dt");
+        assert_snapshot!(
+            builder.build().snapshot(),
+            @"dt :: datetime :: import datetime as dt",
+        );
+    }
+
+    /// A name the file already binds means what the file says it means, so nothing is offered
+    /// for the module it happens to be an alias of.
+    #[test]
+    fn common_alias_yields_to_a_binding() {
+        let builder = completion_test_builder(
+            "\
+dt = 1
+dt.timed<CURSOR>
+",
+        )
+        .module_names()
+        .imports();
+        assert_snapshot!(builder.build().snapshot(), @"<No completions found>");
+    }
+
+    /// Nor is the alias offered as a name to import when the scope already carries it.
+    #[test]
+    fn common_alias_is_not_offered_over_a_binding() {
+        let builder = completion_test_builder(
+            "\
+dt = 1
+d<CURSOR>
+",
+        )
+        .module_names()
+        .imports()
+        .filter(|c| c.name == "dt");
+        assert_snapshot!(
+            builder.build().snapshot(),
+            @"dt :: <no import required> :: <no import edit>",
+        );
+    }
+
+    /// Once the file writes the import, `dt` resolves on its own and the members come with no
+    /// import attached.
+    #[test]
+    fn common_alias_adds_no_import_once_it_is_written() {
+        let builder = completion_test_builder(
+            "\
+import datetime as dt
+
+dt.timed<CURSOR>
+",
+        )
+        .module_names()
+        .imports();
+        assert_snapshot!(
+            builder.build().snapshot(),
+            @"timedelta :: <no import required> :: <no import edit>",
+        );
+    }
+
+    /// An alias of a module the project does not have is not offered at all.
+    #[test]
+    fn common_alias_of_a_missing_module_is_not_offered() {
+        let builder = completion_test_builder(
+            "\
+np.ara<CURSOR>
+",
+        )
+        .module_names()
+        .imports();
+        assert_snapshot!(builder.build().snapshot(), @"<No completions found>");
+    }
+
+    /// A project spells aliases of its own under `[tool.ty.editor]`.
+    #[test]
+    fn configured_common_alias_offers_the_modules_members() {
+        let builder = CursorTest::builder()
+            .options(common_aliases([("bo", "bureau")]))
+            .source("main.py", "bo.dep<CURSOR>")
+            .source("bureau/__init__.py", "def deposit(): ...\n")
+            .completion_test_builder()
+            .module_names()
+            .imports();
+        assert_snapshot!(
+            builder.build().snapshot(),
+            @"deposit :: bureau :: import bureau as bo",
+        );
+    }
+
+    /// A configured alias replaces the one ty knows by that name.
+    #[test]
+    fn configured_common_alias_replaces_a_known_one() {
+        let builder = CursorTest::builder()
+            .options(common_aliases([("dt", "bureau")]))
+            .source("main.py", "dt.<CURSOR>")
+            .source("bureau/__init__.py", "def deposit(): ...\n")
+            .completion_test_builder()
+            .module_names()
+            .imports()
+            .filter(|c| matches!(c.name.as_str(), "deposit" | "timedelta"));
+        assert_snapshot!(
+            builder.build().snapshot(),
+            @"deposit :: bureau :: import bureau as dt",
+        );
+    }
+
+    /// Options configuring just the common aliases.
+    fn common_aliases<const N: usize>(aliases: [(&str, &str); N]) -> Options {
+        Options {
+            editor: Some(EditorOptions {
+                common_aliases: Some(
+                    aliases
+                        .into_iter()
+                        .map(|(alias, module)| (alias.to_string(), module.to_string()))
+                        .collect(),
+                ),
+            }),
+            ..Options::default()
+        }
     }
 
     #[test]

--- a/crates/ty_ide/src/importer.rs
+++ b/crates/ty_ide/src/importer.rs
@@ -152,7 +152,11 @@ impl<'a> Importer<'a> {
             self.file.resolver_environment(self.db),
         );
         let request = request.avoid_conflicts(self.db, importing_file, members);
-        let mut symbol_text: Box<str> = request.member.unwrap_or(request.module).into();
+        let mut symbol_text: Box<str> = request
+            .member
+            .or(request.asname)
+            .unwrap_or(request.module)
+            .into();
         let Some(response) = self.find(importing_file, &request, members.at) else {
             let insertion = if let Some(future) = self.find_last_future_import(members.at) {
                 Insertion::end_of_statement(future.stmt, self.source, self.stylist)
@@ -382,7 +386,7 @@ impl<'ast> MembersInScope<'ast> {
         importing_file: ImportingFile<'_>,
         request: &ImportRequest<'_>,
     ) -> bool {
-        let symbol_text = request.member.unwrap_or(request.module);
+        let symbol_text = request.member.or(request.asname).unwrap_or(request.module);
         let Some(member) = self.find_member(symbol_text) else {
             return false;
         };
@@ -526,10 +530,13 @@ impl<'ast> AstImportKind<'ast> {
                 if request.force_style && !matches!(request.style, ImportStyle::Import) {
                     return None;
                 }
-                let alias = ast
-                    .names
-                    .iter()
-                    .find(|alias| alias.name.as_str() == request.module)?;
+                let alias = ast.names.iter().find(|alias| {
+                    // `import numpy` does not satisfy a request for `import numpy as np`: it
+                    // brings the module into scope, but not under the name that was asked for
+                    alias.name.as_str() == request.module
+                        && (request.asname.is_none()
+                            || alias.asname.as_ref().map(ast::Identifier::as_str) == request.asname)
+                })?;
                 Some(ImportResponseKind::Qualified { ast, alias })
             }
             AstImportKind::ImportFrom(ast) => {
@@ -575,6 +582,11 @@ pub(crate) struct ImportRequest<'a> {
     /// When `member` is absent, then this request reflects an import
     /// of the module itself. i.e., `import module`.
     member: Option<&'a str>,
+    /// The name to bind the module to (e.g., `np`, in `import numpy as np`).
+    ///
+    /// Only a request for a module itself carries one, since that is the
+    /// only import an alias is asked for today.
+    asname: Option<&'a str>,
     /// The preferred style to use when importing the symbol (e.g.,
     /// `import foo` or `from foo import bar`).
     ///
@@ -597,6 +609,7 @@ impl<'a> ImportRequest<'a> {
         Self {
             module,
             member: Some(member),
+            asname: None,
             style: ImportStyle::Import,
             force_style: false,
         }
@@ -610,6 +623,7 @@ impl<'a> ImportRequest<'a> {
         Self {
             module,
             member: Some(member),
+            asname: None,
             style: ImportStyle::ImportFrom,
             force_style: false,
         }
@@ -624,8 +638,18 @@ impl<'a> ImportRequest<'a> {
         Self {
             module,
             member: None,
+            asname: None,
             style: ImportStyle::Import,
             force_style: false,
+        }
+    }
+
+    /// Create a new [`ImportRequest`] for bringing the given module
+    /// into scope under a name of its own, as in `import numpy as np`.
+    pub(crate) fn module_as(module: &'a str, asname: &'a str) -> Self {
+        Self {
+            asname: Some(asname),
+            ..Self::module(module)
         }
     }
 
@@ -717,12 +741,17 @@ impl<'a> ImportRequest<'a> {
 
 impl std::fmt::Display for ImportRequest<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self.style {
-            ImportStyle::Import => write!(f, "import {}", self.module),
-            ImportStyle::ImportFrom => match self.member {
-                None => write!(f, "import {}", self.module),
-                Some(member) => write!(f, "from {} import {member}", self.module),
-            },
+        match (&self.style, self.member) {
+            (ImportStyle::ImportFrom, Some(member)) => {
+                write!(f, "from {} import {member}", self.module)
+            }
+            _ => {
+                write!(f, "import {}", self.module)?;
+                match self.asname {
+                    Some(asname) => write!(f, " as {asname}"),
+                    None => Ok(()),
+                }
+            }
         }
     }
 }

--- a/crates/ty_ide/src/lib.rs
+++ b/crates/ty_ide/src/lib.rs
@@ -6,6 +6,7 @@ mod add_dependency;
 mod all_symbols;
 mod call_hierarchy;
 mod code_action;
+mod common_aliases;
 mod completion;
 mod data_flow;
 mod django_template;
@@ -430,6 +431,7 @@ mod tests {
     use ruff_python_trivia::textwrap::dedent;
     use ruff_text_size::TextSize;
     use ty_module_resolver::SearchPathSettings;
+    use ty_project::metadata::options::Options;
     use ty_project::{Db as _, ProjectMetadata, SemanticDb as _};
     use ty_python_core::ProgramFile;
     use ty_python_core::platform::PythonPlatform;
@@ -537,12 +539,17 @@ mod tests {
         snapshot_filters: Vec<(String, String)>,
         /// The python version to use.
         python_version: Option<PythonVersion>,
+        /// The `[tool.ty]` options the project is configured with.
+        options: Option<Options>,
     }
 
     impl CursorTestBuilder {
         pub(super) fn build(&self) -> CursorTest {
-            let mut db =
-                ty_project::TestDb::new(ProjectMetadata::new("test", SystemPathBuf::from("/")));
+            let mut metadata = ProjectMetadata::new("test", SystemPathBuf::from("/"));
+            if let Some(options) = self.options.clone() {
+                metadata.apply_override_options(options);
+            }
+            let mut db = ty_project::TestDb::new(metadata);
 
             if let Some(python_version) = self.python_version {
                 db.set_python_version(python_version);
@@ -641,11 +648,18 @@ mod tests {
             self
         }
 
+        /// Configure the project as a `[tool.ty]` table would.
+        pub(super) fn options(&mut self, options: Options) -> &mut CursorTestBuilder {
+            self.options = Some(options);
+            self
+        }
+
         /// Convert to a builder that supports site-packages (third-party dependencies).
         pub(super) fn with_site_packages(self) -> SitePackagesCursorTestBuilder {
             SitePackagesCursorTestBuilder {
                 sources: self.sources,
                 site_packages_sources: Vec::new(),
+                options: self.options,
             }
         }
     }
@@ -664,6 +678,7 @@ mod tests {
     pub(super) struct SitePackagesCursorTestBuilder {
         sources: Vec<Source>,
         site_packages_sources: Vec<Source>,
+        options: Option<Options>,
     }
 
     impl SitePackagesCursorTestBuilder {
@@ -671,8 +686,11 @@ mod tests {
             let project_root = SystemPathBuf::from("/src");
             let site_packages_path = SystemPathBuf::from("/site-packages");
 
-            let mut db =
-                ty_project::TestDb::new(ProjectMetadata::new("test", project_root.clone()));
+            let mut metadata = ProjectMetadata::new("test", project_root.clone());
+            if let Some(options) = self.options.clone() {
+                metadata.apply_override_options(options);
+            }
+            let mut db = ty_project::TestDb::new(metadata);
 
             // Write site-packages files first.
             for Source {

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -3,7 +3,7 @@ use crate::glob::{ExcludeFilter, IncludeExcludeFilter, IncludeFilter, PortableGl
 use crate::metadata::python_version::SupportedPythonVersion;
 use crate::metadata::settings::{OverrideSettings, SrcSettings};
 
-use super::settings::{Override, Settings, TerminalSettings};
+use super::settings::{EditorSettings, Override, Settings, TerminalSettings};
 use crate::metadata::value::{RelativeGlobPattern, RelativePathBuf};
 use anyhow::Context;
 use ordermap::OrderMap;
@@ -23,6 +23,7 @@ use rustc_hash::FxHasher;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::cmp::Ordering;
+use std::collections::BTreeMap;
 use std::fmt::{self, Debug, Display};
 use std::hash::BuildHasherDefault;
 use std::ops::Deref;
@@ -104,6 +105,11 @@ pub struct Options {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[option_group]
     pub run: Option<RunOptions>,
+
+    /// Configures the parts of the editor experience that type checking does not decide.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option_group]
+    pub editor: Option<EditorOptions>,
 
     /// Override configurations for specific file patterns.
     ///
@@ -493,11 +499,20 @@ impl Options {
             });
         let overrides = strategy.fallback(overrides, |_| Vec::new())?;
 
+        let editor = EditorSettings::new(
+            self.editor
+                .as_ref()
+                .and_then(|editor| editor.common_aliases.as_ref())
+                .into_iter()
+                .flat_map(CommonAliases::iter),
+        );
+
         let settings = Settings {
             rules: Arc::new(rules),
             terminal,
             src,
             analysis,
+            editor,
             overrides,
         };
 
@@ -1487,6 +1502,81 @@ pub struct RunOptions {
         "#
     )]
     pub main: Option<RangedValue<String>>,
+}
+
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    Eq,
+    PartialEq,
+    Combine,
+    Serialize,
+    Deserialize,
+    OptionsMetadata,
+    get_size2::GetSize,
+)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct EditorOptions {
+    /// The modules a name is a common alias of, keyed by the alias.
+    ///
+    /// A file that writes `np.` before importing anything almost always means numpy, because `np`
+    /// is what numpy is conventionally imported as. The editor completes such a name as the module
+    /// it names, and accepting one of those completions writes the `import numpy as np` that makes
+    /// the name real.
+    ///
+    /// This adds aliases of your own to the ones ty already knows; an entry whose alias ty knows
+    /// replaces it. An alias for a module the project does not have is never offered, so an entry
+    /// for a module nobody installed costs nothing.
+    ///
+    /// Defaults to `{}`, which leaves ty's own aliases as they are.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"{}"#,
+        value_type = "dict[str, str]",
+        example = r#"
+            [tool.ty.editor.common-aliases]
+            npt = "numpy.typing"
+        "#
+    )]
+    pub common_aliases: Option<CommonAliases>,
+}
+
+/// The modules that names are common aliases of, keyed by the alias.
+///
+/// A `BTreeMap` rather than a hash map because the order these are offered in should not depend on
+/// a hash seed.
+#[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize, get_size2::GetSize)]
+#[serde(transparent)]
+pub struct CommonAliases {
+    inner: BTreeMap<String, String>,
+}
+
+impl CommonAliases {
+    /// The configured aliases, each paired with the module it names.
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = (&str, &str)> {
+        self.inner
+            .iter()
+            .map(|(alias, module)| (alias.as_str(), module.as_str()))
+    }
+}
+
+impl Combine for CommonAliases {
+    fn combine_with(&mut self, mut other: Self) {
+        // `self` takes precedence over `other`, and `extend` overwrites what it lands on, so the
+        // lower-precedence map is the one that gets extended
+        std::mem::swap(&mut self.inner, &mut other.inner);
+        self.inner.extend(other.inner);
+    }
+}
+
+impl FromIterator<(String, String)> for CommonAliases {
+    fn from_iter<T: IntoIterator<Item = (String, String)>>(iter: T) -> Self {
+        Self {
+            inner: iter.into_iter().collect(),
+        }
+    }
 }
 
 #[derive(
@@ -2679,6 +2769,19 @@ mod schema {
             object.insert("additionalProperties".to_string(), level_schema.into());
 
             schema
+        }
+    }
+
+    impl schemars::JsonSchema for super::CommonAliases {
+        fn schema_name() -> std::borrow::Cow<'static, str> {
+            std::borrow::Cow::Borrowed("CommonAliases")
+        }
+
+        fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+            schemars::json_schema!({
+                "type": "object",
+                "additionalProperties": { "type": "string" },
+            })
         }
     }
 }

--- a/crates/ty_project/src/metadata/settings.rs
+++ b/crates/ty_project/src/metadata/settings.rs
@@ -28,6 +28,7 @@ pub struct Settings {
     pub(super) terminal: TerminalSettings,
     pub(super) src: SrcSettings,
     pub(super) analysis: AnalysisSettings,
+    pub(super) editor: EditorSettings,
 
     /// Settings for configuration overrides that apply to specific file patterns.
     ///
@@ -60,6 +61,47 @@ impl Settings {
 
     pub(crate) fn analysis(&self) -> &AnalysisSettings {
         &self.analysis
+    }
+
+    pub fn editor(&self) -> &EditorSettings {
+        &self.editor
+    }
+}
+
+/// The resolved `[tool.ty.editor]` options.
+#[derive(Debug, Default, Clone, PartialEq, Eq, get_size2::GetSize)]
+pub struct EditorSettings {
+    /// The modules a name is a common alias of, paired with the alias and sorted by it.
+    ///
+    /// These are only the aliases the project configured. The ones the editor knows on its own
+    /// live with the feature that offers them, in `ty_ide`.
+    common_aliases: Box<[(Box<str>, Box<str>)]>,
+}
+
+impl EditorSettings {
+    pub(super) fn new<'a>(common_aliases: impl Iterator<Item = (&'a str, &'a str)>) -> Self {
+        let mut common_aliases: Box<[(Box<str>, Box<str>)]> = common_aliases
+            .map(|(alias, module)| (Box::from(alias), Box::from(module)))
+            .collect();
+        // `common_alias` looks these up by binary search
+        common_aliases.sort_by(|(left, _), (right, _)| left.cmp(right));
+        Self { common_aliases }
+    }
+
+    /// The module the project configured `alias` to name, if it configured one.
+    pub fn common_alias(&self, alias: &str) -> Option<&str> {
+        self.common_aliases
+            .binary_search_by(|(configured, _)| (**configured).cmp(alias))
+            .ok()
+            .and_then(|found| self.common_aliases.get(found))
+            .map(|(_, module)| &**module)
+    }
+
+    /// Every alias the project configured, paired with the module it names, in alias order.
+    pub fn common_aliases(&self) -> impl ExactSizeIterator<Item = (&str, &str)> {
+        self.common_aliases
+            .iter()
+            .map(|(alias, module)| (&**alias, &**module))
     }
 }
 

--- a/crates/ty_python_semantic/src/assumed.rs
+++ b/crates/ty_python_semantic/src/assumed.rs
@@ -665,7 +665,8 @@ def f():
             .build()
             .expect("valid TestDb setup");
 
-        let stopped = system_path_to_file(&db, "/src/stopped.py").expect("the fixture was written");
+        let stopped =
+            system_path_to_file(&db, "/src/stopped.py").expect("the fixture was written");
         let other = system_path_to_file(&db, "/src/other.py").expect("the fixture was written");
 
         let assumptions = Assumptions::new(

--- a/crates/ty_python_semantic/src/assumed.rs
+++ b/crates/ty_python_semantic/src/assumed.rs
@@ -665,8 +665,7 @@ def f():
             .build()
             .expect("valid TestDb setup");
 
-        let stopped =
-            system_path_to_file(&db, "/src/stopped.py").expect("the fixture was written");
+        let stopped = system_path_to_file(&db, "/src/stopped.py").expect("the fixture was written");
         let other = system_path_to_file(&db, "/src/other.py").expect("the fixture was written");
 
         let assumptions = Assumptions::new(

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -1111,18 +1111,23 @@ impl<'db> SemanticModel<'db> {
         self.submodule_completions(&module)
     }
 
-    /// Returns completions for symbols available in the given module as if
-    /// it were imported by this model's `File`.
-    fn module_completions(&self, module_name: &ModuleName) -> Vec<Completion<'db>> {
-        let db = self.db;
-        let Some(module) = resolve_module(
+    /// Resolves `module_name` as if it were imported by this model's `File`.
+    pub fn resolve_module_name(&self, module_name: &ModuleName) -> Option<Module<'db>> {
+        resolve_module(
             self.db,
             ImportingFile::File(
                 self.file(),
                 self.program_environment().resolver_environment(self.db),
             ),
             module_name,
-        ) else {
+        )
+    }
+
+    /// Returns completions for symbols available in the given module as if
+    /// it were imported by this model's `File`.
+    pub fn module_completions(&self, module_name: &ModuleName) -> Vec<Completion<'db>> {
+        let db = self.db;
+        let Some(module) = self.resolve_module_name(module_name) else {
             tracing::debug!("Could not resolve module from `{module_name:?}`");
             return vec![];
         };

--- a/crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
@@ -234,6 +234,9 @@ Settings: Settings {
             "builtins.classmethod",
         ],
     },
+    editor: EditorSettings {
+        common_aliases: [],
+    },
     overrides: [],
 }
 

--- a/docs/basedpython/features/editor.md
+++ b/docs/basedpython/features/editor.md
@@ -82,6 +82,42 @@ a type position offers the words basedpython spells types with — `literal`,
 keywords, which never read there. a [type parameter](generics.md) offers its
 modifiers before the name: `in`, `out`, `in out`, `overlapping`, `reified`
 
+### common aliases
+
+a name that is conventionally an alias of a module completes as that module,
+in a file that has not imported it yet. `np.` offers what numpy has, and
+accepting one of those completions writes the import that binds the name:
+
+```py
+import numpy as np
+
+np.arange
+```
+
+the alias itself completes the same way — typing `n` offers `np`, and taking it
+writes `import numpy as np`
+
+only a module the project actually has is offered, and only where the name is
+free: a file that binds `np` to something of its own means that, and gets
+nothing from numpy
+
+the aliases are the ones the python ecosystem already writes — `np`, `pd`,
+`plt`, `dt`, and the rest. a project spells aliases of its own in its
+configuration, keyed by the alias:
+
+```toml
+[tool.ty.editor.common-aliases]
+npt = "numpy.typing"
+```
+
+an alias configured under a name ty already knows replaces it
+
+a name left unimported reports as unresolved, and the quick fix on that
+diagnostic writes the same import
+
+these are auto-imports, so turning off `ty.completions.autoImport` turns them
+off too
+
 ### enum members and extensions
 
 a bare [enum member](enums.md) is offered where the expected type admits one —

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -13,6 +13,17 @@
         }
       ]
     },
+    "editor": {
+      "description": "Configures the parts of the editor experience that type checking does not decide.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/EditorOptions"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "environment": {
       "description": "Configures the type checking environment.",
       "anyOf": [
@@ -231,6 +242,29 @@
       "items": {
         "$ref": "#/definitions/string"
       }
+    },
+    "CommonAliases": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "EditorOptions": {
+      "type": "object",
+      "properties": {
+        "common-aliases": {
+          "description": "The modules a name is a common alias of, keyed by the alias.\n\nA file that writes `np.` before importing anything almost always means numpy, because `np`\nis what numpy is conventionally imported as. The editor completes such a name as the module\nit names, and accepting one of those completions writes the `import numpy as np` that makes\nthe name real.\n\nThis adds aliases of your own to the ones ty already knows; an entry whose alias ty knows\nreplaces it. An alias for a module the project does not have is never offered, so an entry\nfor a module nobody installed costs nothing.\n\nDefaults to `{}`, which leaves ty's own aliases as they are.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CommonAliases"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
     },
     "EnvironmentOptions": {
       "type": "object",


### PR DESCRIPTION
a name that is conventionally an alias of a module now completes as that module in a file that has not imported it: `np.` offers numpy's members and `n` offers `np`, each carrying the `import numpy as np` that binds the name. the quick fix on an unresolved alias writes the same import

`[tool.ty.editor] common-aliases` adds aliases of a project's own
