### PR TITLE
the traceback shim refuses a mapping its digests no longer vouch for

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4721,6 +4721,7 @@ dependencies = [
  "salsa",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "tikv-jemallocator",
  "toml 1.1.4+spec-1.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,6 +183,7 @@ serde = { version = "1.0.197", features = ["derive"] }
 serde-wasm-bindgen = { version = "0.6.4" }
 serde_json = { version = "1.0.113" }
 serde_test = { version = "1.0.152" }
+sha2 = { version = "0.10.9" }
 shellexpand = { version = "3.0.0" }
 similar = { version = "3.0.0", features = ["inline"] }
 smallvec = { version = "1.13.2", features = ["union", "const_generics", "const_new"] }

--- a/crates/basedpython/Cargo.lock
+++ b/crates/basedpython/Cargo.lock
@@ -187,6 +187,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,7 +387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
 
@@ -551,6 +560,15 @@ checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -624,6 +642,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -657,6 +685,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -874,6 +912,16 @@ dependencies = [
  "serde",
  "serde_json",
  "url",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -3012,6 +3060,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3474,6 +3533,7 @@ dependencies = [
  "salsa",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "tikv-jemallocator",
  "tracing",
@@ -3775,6 +3835,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3896,6 +3962,12 @@ checksum = "31e9bd4e9c9ff6a2a9b5969462ba26216af3e010df0377dad8320ab515262ef8"
 dependencies = [
  "smallvec",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vte"

--- a/crates/ty/Cargo.toml
+++ b/crates/ty/Cargo.toml
@@ -53,6 +53,7 @@ rayon = { workspace = true }
 salsa = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
 tempfile = { workspace = true }
 tracing = { workspace = true, features = ["release_max_level_debug"] }
 tracing-flame = { workspace = true }

--- a/crates/ty/src/by_commands.rs
+++ b/crates/ty/src/by_commands.rs
@@ -12,8 +12,10 @@ use ruff_db::diagnostic::{
     Severity, Span, SubDiagnostic, SubDiagnosticSeverity,
 };
 use ruff_db::files::system_path_to_file;
+use ruff_db::source::source_text;
 use ruff_db::system::{OsSystem, SystemPath, SystemPathBuf};
 use ruff_text_size::TextRange;
+use sha2::{Digest, Sha256};
 use ty_project::{Db, ProjectDatabase, ProjectMetadata};
 use walkdir::WalkDir;
 
@@ -182,15 +184,11 @@ pub(crate) fn cmd_run(
         &config,
         CheckGate::AllErrors,
         &rebuilder,
-        |bpy, src, line_map| {
-            let py = tmp.path().join(module_relative_path(&roots, &root, bpy));
-            fs::create_dir_all(py.parent().unwrap())?;
-            fs::write(&py, src)?;
-            traceback_entries.push(TracebackEntry {
-                py_path: py,
-                by_path: fs::canonicalize(bpy).unwrap_or_else(|_| bpy.to_path_buf()),
-                line_map: line_map.to_vec(),
-            });
+        |emitted| {
+            let py = tmp
+                .path()
+                .join(module_relative_path(&roots, &root, emitted.by_path));
+            traceback_entries.push(write_module(py, emitted)?);
             Ok(())
         },
     )?;
@@ -221,8 +219,10 @@ pub(crate) fn cmd_run(
         })?;
         let mut built = 0usize;
         for entry in &traceback_entries {
-            let source = fs::read_to_string(&entry.by_path)
-                .with_context(|| format!("could not read {}", entry.by_path.display()))?;
+            // the text the transpile ran on, not a fresh read of the file: a
+            // `.by` saved between the two would give this native module a
+            // different source than the sourcemap and its digest describe
+            let source = &entry.by_source;
             // the generated tree *is* the module tree, so the dotted name is the
             // path within it — and it has to be dotted, because a class's
             // `__module__` is read off the front of its type's `tp_name`. a file
@@ -238,15 +238,15 @@ pub(crate) fn cmd_run(
             if name.dotted() == module {
                 continue;
             }
-            let mut lowered = by_irbuild::module_from_source(&source, name, options.language);
+            let mut lowered = by_irbuild::module_from_source(source, name, options.language);
             lowered.lines = Some(by_ir::function::LineTable::new(
                 entry.by_path.display().to_string(),
-                &source,
+                source,
             ));
             // the root of the generated tree, not the directory the `.py` landed
             // in: the build lays the extension out at its module's own place, and
             // handing it the leaf directory would nest the tree inside itself
-            by_build::build_lowered(lowered, &source, &toolchain, tmp.path(), &options)
+            by_build::build_lowered(lowered, source, &toolchain, tmp.path(), &options)
                 .with_context(|| format!("could not compile {}", entry.by_path.display()))?;
             built += 1;
         }
@@ -445,29 +445,38 @@ pub(crate) fn cmd_build(
     let file_count = handles.len();
     let roots = module_roots(&db, &root);
     let mut packages: BTreeSet<PathBuf> = BTreeSet::new();
+    // `out/` outlives the build that wrote it — it is what a test runner, a
+    // debugger or an editor plugin sees — so the sourcemap goes with it. this is
+    // the directory where a `.by` really can be saved after the transpile, which
+    // is what the digests beside the map are for
+    let mut entries: Vec<TracebackEntry> = Vec::new();
     if !render_check_and_transpile(
         &db,
         &handles,
         &config,
         CheckGate::ParseErrorsOnly,
         &rebuilder,
-        |bpy, src, _line_map| {
-            let relative = module_relative_path(&roots, &root, bpy);
+        |emitted| {
+            let relative = module_relative_path(&roots, &root, emitted.by_path);
             if relative.components().count() > 1
                 && let Some(package) = relative.components().next()
             {
                 packages.insert(out.join(package));
             }
 
-            let py = out.join(relative);
-            fs::create_dir_all(py.parent().unwrap())?;
-            fs::write(&py, src)?;
-            eprintln!("{} -> {}", bpy.display(), py.display());
+            let entry = write_module(out.join(relative), emitted)?;
+            eprintln!(
+                "{} -> {}",
+                emitted.by_path.display(),
+                entry.py_path.display()
+            );
+            entries.push(entry);
             Ok(())
         },
     )? {
         return Ok(ExitStatus::Failure);
     }
+    write_sourcemap_module(&out, &entries)?;
 
     write_markers(&db, &packages)?;
 
@@ -988,9 +997,9 @@ fn forward_dir(dir: &Path, config: &Config) -> anyhow::Result<ExitStatus> {
         config,
         CheckGate::ParseErrorsOnly,
         &rebuilder,
-        |bpy, src, _line_map| {
-            let py = bpy.with_extension("py");
-            fs::write(&py, src).with_context(|| format!("{}", py.display()))?;
+        |emitted| {
+            let py = emitted.by_path.with_extension("py");
+            fs::write(&py, emitted.python).with_context(|| format!("{}", py.display()))?;
             Ok(())
         },
     )?;
@@ -1047,16 +1056,57 @@ struct TracebackEntry {
     py_path: PathBuf,
     by_path: PathBuf,
     line_map: Vec<Option<u32>>,
+    /// the `.by` text the transpile ran on, kept so nothing downstream has to
+    /// read the file a second time and risk reading a different one
+    by_source: String,
+    /// digest of the `.by` bytes the transpiler read
+    by_digest: String,
+    /// digest of the generated python bytes it wrote
+    py_digest: String,
 }
 
-/// Write the sourcemap module + runner shim into the build dir. The shim runs
-/// the target module and, on an uncaught exception, rewrites traceback frames
-/// in generated files back to their `.by` source location.
-fn write_traceback_runtime(dir: &Path, entries: &[TracebackEntry]) -> anyhow::Result<()> {
+/// write one emitted module out and describe it, in that order: the digests
+/// are over the bytes that just landed on disk
+fn write_module(py_path: PathBuf, emitted: &Transpiled<'_>) -> anyhow::Result<TracebackEntry> {
+    if let Some(parent) = py_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    fs::write(&py_path, emitted.python)
+        .with_context(|| format!("failed to write {}", py_path.display()))?;
+    Ok(TracebackEntry {
+        py_path,
+        by_path: fs::canonicalize(emitted.by_path)
+            .unwrap_or_else(|_| emitted.by_path.to_path_buf()),
+        line_map: emitted.line_map.to_vec(),
+        by_source: emitted.by_source.to_owned(),
+        by_digest: content_digest(emitted.by_source.as_bytes()),
+        py_digest: content_digest(emitted.python.as_bytes()),
+    })
+}
+
+/// a content digest as `_by_sourcemap.py` spells it: `sha256:` then lowercase
+/// hex
+///
+/// the algorithm is named in the value so it can be changed later without
+/// breaking readers — a reader that meets an algorithm it does not know refuses
+/// the entry, instead of comparing a hex it could never have produced
+fn content_digest(bytes: &[u8]) -> String {
+    format!("sha256:{:x}", Sha256::digest(bytes))
+}
+
+/// write the sourcemap module beside the generated python it describes
+///
+/// both tables are keyed by the generated path exactly as written here. a
+/// consumer that normalises those keys — the runner shim resolves symlinks, for
+/// one — has to keep the original key to reach the entry's digests
+fn write_sourcemap_module(dir: &Path, entries: &[TracebackEntry]) -> anyhow::Result<()> {
     use std::fmt::Write as _;
 
     let mut map_src = String::from(
-        "# generated by `by run` — maps transpiled python frames to .by source\nSOURCEMAP = {\n",
+        "# generated by basedpython — maps transpiled python frames to .by source\n\
+         # the two tables share their keys: the generated path, spelled as it is here\n\
+         SOURCEMAP = {\n",
     );
     for e in entries {
         let elems: Vec<String> = e
@@ -1072,9 +1122,41 @@ fn write_traceback_runtime(dir: &Path, entries: &[TracebackEntry]) -> anyhow::Re
             elems.join(", "),
         );
     }
+    map_src.push_str("}\n\n");
+
+    // `SOURCEMAP` alone cannot be checked: a `.by` edited since the transpile
+    // leaves it describing a pair of files that no longer exists, and every line
+    // it then reports is wrong with total confidence. the digests are what a
+    // consumer recomputes from disk before trusting a mapped line. a separate
+    // table rather than a wider tuple, so a reader that predates it is unaffected
+    map_src.push_str(
+        "# sha-256 of the two files each SOURCEMAP entry describes, over the bytes\n\
+         # the transpiler read and wrote. recompute both from disk before trusting a\n\
+         # mapped line: a mismatch means the file is no longer the one mapped\n\
+         DIGESTS = {\n",
+    );
+    for e in entries {
+        let _ = writeln!(
+            map_src,
+            "    {}: {{\"by\": {}, \"py\": {}}},",
+            py_str_literal(&e.py_path.to_string_lossy()),
+            py_str_literal(&e.by_digest),
+            py_str_literal(&e.py_digest),
+        );
+    }
     map_src.push_str("}\n");
+
+    fs::create_dir_all(dir).with_context(|| format!("failed to create {}", dir.display()))?;
     fs::write(dir.join(BY_SOURCEMAP_FILENAME), map_src)
         .with_context(|| "failed to write sourcemap module")?;
+    Ok(())
+}
+
+/// write the sourcemap module + runner shim into the run dir. the shim runs the
+/// target module and, on an uncaught exception, rewrites traceback frames in
+/// generated files back to their `.by` source location
+fn write_traceback_runtime(dir: &Path, entries: &[TracebackEntry]) -> anyhow::Result<()> {
+    write_sourcemap_module(dir, entries)?;
     fs::write(dir.join(BY_RUNNER_FILENAME), BY_RUNNER_SRC)
         .with_context(|| "failed to write runner shim")?;
     Ok(())
@@ -1098,16 +1180,67 @@ fn py_str_literal(s: &str) -> String {
 }
 
 const BY_RUNNER_SRC: &str = r#"# generated by `by run` — runs the target module with .by-aware tracebacks
+import hashlib
+import linecache
 import os
 import runpy
 import sys
 import traceback
 
-from _by_sourcemap import SOURCEMAP
+from _by_sourcemap import DIGESTS, SOURCEMAP
 
 # index the sourcemap by realpath so symlinked temp dirs (e.g. /tmp on macOS)
-# still match the filenames python reports in frames
-_BY_MAP = {os.path.realpath(py): info for py, info in SOURCEMAP.items()}
+# still match the filenames python reports in frames. the key the entry was
+# written under travels with it, because DIGESTS is keyed the unresolved way
+_BY_MAP = {os.path.realpath(py): (py, info) for py, info in SOURCEMAP.items()}
+
+# entries already checked against their digests, so each file is read at most
+# once no matter how many frames it contributes
+_CURRENT = set()
+_STALE = set()
+
+
+def _digest_matches(path, spec):
+    # the algorithm is named in the value, so one this reader does not know is a
+    # refusal rather than hex it could never have produced
+    algorithm, _, expected = spec.partition(":")
+    try:
+        digest = hashlib.new(algorithm)
+    except ValueError:
+        return False
+    try:
+        with open(path, "rb") as handle:
+            for chunk in iter(lambda: handle.read(65536), b""):
+                digest.update(chunk)
+    except OSError:
+        return False
+    return digest.hexdigest() == expected
+
+
+def _is_current(key, by_path):
+    # the map describes a *pair* of files, and a .by line read out of it is only
+    # true while both are still the ones it was built from. a source saved since
+    # the transpile would otherwise be quoted at line numbers belonging to the
+    # file it replaced — a wrong answer, where leaving the frame generated is
+    # merely a worse one
+    if key in _CURRENT:
+        return True
+    if key in _STALE:
+        return False
+    digests = DIGESTS.get(key)
+    if (
+        digests is not None
+        and _digest_matches(by_path, digests["by"])
+        and _digest_matches(key, digests["py"])
+    ):
+        _CURRENT.add(key)
+        return True
+    _STALE.add(key)
+    sys.stderr.write(
+        f"note: {by_path} no longer matches what it was transpiled from — "
+        "its frames are left as generated python\n"
+    )
+    return False
 
 
 def _rewrite(frames):
@@ -1116,14 +1249,12 @@ def _rewrite(frames):
     frames = frames[first:] if first is not None else frames
     out = []
     for f in frames:
-        info = _BY_MAP.get(os.path.realpath(f.filename))
-        if info is not None and f.lineno is not None:
-            by_path, lines = info
+        entry = _BY_MAP.get(os.path.realpath(f.filename))
+        if entry is not None and f.lineno is not None:
+            key, (by_path, lines) = entry
             idx = f.lineno - 1
             mapped = lines[idx] if 0 <= idx < len(lines) else None
-            if mapped is not None:
-                import linecache
-
+            if mapped is not None and _is_current(key, by_path):
                 by_lineno = mapped + 1
                 text = linecache.getline(by_path, by_lineno).strip() or f.line
                 out.append(traceback.FrameSummary(by_path, by_lineno, f.name, line=text))
@@ -1337,6 +1468,23 @@ enum CheckGate {
     AllErrors,
 }
 
+/// one transpiled module, as [`render_check_and_transpile`] hands it over
+///
+/// the two texts are named rather than positional because a caller that mixes
+/// them up — hashing the python as if it were the `.by`, say — would still
+/// compile
+struct Transpiled<'a> {
+    by_path: &'a Path,
+    /// the `.by` text this transpile ran on. it is the same read, not a fresh
+    /// one: [`source_text`] is memoized, so a digest taken here is over the
+    /// bytes that actually produced `python`
+    by_source: &'a str,
+    /// the generated python, exactly as the caller is expected to write it out
+    python: &'a str,
+    /// generated line (0-indexed) → the `.by` line it came from
+    line_map: &'a [Option<u32>],
+}
+
 /// Check every file, render diagnostics, then for each non-blocked file call
 /// `consume` with the transpiled Python. Returns `Ok(false)` if the check
 /// outcome blocks per `gate`, or a transpiler bug occurred (caller should
@@ -1347,7 +1495,7 @@ fn render_check_and_transpile(
     config: &Config,
     gate: CheckGate,
     rebuilder: &Rebuilder,
-    mut consume: impl FnMut(&Path, &str, &[Option<u32>]) -> anyhow::Result<()>,
+    mut consume: impl FnMut(&Transpiled<'_>) -> anyhow::Result<()>,
 ) -> anyhow::Result<bool> {
     let mut all_diagnostics: Vec<Diagnostic> = Vec::new();
     let mut unusable: Vec<ruff_db::files::File> = Vec::new();
@@ -1385,7 +1533,15 @@ fn render_check_and_transpile(
             continue;
         }
         match by_transforms::transpile_typed_with_map(db, *file, config, Some(&rebuild)) {
-            Ok((out, line_map)) => consume(bpy, &out, &line_map)?,
+            Ok((out, line_map)) => {
+                let by_source = source_text(db, *file);
+                consume(&Transpiled {
+                    by_path: bpy,
+                    by_source: by_source.as_str(),
+                    python: &out,
+                    line_map: &line_map,
+                })?;
+            }
             Err(e) => {
                 all_diagnostics.push(transpile_bug_diagnostic(*file, &e));
                 ok = false;
@@ -1496,8 +1652,9 @@ pub(crate) fn cmd_version_by(output_format: crate::args::HelpFormat) -> ExitStat
 #[cfg(test)]
 mod tests {
     use super::{
-        dotted_module_name, is_hidden_within, module_relative_path, reverse_dir,
-        reverse_dir_converting,
+        BY_SOURCEMAP_FILENAME, TracebackEntry, content_digest, dotted_module_name,
+        is_hidden_within, module_relative_path, reverse_dir, reverse_dir_converting,
+        write_sourcemap_module,
     };
     use crate::ExitStatus;
     use by_transforms::config::Config;
@@ -1682,6 +1839,49 @@ mod tests {
         // left exactly as it was found: neither converted nor deleted
         assert!(exploding.is_file());
         assert!(!dir.path().join("exploding.by").exists());
+        Ok(())
+    }
+
+    /// the digest carries the algorithm that produced it, so a reader that does
+    /// not know one can refuse the entry rather than compare hex it could never
+    /// have produced
+    #[test]
+    fn a_digest_names_the_algorithm_before_the_hex() {
+        assert_eq!(
+            content_digest(b"abc"),
+            "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    /// `DIGESTS` is a second table keyed exactly as `SOURCEMAP` is — additive,
+    /// so a consumer that only knows the tuple reads the same file unchanged
+    #[test]
+    fn the_sourcemap_module_digests_both_files_of_every_entry() -> anyhow::Result<()> {
+        let dir = tempfile::TempDir::new()?;
+        let entries = vec![TracebackEntry {
+            py_path: PathBuf::from("/build/demo.py"),
+            by_path: PathBuf::from("/src/demo.by"),
+            line_map: vec![None, Some(0)],
+            by_source: "the .by source".to_owned(),
+            by_digest: content_digest(b"the .by source"),
+            py_digest: content_digest(b"the generated python"),
+        }];
+
+        write_sourcemap_module(dir.path(), &entries)?;
+        let emitted = std::fs::read_to_string(dir.path().join(BY_SOURCEMAP_FILENAME))?;
+
+        assert!(
+            emitted.contains(r#"    "/build/demo.py": ("/src/demo.by", [None, 0]),"#),
+            "the existing entry shape is unchanged:\n{emitted}"
+        );
+        assert!(
+            emitted.contains(&format!(
+                r#"    "/build/demo.py": {{"by": "{}", "py": "{}"}},"#,
+                content_digest(b"the .by source"),
+                content_digest(b"the generated python"),
+            )),
+            "both digests are keyed by the generated path:\n{emitted}"
+        );
         Ok(())
     }
 }

--- a/crates/ty/src/lib.rs
+++ b/crates/ty/src/lib.rs
@@ -57,7 +57,30 @@ where
         .context("Failed to read CLI arguments from file")?;
     let args = Cli::parse_from(args);
 
-    match args.command {
+    // type inference recurses with the shape of the program it is checking, so
+    // how deep a file it can survive is decided by the stack it runs on. the
+    // rayon pool asks for `STACK_SIZE`, but the thread a process starts on gets a
+    // platform default — 1 MiB on windows — and the commands that check on the
+    // calling thread rather than through the pool (`run`, `build`, `transpile`,
+    // `compile`) were overflowing it there. so the whole command runs on a thread
+    // this codebase has sized for the job, wherever it is dispatched to
+    std::thread::scope(|scope| {
+        let command = std::thread::Builder::new()
+            .stack_size(STACK_SIZE)
+            .spawn_scoped(scope, || run_command(args.command))
+            .context("failed to start the worker thread")?;
+        match command.join() {
+            Ok(status) => status,
+            // the panic has already been reported by the default hook; carrying
+            // it across the join keeps the process behaving as if it never moved
+            // off the starting thread
+            Err(payload) => std::panic::resume_unwind(payload),
+        }
+    })
+}
+
+fn run_command(command: Command) -> anyhow::Result<ExitStatus> {
+    match command {
         Command::Server => run_server().map(|()| ExitStatus::Success),
         Command::Check(check_args) => run_check(check_args),
         Command::Version { output_format } => Ok(by_commands::cmd_version_by(output_format)),

--- a/crates/ty/tests/by_e2e.rs
+++ b/crates/ty/tests/by_e2e.rs
@@ -294,6 +294,30 @@ fn run_executes_module() {
     );
 }
 
+/// inference recurses with the shape of the expression it is checking, and `run`
+/// checks on the thread it was dispatched to rather than through the rayon pool.
+/// on the stack a process starts with — 1 MiB on windows — a file like this one
+/// overflowed before that thread was sized for the work
+#[test]
+fn run_checks_a_deeply_nested_expression() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let terms = vec!["1"; 2000].join(" + ");
+    fs::write(dir.path().join("main.by"), format!("print({terms})\n")).unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_by"))
+        .args(["run", "main"])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to spawn by");
+
+    assert!(
+        output.status.success(),
+        "by run failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "2000");
+}
+
 #[test]
 fn run_force_unwrap_yields_inner_value() {
     // `Some(x)` lowers to the `Optional(x)` wrapper; force-unwrapping it must
@@ -1780,17 +1804,36 @@ fn build_writes_a_sourcemap_beside_the_generated_python() {
     let out = dir.path().join("out");
     let map = fs::read_to_string(out.join("_by_sourcemap.py")).expect("sourcemap module");
 
-    // the paths in the map are the ones the build ran against, so a symlinked
-    // temp dir (`/tmp` on macOS) is spelled resolved there and has to be here
-    let resolved = fs::canonicalize(&out).expect("out directory");
-    let py_key = format!("{:?}", resolved.join("main.py").to_string_lossy());
+    // read the keys out of the file rather than rebuilding them: the build
+    // spells a path the way the system handed it over, which is neither the
+    // test's `dir.path()` (a symlink under `/tmp` on macOS) nor its canonical
+    // form (a `\\?\` path with the long directory name on windows)
+    let first_key_of = |table: &str| {
+        let (_, body) = map
+            .split_once(&format!("{table} = {{\n"))
+            .unwrap_or_else(|| panic!("no {table} table:\n{map}"));
+        let entry = body.lines().next().expect("an entry");
+        entry
+            .trim()
+            .split_once(": ")
+            .unwrap_or_else(|| panic!("no key in {table}:\n{map}"))
+            .0
+            .to_owned()
+    };
+
+    let mapped = first_key_of("SOURCEMAP");
     assert!(
-        map.contains(&format!("SOURCEMAP = {{\n    {py_key}: (")),
+        mapped.ends_with("main.py\""),
         "the generated module should be mapped by its own path:\n{map}"
     );
+    assert_eq!(
+        mapped,
+        first_key_of("DIGESTS"),
+        "both tables key the same generated file:\n{map}"
+    );
     assert!(
-        map.contains(&format!("    {py_key}: {{\"by\": \"sha256:")),
-        "and digested under the same key:\n{map}"
+        map.contains(&format!("{mapped}: {{\"by\": \"sha256:")),
+        "the entry should carry a digest of each side:\n{map}"
     );
     // the runner shim belongs to `by run`; a build output is not an entry point
     assert!(

--- a/crates/ty/tests/by_e2e.rs
+++ b/crates/ty/tests/by_e2e.rs
@@ -1171,6 +1171,118 @@ main()
 }
 
 #[test]
+fn run_sourcemap_digests_match_the_files_they_describe() {
+    // `SOURCEMAP` describes a pair of files, and a consumer that reports a `.by`
+    // line from it is trusting that both are still the ones it was built from.
+    // `DIGESTS` is what makes that checkable, so it has to be over the bytes
+    // actually read and written — the debuggee recomputes both from disk here,
+    // then edits its own source to prove the digest discriminates at all
+    let dir = tempfile::tempdir().expect("tempdir");
+    fs::write(
+        dir.path().join("main.by"),
+        "\
+import hashlib
+import importlib
+
+# imported dynamically: it is generated into the build dir, so there is nothing
+# for the checker to resolve at the time this file is checked
+sourcemap = importlib.import_module('_by_sourcemap')
+
+
+def digest_of(path: str) -> str:
+    with open(path, 'rb') as handle:
+        return 'sha256:' + hashlib.sha256(handle.read()).hexdigest()
+
+
+checked = 0
+for py_path, entry in sourcemap.SOURCEMAP.items():
+    by_path = entry[0]
+    digests = sourcemap.DIGESTS[py_path]
+    assert digest_of(by_path) == digests['by'], 'stale .by digest for ' + by_path
+    assert digest_of(py_path) == digests['py'], 'stale .py digest for ' + py_path
+    for path, side in ((by_path, 'by'), (py_path, 'py')):
+        with open(path, 'ab') as handle:
+            handle.write(b'# edited after the transpile\\n')
+        assert digest_of(path) != digests[side], 'an edited file still matched its digest'
+    checked += 1
+
+print('verified', checked)
+",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_by"))
+        .args(["run", "main"])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to spawn by");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "by run failed:\n{stderr}");
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "verified 1",
+        "every sourcemap entry should have been checked:\n{stderr}"
+    );
+}
+
+#[test]
+fn run_leaves_a_frame_generated_when_its_source_no_longer_matches() {
+    // the traceback shim is the digests' first consumer: once the `.by` has been
+    // saved over, its line table describes the file that was replaced, so a
+    // mapped frame would quote the *new* text at the *old* line numbers. it has
+    // to refuse the mapping and say why, rather than answer confidently wrong
+    let dir = tempfile::tempdir().expect("tempdir");
+    fs::write(
+        dir.path().join("main.by"),
+        "\
+import importlib
+
+sourcemap = importlib.import_module('_by_sourcemap')
+
+
+def boom() -> None:
+    raise ValueError('bang')
+
+
+# stand a different file in the place of every source the map describes
+for entry in sourcemap.SOURCEMAP.values():
+    with open(entry[0], 'w') as handle:
+        handle.write('# not the file that was transpiled\\n')
+
+boom()
+",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_by"))
+        .args(["run", "main"])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to spawn by");
+
+    assert!(!output.status.success(), "expected a non-zero exit");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        stderr.contains("no longer matches what it was transpiled from"),
+        "the refusal should be reported, not silent:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("main.by\", line"),
+        "no frame may claim a line in a .by the map no longer describes:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("main.py\", line"),
+        "frames should fall back to the generated python:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("ValueError"),
+        "exception type should be preserved:\n{stderr}"
+    );
+}
+
+#[test]
 fn build_skips_a_source_it_cannot_read() {
     // a source ty cannot decode reads as an empty module, so emitting for it
     // would write an empty `.py` over the real one. it is reported and skipped
@@ -1646,6 +1758,44 @@ fn build_mirrors_the_module_tree_not_the_directory_tree() {
     assert!(
         !out.join("src").exists(),
         "the source root must not appear in the output tree:\n{stderr}"
+    );
+}
+
+/// `out/` outlives the build that wrote it — a test runner, a debugger or an
+/// editor reads it later — so it is the tree where a `.by` really can be saved
+/// after the transpile, and the one that needs the digests to say so
+#[test]
+fn build_writes_a_sourcemap_beside_the_generated_python() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fs::write(dir.path().join("main.by"), "print(\"built\")\n").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_by"))
+        .arg("build")
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to spawn by");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "by build failed:\n{stderr}");
+    let out = dir.path().join("out");
+    let map = fs::read_to_string(out.join("_by_sourcemap.py")).expect("sourcemap module");
+
+    // the paths in the map are the ones the build ran against, so a symlinked
+    // temp dir (`/tmp` on macOS) is spelled resolved there and has to be here
+    let resolved = fs::canonicalize(&out).expect("out directory");
+    let py_key = format!("{:?}", resolved.join("main.py").to_string_lossy());
+    assert!(
+        map.contains(&format!("SOURCEMAP = {{\n    {py_key}: (")),
+        "the generated module should be mapped by its own path:\n{map}"
+    );
+    assert!(
+        map.contains(&format!("    {py_key}: {{\"by\": \"sha256:")),
+        "and digested under the same key:\n{map}"
+    );
+    // the runner shim belongs to `by run`; a build output is not an entry point
+    assert!(
+        !out.join("_by_runner.py").exists(),
+        "the runner shim should not be written into a build output"
     );
 }
 

--- a/docs/basedpython/cli-reference.md
+++ b/docs/basedpython/cli-reference.md
@@ -89,6 +89,11 @@ the same way an import does. the `out/` directory is **not** considered
 first-party source for `by check` or `by generate-api-file` — it is regenerated
 on every build
 
+alongside the python it writes `out/_by_sourcemap.py`, mapping each generated
+line back to the `.by` line it came from, with a digest of both files so a tool
+reading it can tell whether it still describes what is on disk — see
+[sourcemaps](development/sourcemaps.md)
+
 ## `by compile`
 
 > **status: early.** integer, float and bool arithmetic, control flow, and calls

--- a/docs/basedpython/development/sourcemaps.md
+++ b/docs/basedpython/development/sourcemaps.md
@@ -31,6 +31,11 @@ a correct sourcemap is the single primitive all of these share
     1 applies no body edits and later phases only prepend). consumed by `by run`
     to rewrite tracebacks and by `by transpile` to map a transpiler-invalid-output
     span back to its `.by` line for a source-annotated diagnostic
+- `_by_sourcemap.py` carries two tables keyed by the generated `.py` path:
+    `SOURCEMAP`, the `.by` path and its line table, and `DIGESTS`, the sha-256 of
+    both files that entry describes. `by build` writes it into `out/` beside the
+    python it describes, and `by run` into the temporary tree it executes — where
+    it lives only as long as that run. see [staleness](#staleness) below
 
 ### limitations to remove
 
@@ -41,6 +46,59 @@ a correct sourcemap is the single primitive all of these share
 - **prepend-only assumption** — the composition trick assumes later phases never
     insert mid-body. true today; brittle as a contract
 - **untested arithmetic** — offset math has no property tests
+
+## staleness
+
+built, unlike the rest of this document
+
+a map describes a *pair* of files, and the lines it reports are only true while
+both are still the ones it was built from. an editor that saves the `.by` after
+the transpile leaves the map describing a pair that no longer exists — and it
+goes on resolving lines with total confidence. that is a wrong answer rather
+than a missing one, which is the failure a sourcemap exists to prevent
+
+so every entry carries a digest of both sides, and a consumer must recompute
+them from disk before it trusts a line:
+
+```python
+DIGESTS = {
+    "/tmp/.tmpXXXX/demo.py": {
+        "by": "sha256:…",  # the .by bytes the transpiler read
+        "py": "sha256:…",  # the python bytes it wrote
+    },
+}
+```
+
+three things that shape pins down:
+
+- **the bytes that were read and written** — both digests are taken in the
+    transpiling pass, over the source text it ran on and the python it produced.
+    hashing the files again afterwards would only be a second chance for them to
+    have changed
+- **raw bytes** — so a consumer recomputes with
+    `sha256(open(path, "rb").read())` and needs to know nothing about encoding or
+    line endings
+- **the algorithm named in the value** — it can be changed later without
+    breaking readers, and a reader that meets one it does not know refuses the
+    entry instead of comparing hex it could never have produced
+
+`DIGESTS` is a separate top-level name rather than a third element of the
+`SOURCEMAP` tuple: that tuple has consumers (the traceback shim, the pycharm
+plugin), a positional change would break every one of them, and a name they
+never read is invisible to them
+
+the traceback shim is the first consumer, and it shows what refusing looks like:
+when either digest disagrees it leaves the frame in the generated python and
+writes a note saying which file no longer matches. a frame pointing at
+`out/main.py` is a worse answer, but a frame quoting a `.by` that has been
+rewritten since is a false one
+
+both tables are keyed by the generated path exactly as the map spells it. the
+shim resolves symlinks before matching a frame's filename against it — a
+temporary tree under `/tmp` on macOS is reached by a different path than the one
+python reports — so it carries the original key alongside the resolved one. a
+consumer that normalises keys has to do the same, or its digest lookup misses
+and every entry reads as stale
 
 ## goals
 


### PR DESCRIPTION
the digests had no consumer: the shim read SOURCEMAP alone, and by build wrote no map at all — so the check existed where a map lives for one run, and not where one outlives the build that wrote it
