### PR TITLE
a callable converts to one returning None by discarding its result

### DIFF
--- a/crates/by_transforms/src/transforms/conversion.rs
+++ b/crates/by_transforms/src/transforms/conversion.rs
@@ -2,13 +2,14 @@
 //!
 //! A conversion site is a position where the checker accepted a value that is
 //! not assignable to the type declared there, because some conversion repairs
-//! it. There are four, and ty resolves which one applies — this pass only emits
+//! it. There are five, and ty resolves which one applies — this pass only emits
 //! the call it was handed:
 //!
 //! ```text
 //! report(celsius)         →  report(Fahrenheit.__from__(celsius))
 //! v: Vec3 = [1.0, 2.0]    →  v: Vec3 = Vec3.__of__([1.0, 2.0])
 //! report(celsius)         →  report((celsius).__into__())
+//! on_click(handler)       →  on_click(_by_discard(handler))
 //! ```
 //!
 //! Which one it is never matters here: a conversion arrives as the text to put
@@ -25,9 +26,10 @@
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_ast::{self as ast, Expr, Stmt};
 use ruff_text_size::{Ranged, TextRange, TextSize};
-use ty_python_semantic::{ConversionInfo, PreludeDunderReceiver};
+use ty_python_semantic::{ConversionInfo, ConversionRuntime, PreludeDunderReceiver};
 
 use super::ast_driver::{Fragment, PassContext, TypeAwarePass};
+use super::wrapped_runtime::discard_return_runtime;
 use crate::type_info::TypeInfo;
 
 /// emit the conversion the checker resolved at every conversion site
@@ -119,6 +121,7 @@ impl TypeAwarePass for ConversionPass<'_> {
                 let ConversionInfo::Call {
                     referenced_name,
                     imports,
+                    runtime,
                     ..
                 } = info
                 else {
@@ -134,6 +137,15 @@ impl TypeAwarePass for ConversionPass<'_> {
                     rejected = true;
                     continue;
                 };
+                // a definition no module can supply, injected at the top of the
+                // file. `required_imports` dedupes, so several sites needing the
+                // same adapter still define it once
+                match runtime {
+                    Some(ConversionRuntime::DiscardReturn) => {
+                        ctx.required_imports.push(discard_return_runtime());
+                    }
+                    None => {}
+                }
                 for import in imports {
                     // always aliased: the class's own name may already mean
                     // something else here, and an import that rebinds it — or that

--- a/crates/by_transforms/src/transforms/wrapped_runtime.rs
+++ b/crates/by_transforms/src/transforms/wrapped_runtime.rs
@@ -1,4 +1,4 @@
-//! Shared runtime polyfill for basedpython wrapped optionals.
+//! Shared runtime polyfills basedpython injects into the file that needs them.
 //!
 //! `Optional` is the runtime machine for wrapped optionals: it is both the
 //! present-case value wrapper that `Some(x)` lowers to (`Optional(x)`, holding
@@ -6,6 +6,11 @@
 //! (`Optional[int | None]`). Passes that emit either form inject this class via
 //! [`PassContext::required_imports`](super::ast_driver::PassContext), which
 //! dedupes identical entries so the class is defined at most once.
+//!
+//! `_by_discard` is the adapter a conversion site wraps a callable in when the
+//! site asked for one returning `None`.
+
+use ty_python_semantic::DISCARD_ADAPTER;
 
 pub(crate) const OPTIONAL_RUNTIME: &str = "\
 class Optional:
@@ -18,3 +23,41 @@ class Optional:
     def __repr__(self):
         return f\"Some({self.value!r})\"
 ";
+
+/// The adapter a callable is wrapped in where the site declared one returning
+/// `None` and the callable returns something else — basedpython's coercion to
+/// `None`, which the checker resolves as a conversion route.
+///
+/// A bare closure would throw the result away just as well. It would also stop
+/// comparing equal to the callable it wraps, and python deregisters callbacks by
+/// value all the time — `observers.remove(cb)`, `atexit.unregister(cb)`,
+/// `signal.disconnect(cb)`. Delegating `__eq__` and `__hash__` is what keeps a
+/// wrapped callback removable; delegating everything else through `__getattr__`
+/// is what keeps `cb.__name__` answering for a framework that reads it
+pub(crate) fn discard_return_runtime() -> String {
+    format!(
+        "\
+class {DISCARD_ADAPTER}:
+    __slots__ = (\"__wrapped__\",)
+
+    def __init__(self, fn):
+        self.__wrapped__ = fn
+
+    def __call__(self, *args, **kwargs):
+        self.__wrapped__(*args, **kwargs)
+
+    def __getattr__(self, name):
+        if name == \"__wrapped__\":
+            raise AttributeError(name)
+        return getattr(self.__wrapped__, name)
+
+    def __eq__(self, other):
+        if isinstance(other, {DISCARD_ADAPTER}):
+            other = other.__wrapped__
+        return self.__wrapped__ == other
+
+    def __hash__(self):
+        return hash(self.__wrapped__)
+"
+    )
+}

--- a/crates/by_transforms/tests/discard_return_runtime.rs
+++ b/crates/by_transforms/tests/discard_return_runtime.rs
@@ -1,0 +1,184 @@
+//! Runtime test for the adapter a callable gets at a `-> None` conversion site.
+//!
+//! The mdtest shows which sites the checker accepts and the text-level test shows
+//! the wrap; what neither can show is that the adapter behaves like the callable
+//! it replaced. Every claim exercised here is one a plausible-looking adapter
+//! would break:
+//!
+//! - the result really is `None`, which is the whole reason the site was allowed
+//!   to accept a callable returning something else
+//! - the wrapped callable still runs, and every argument reaches it unchanged —
+//!   positional, keyword, variadic and keyword-variadic
+//! - a wrapped callback can still be deregistered. python does that by value
+//!   (`observers.remove(cb)`, `seen.discard(cb)`), and each site wraps the value
+//!   separately, so two *different* adapter objects have to compare equal and
+//!   hash alike or the callback is stuck in the list forever
+//! - attributes still answer, so a framework reading `cb.__name__` off a wrapped
+//!   callback gets the wrapped function's name rather than an `AttributeError`
+
+use std::process::{Command, Stdio};
+
+use by_transforms::{Config, PythonVersion, transpile};
+
+/// basedpython whose module-level `assert`s exercise the adapter end to end
+const PROGRAM: &str = r#"
+calls: list[str] = []
+
+def handler() -> int:
+    calls.append("handler")
+    return 1
+
+def varied(a: int, /, name: str = "n", *rest: int, **kw: int) -> str:
+    calls.append(f"{a}|{name}|{rest}|{sorted(kw.items())}")
+    return "done"
+
+# the site declared `None`, so `None` is what the caller sees — the value the
+# wrapped callable returned is gone rather than merely mistyped
+def call_it(cb: () -> None) -> object:
+    return cb()
+
+assert call_it(handler) is None
+assert calls == ["handler"], calls
+calls.clear()
+
+# a lambda converts the same way a named function does
+assert call_it(lambda: 1) is None
+
+# every argument reaches the wrapped callable unchanged
+def call_varied(cb: (int, /, name: str, *args: int, **kwargs: int) -> None) -> None:
+    cb(1, name="x", **{"k": 3})
+
+call_varied(varied)
+assert calls == ["1|x|()|[('k', 3)]"], calls
+calls.clear()
+
+# deregistration by value: the adapter at the `remove` site is a different object
+# from the one at the `append` site, so this only works if they compare equal
+observers: list[() -> None] = []
+
+def subscribe(cb: () -> None) -> None:
+    observers.append(cb)
+
+def unsubscribe(cb: () -> None) -> None:
+    observers.remove(cb)
+
+subscribe(handler)
+assert len(observers) == 1
+for observer in observers:
+    assert observer() is None
+assert calls == ["handler"], calls
+calls.clear()
+unsubscribe(handler)
+assert observers == [], observers
+
+# the same through a hash-based container, which needs `__hash__` to agree too
+seen: set[() -> None] = set()
+seen.add(handler)
+assert len(seen) == 1
+seen.discard(handler)
+assert len(seen) == 0, len(seen)
+
+# a method is reached through a different branch of the check that decides
+# whether a call is worth inspecting at all, so it needs its own exercise
+class Registry:
+    def __init__(self):
+        self.items: list[() -> None] = []
+
+    def add(self, cb: () -> None) -> None:
+        self.items.append(cb)
+
+registry = Registry()
+registry.add(handler)
+assert registry.items[0]() is None
+assert calls == ["handler"], calls
+calls.clear()
+
+# attributes answer off the wrapped callable
+held: () -> None = handler
+assert getattr(held, "__name__") == "handler", getattr(held, "__name__")
+
+# a callable that arrives in a variable converts as one named at the site does
+source: () -> int = handler
+assert call_it(source) is None
+calls.clear()
+
+# a `return`
+def make() -> (() -> None):
+    return handler
+
+assert make()() is None
+calls.clear()
+
+# an attribute assignment
+class Widget:
+    on_click: () -> None
+
+widget = Widget()
+widget.on_click = handler
+assert widget.on_click() is None
+calls.clear()
+
+# element-wise inside a literal collection: each element is wrapped where it
+# stands, and each one still discards
+callbacks: list[() -> None] = [handler, handler]
+assert [cb() for cb in callbacks] == [None, None]
+assert calls == ["handler", "handler"], calls
+
+# a callable that already returns `None` is untouched, so it stays the very same
+# object rather than picking up an adapter it does not need
+def silent() -> None: ...
+
+plain: () -> None = silent
+assert plain === silent
+
+print("ok")
+"#;
+
+/// the first interpreter that accepts `probe`
+fn python_supporting(probe: &str) -> Option<String> {
+    let mut candidates = Vec::new();
+    if let Ok(p) = std::env::var("PYTHON") {
+        candidates.push(p);
+    }
+    candidates.extend(["python3.13", "python3"].map(String::from));
+
+    candidates.into_iter().find(|py| {
+        Command::new(py)
+            .args(["-c", probe])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    })
+}
+
+#[test]
+#[expect(
+    clippy::print_stderr,
+    reason = "a skipped test must say why it skipped, or it reads as a pass"
+)]
+fn discarded_returns_run_correctly() {
+    let Some(python) = python_supporting("import sys; sys.exit(0)") else {
+        eprintln!("skipping discard-return runtime test: no python interpreter found");
+        return;
+    };
+    let config = Config {
+        min_version: PythonVersion::PY313,
+        ..Config::default()
+    };
+    let transpiled = transpile(PROGRAM, &config).expect("transpile should succeed");
+
+    let output = Command::new(&python)
+        .arg("-c")
+        .arg(&transpiled)
+        .output()
+        .expect("failed to spawn python");
+
+    assert!(
+        output.status.success(),
+        "transpiled discard-return program failed on {python}:\n--- stdout ---\n{}\n--- stderr ---\n{}\n--- transpiled ---\n{transpiled}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}

--- a/crates/ty_python_semantic/resources/mdtest/basedpython_conversions.md
+++ b/crates/ty_python_semantic/resources/mdtest/basedpython_conversions.md
@@ -803,3 +803,158 @@ extension str(Show):
 
 frozen: frozenset[Show] = {"a"}  # error: [invalid-assignment]
 ```
+
+## a callable converts to one that returns `None`
+
+A site that declared a callable returning `None` throws the return value away, so a callable that
+returns something else reaches it through an adapter. This is the one route that needs no dunder:
+what repairs the value is code the transpiler writes, not code the type declares.
+
+```by
+def on_click(cb: () -> None) -> None: ...
+
+def handler() -> int:
+    return 1
+
+on_click(handler)
+on_click(lambda: 1)
+```
+
+## a callable value converts, not just one written out at the site
+
+The adapter forwards whatever it wraps, so it is honest about a callable that arrives in a variable
+just as it is about one named at the site.
+
+```by
+def on_click(cb: () -> None) -> None: ...
+
+def handler() -> int:
+    return 1
+
+held: () -> int = handler
+on_click(held)
+```
+
+## the site has to promise `None` before a return is dropped
+
+A wider return type is a caller that may still read the value the adapter would have dropped.
+`-> object` already accepts every callable without any repair, and `-> int` wants the value.
+
+```by
+def wants_object(cb: () -> object) -> None: ...
+def wants_int(cb: () -> int) -> None: ...
+
+def handler() -> str:
+    return "x"
+
+wants_object(handler)
+wants_int(handler)  # error: [invalid-argument-type]
+```
+
+## only the return type is repaired
+
+The adapter forwards its arguments unchanged, so it cannot repair a parameter list. A callable that
+takes the wrong arguments is as unassignable as it ever was.
+
+```by
+def on_click(cb: () -> None) -> None: ...
+
+def needs_argument(a: int) -> int:
+    return a
+
+on_click(needs_argument)  # error: [invalid-argument-type]
+```
+
+## discarding a return does not reach inside a generic
+
+The adapter is a *different callable* from the one it wraps, so this stays a conversion rather than
+a subtyping edge — exactly as `__from__` does, and for the same reason. There is nowhere inside a
+constructed generic to put the adapter, and an element read back out would be a callable no one
+wrapped.
+
+```by
+def handlers() -> list[() -> int]:
+    return []
+
+callbacks: list[() -> None] = handlers()  # error: [invalid-assignment]
+```
+
+## a callable that already returns `None` is left alone
+
+```by
+def on_click(cb: () -> None) -> None: ...
+
+def handler() -> None: ...
+
+on_click(handler)
+```
+
+## a discarded return is ambiguous beside a dunder that also applies
+
+A callable object may declare `__into__` as well, and the two produce different runtime values — the
+adapter forwards to `__call__`, `__into__` hands back whatever its body built. Which one runs must
+not depend on ordering, so the site is reported rather than resolved.
+
+```by
+def sink() -> None: ...
+
+class Handler:
+    def __call__(self) -> int:
+        return 1
+
+    def __into__(self) -> (() -> None):
+        return sink
+
+def on_click(cb: () -> None) -> None: ...
+
+on_click(Handler())  # error: [ambiguous-conversion]
+```
+
+## an `async` callable is not repaired by a synchronous adapter
+
+An `async def` returns a coroutine rather than the value its body produces, so the return type a
+site declares is `Coroutine[..., None]` and not `None`. Requiring the site to promise exactly `None`
+is what keeps the adapter away: wrapping one of these would return a coroutine that nothing ever
+awaits, and the call would silently do nothing.
+
+```by
+def on_click(cb: () -> Coroutine[object, object, None]) -> None: ...
+
+async def handler() -> int:
+    return 1
+
+on_click(handler)  # error: [invalid-argument-type]
+```
+
+## a reified generic is not repaired by an adapter
+
+A [reified generic](basedpython_reified_generics.md) is a two-step callable — `f[int]()` — and a
+plain callable has no slot for the specialization step. Reading it *as* a callable loses that step,
+so the question of whether only the return type is wrong is asked of the function itself rather than
+of a callable rebuilt from it.
+
+```by
+def f[T]():
+    print(T)
+
+callback: () -> None = f  # error: [invalid-assignment]
+```
+
+## a target that asks for more than a callable is not repaired
+
+The adapter is a callable and nothing else, so a protocol wanting other members alongside `__call__`
+is no better served by the wrapped callable than by the bare one.
+
+```by
+protocol Handler:
+    name: str
+
+    def __call__(self) -> None
+
+def on_click(cb: Handler) -> None: ...
+
+def handler() -> int:
+    return 1
+
+on_click(handler)  # error: [invalid-argument-type]
+```

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -46,7 +46,9 @@ pub use types::conformance::declares_conformances;
 pub use types::conformance::{
     ConformanceRegistration, ConformanceTest, WitnessDispatch, WitnessKind,
 };
-pub use types::conversions::{ConversionImport, ConversionInfo};
+pub use types::conversions::{
+    ConversionImport, ConversionInfo, ConversionRuntime, DISCARD_ADAPTER,
+};
 pub use types::extensions::{ExtensionAttributeInfo, ExtensionMemberKind};
 pub use types::ide_support::{
     ImplementationsFinder, ImportAliasResolution, OverridableMember, ResolvedDefinition,

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -605,12 +605,14 @@ impl<'db> SemanticModel<'db> {
         };
         signature.iter().any(|overload| {
             overload.parameters().iter().any(|parameter| {
-                crate::types::conversions::may_convert(
-                    db,
-                    env,
-                    self.file.file(db),
-                    parameter.annotated_type(),
-                )
+                let parameter_type = parameter.annotated_type();
+                crate::types::conversions::may_convert(db, env, self.file.file(db), parameter_type)
+                    // a callable that returns something the parameter does not
+                    // want is repaired by an adapter rather than by a dunder, so
+                    // there is no class for `may_convert` to read it off. asked
+                    // of the parameter and not of the argument because only the
+                    // *declared* side decides whether a return may be dropped
+                    || crate::types::conversions::target_discards_return(db, env, parameter_type)
             })
         })
     }

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -597,6 +597,41 @@ impl<'db> CallableType<'db> {
         )
     }
 
+    /// the same callable, with every overload returning `return_ty` instead.
+    ///
+    /// basedpython asks this to describe a callable it has not built yet: the
+    /// adapter that a `-> None` conversion site wraps a value in returns `None`
+    /// whatever the wrapped callable returned, and the relation between that
+    /// adapter and the declared type is what decides whether the site converts
+    /// at all. See [`crate::types::conversions`]
+    pub(crate) fn with_return_type(
+        self,
+        db: &'db dyn Db,
+        return_ty: Type<'db>,
+    ) -> CallableType<'db> {
+        CallableType::new(
+            db,
+            CallableSignature::from_overloads(
+                self.signatures(db)
+                    .iter()
+                    .map(|signature| signature.clone().with_return_type(return_ty)),
+            ),
+            self.kind(db),
+            self.provenance(db),
+        )
+    }
+
+    /// does every overload return exactly `None`?
+    ///
+    /// The question a conversion site asks of the *declared* type before it will
+    /// throw a return value away. Anything wider — `object`, `int | None` — is a
+    /// caller that may still read the value the adapter would have dropped
+    pub(crate) fn returns_only_none(self, db: &'db dyn Db) -> bool {
+        self.signatures(db)
+            .iter()
+            .all(|signature| signature.return_ty.is_none(db))
+    }
+
     /// Returns the reduced callable produced by partially applying selected overloads.
     pub(crate) fn partially_apply(
         db: &'db dyn Db,

--- a/crates/ty_python_semantic/src/types/conversions.rs
+++ b/crates/ty_python_semantic/src/types/conversions.rs
@@ -1,4 +1,5 @@
-//! basedpython conversion dunders (`__from__`, `__into__`, `__of__`)
+//! basedpython conversions (`__from__`, `__into__`, `__of__`, and the adapter a
+//! callable gets where the site asked for one returning `None`)
 //!
 //! A conversion is a *call*, not a subtype relation: `Celsius` is never
 //! assignable to `Fahrenheit`, or `list[Celsius]` would be a `list[Fahrenheit]`
@@ -6,7 +7,7 @@
 //! relation stays out of the lattice and lives only at the positions where the
 //! transpiler can materialize the call.
 //!
-//! This module owns that rule for all four routes a value can be repaired by,
+//! This module owns that rule for all five routes a value can be repaired by,
 //! so every site asks one question and gets one answer:
 //!
 //! - `T.__from__(x)` — a classmethod on the target taking the source
@@ -18,6 +19,9 @@
 //!   emitted for one — the value already *is* what the protocol asks for at
 //!   runtime — but the route still lives here so that a site served by two
 //!   routes at once is reported rather than silently picked between
+//! - `_by_discard(f)` — the one route no type declares. a callable reaching a
+//!   site that asked for one returning `None` is wrapped in an adapter that
+//!   calls it and throws the result away. See [`discards_return`]
 //!
 //! More than one applicable route is an error rather than a precedence rule:
 //! `__from__` and `__into__` are hand-written bodies that can disagree, and
@@ -81,6 +85,10 @@ pub(crate) enum Route<'db> {
     /// `value.__into__()`. carries the *source* type, for diagnostics only —
     /// the lowered call names nothing
     Into(Type<'db>),
+    /// the value is a callable that returns something, and the site declared a
+    /// callable that returns `None`. it is wrapped in an adapter that calls it
+    /// and throws the result away
+    DiscardReturn,
 }
 
 impl<'db> Route<'db> {
@@ -101,6 +109,7 @@ impl<'db> Route<'db> {
             Route::From(class, source) => dunder(class, source, FROM),
             Route::Of(class, source) => dunder(class, source, OF),
             Route::Into(source) => format!("{}.{INTO}", source.display(db, env)),
+            Route::DiscardReturn => "discarding the return value".to_owned(),
         }
     }
 }
@@ -151,6 +160,9 @@ pub(crate) fn repair_conversion<'db>(
         routes.push(Route::Conformance(protocol));
     }
     dunder_routes(db, env, file, source, target, value, &mut routes);
+    if discards_return(db, env, source, target) {
+        routes.push(Route::DiscardReturn);
+    }
 
     let mut routes = routes.into_iter();
     let route = routes.next()?;
@@ -234,6 +246,80 @@ fn dunder_routes<'db>(
     {
         routes.push(Route::Into(source));
     }
+}
+
+/// would `source` fit `target` if its return value were thrown away?
+///
+/// This is kotlin's coercion to `Unit`, and it is a conversion here for the same
+/// reason it is not subtyping there: the adapter is a *different callable*, so
+/// `list[() -> int]` has to stay unrelated to `list[() -> None]`. Only a site the
+/// transpiler can wrap gets to ask, which is what keeps the relation out of the
+/// lattice — and out of the reach of the native backend, which picks a value
+/// representation from the declared type and would be picking it from a lie.
+///
+/// Nothing about the parameters is restated here: both halves below are ordinary
+/// assignability questions, so overloads, generics and parameter contravariance
+/// come from the relation rather than from a second implementation of it.
+///
+/// Two questions rather than one, because neither is sufficient alone:
+///
+/// 1. is the *return type* the only thing wrong? Asked by widening the target's
+///    return to `object`, which every type satisfies, and checking `source`
+///    against that — `source` itself, never a callable rebuilt from it.
+///    Upcasting to a callable is a lossy view: a reified generic is a two-step
+///    `f[...]()` that a plain callable has no slot for, and rebuilding from the
+///    view would quietly drop that and call the result repaired
+/// 2. does the adapter actually satisfy the target? Asked of `source` rebuilt
+///    with a `None` return, which is what the adapter's type is. A target that
+///    asks for more than a callable — a protocol with a `__call__` *and* other
+///    members — is not satisfied by an adapter, and only this half notices
+fn discards_return<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    source: Type<'db>,
+    target: Type<'db>,
+) -> bool {
+    if !target_discards_return(db, env, target) {
+        return false;
+    }
+    let Some(target_callables) = target.try_upcast_to_callable(db, env) else {
+        return false;
+    };
+    let anything = KnownClass::Object.to_instance(db, env);
+    let ignores_return = target_callables
+        .map(|callable| callable.with_return_type(db, anything))
+        .into_type(db, env);
+    if !source.is_assignable_to(db, env, ignores_return) {
+        return false;
+    }
+
+    let Some(source_callables) = source.try_upcast_to_callable(db, env) else {
+        return false;
+    };
+    let none = Type::none(db, env);
+    source_callables
+        .map(|callable| callable.with_return_type(db, none))
+        .into_type(db, env)
+        .is_assignable_to(db, env, target)
+}
+
+/// does `target` ask for a callable that returns exactly `None`?
+///
+/// Anything wider is a caller that may still read the value the adapter would
+/// have dropped: `-> object` already accepts every callable without one, and
+/// `-> int | None` would hand back a `None` where an `int` was promised
+pub(crate) fn target_discards_return<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    target: Type<'db>,
+) -> bool {
+    target
+        .try_upcast_to_callable(db, env)
+        .is_some_and(|callables| {
+            callables
+                .iter()
+                .all(|callable| callable.returns_only_none(db))
+        })
 }
 
 /// does calling `dunder` on `receiver` with `arguments` produce something the
@@ -911,6 +997,22 @@ pub struct ConversionImport {
     pub alias: String,
 }
 
+/// the name of the adapter [`ConversionRuntime::DiscardReturn`] defines, which
+/// is what the emitted `prefix` spells. The definition itself lives with the
+/// transpiler's other injected helpers, and is built from this
+pub const DISCARD_ADAPTER: &str = "_by_discard";
+
+/// a definition a conversion's emitted call needs that no module supplies.
+///
+/// The python text lives in the transpiler beside the other injected helpers;
+/// this only says which one the site needs, so that the lowering pass still
+/// never has to know which *route* it is emitting
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConversionRuntime {
+    /// the adapter that calls a callable and throws its result away
+    DiscardReturn,
+}
+
 /// how the transpiler materializes one conversion
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConversionInfo {
@@ -933,6 +1035,10 @@ pub enum ConversionInfo {
         referenced_name: Option<String>,
         /// every name `prefix` spells that this file does not already bind
         imports: Vec<ConversionImport>,
+        /// a definition `prefix` spells that no module can supply, injected once
+        /// at the top of the file. `None` for a route that only names code that
+        /// already exists somewhere
+        runtime: Option<ConversionRuntime>,
     },
     /// the checker accepted the site, but the conversion cannot be spelled here.
     /// The transpiler reports this rather than skipping it: emitting nothing
@@ -967,6 +1073,7 @@ pub(crate) fn conversion_info<'db>(
             replaces_value: false,
             referenced_name: None,
             imports: Vec::new(),
+            runtime: None,
         },
         Route::From(class, source) => {
             dunder_call_info(db, env, from_file, model, anchor, class, FROM, source)
@@ -983,6 +1090,18 @@ pub(crate) fn conversion_info<'db>(
             replaces_value: false,
             referenced_name: None,
             imports: Vec::new(),
+            runtime: None,
+        },
+        // the adapter is injected above every statement in the file, so unlike a
+        // class this file declares there is no order for the site to fall foul
+        // of — which is why it names nothing for the import-time check to read
+        Route::DiscardReturn => ConversionInfo::Call {
+            prefix: format!("{DISCARD_ADAPTER}("),
+            suffix: ")".to_owned(),
+            replaces_value: false,
+            referenced_name: None,
+            imports: Vec::new(),
+            runtime: Some(ConversionRuntime::DiscardReturn),
         },
     }
 }
@@ -1032,6 +1151,7 @@ fn dunder_call_info<'db>(
             replaces_value,
             referenced_name: Some(name),
             imports: import.into_iter().collect(),
+            runtime: None,
         },
         Err(reason) => ConversionInfo::Rejected(reason),
     }
@@ -1085,6 +1205,7 @@ fn backing_call_info<'db>(
         replaces_value: false,
         referenced_name: Some(receiver),
         imports,
+        runtime: None,
     }
 }
 

--- a/docs/basedpython/features/conversions.md
+++ b/docs/basedpython/features/conversions.md
@@ -33,6 +33,10 @@ after rust's `From` and `Into`. `__of__` is the third case rust has no name for:
 constructing a type from a written-out value, so that `1`, `None` and
 `[1, 2, foo()]` can stand for something that is not an `int`, `None` or a `list`.
 
+a fourth route needs no dunder at all: a callable reaching a site that asked for
+one returning `None` is wrapped in an adapter that
+[throws the result away](#discarding-a-return-value).
+
 they are ordinary methods. nothing is registered and nothing is monkeypatched —
 `Fahrenheit.__from__(c)` is a plain classmethod call, and the whole feature is
 the checker agreeing to insert it for you.
@@ -170,6 +174,89 @@ p: Path = _by_ext__Path____of__(Path, "/tmp/x")
 a type that declares the dunder itself wins, the same way an extension never
 shadows a declared member. this is how the builtin frozen containers get theirs;
 see [frozen container displays](frozen-displays.md).
+
+## discarding a return value
+
+a callable that returns something reaches a site that asked for one returning
+`None`:
+
+```by
+def on_click(cb: () -> None): ...
+
+def handler() -> int:
+    return 1
+
+on_click(handler)
+```
+
+→
+
+```python
+on_click(_by_discard(handler))
+```
+
+`_by_discard` calls what it wraps and throws the result away, so a callee that
+declared `None` really is handed `None`. it forwards every argument, compares
+equal to the callable it wraps and answers attributes off it, so a callback
+registered through one can still be found again:
+
+```by
+observers: list[() -> None] = []
+
+def subscribe(cb: () -> None):
+    observers.append(cb)
+
+def unsubscribe(cb: () -> None):
+    observers.remove(cb)      # finds the callback `subscribe` added
+```
+
+this is the one route that needs no dunder — nothing has to be declared, and it
+applies wherever a callable meets a callable type returning `None`.
+
+the site has to promise `None` and nothing else. `-> object` already accepts
+every callable and needs no adapter; any other return type still wants the
+value:
+
+```by
+def wants_object(cb: () -> object): ...
+def wants_str(cb: () -> str): ...
+
+wants_object(handler)         # fine, and unwrapped — `object` takes the `int`
+wants_str(handler)            # error: `int` is not assignable to `str`
+```
+
+only the return type is repaired. the adapter forwards its arguments unchanged,
+so a callable that takes the wrong ones is as unassignable as ever:
+
+```by
+def needs_argument(a: int) -> int: ...
+
+on_click(needs_argument)      # error
+```
+
+### why it is a conversion and not assignability
+
+kotlin has this feature, and it is worth being precise about what it does. `f(::foo)`
+passes an `Int`-returning function to a `() -> Unit` parameter, but the function
+type itself is not a subtype:
+
+```kotlin
+val g: () -> Int = ::foo
+f(g)                          // error: type mismatch
+```
+
+the same holds here: `() -> int` is not a `() -> None`. the adapter is a
+different object from the callable it wraps, so a relation built on it could not
+survive being carried inside a generic:
+
+```by
+handlers: list[() -> int] = [...]
+callbacks: list[() -> None] = handlers   # error
+```
+
+there is nowhere inside the list to write an adapter, and an element read back
+out would be a callable nobody wrapped. so the rule lives where the other
+conversions live — at sites the transpiler can write the adapter into.
 
 ## conversion sites
 

--- a/docs/basedpython/features/index.md
+++ b/docs/basedpython/features/index.md
@@ -185,7 +185,8 @@ syntax inside a function body
 - [export imports](export-imports.md) — `from x export y`
 - [extensions](extensions.md) — add members to an existing type, and declare that
     it conforms to an existing protocol
-- [conversions (`__from__` / `__into__` / `__of__`)](conversions.md)
+- [conversions (`__from__` / `__into__` / `__of__`)](conversions.md) — and
+    discarding a callable's return where the site asked for `None`
 - [frozen container displays](frozen-displays.md) — `{1}` for a `frozenset`
 - [context parameters](context-parameters.md)
 - [local lifetimes (`local` / `once`)](local-lifetimes.md)


### PR DESCRIPTION
coercion to None, as a fifth conversion route rather than a subtyping edge — the adapter is a different object from the callable it wraps, so the relation has to stay out of the lattice
