### PR TITLE
Sort a module's imports when the file is reformatted, without pruning them

### DIFF
--- a/crates/ruff_server/src/lib.rs
+++ b/crates/ruff_server/src/lib.rs
@@ -29,6 +29,8 @@ const SOURCE_ORGANIZE_IMPORTS_RUFF: CodeActionKind =
     CodeActionKind::new("source.organizeImports.ruff");
 const SOURCE_OPTIMIZE_IMPORTS_RUFF: CodeActionKind =
     CodeActionKind::new("source.optimizeImports.ruff");
+const SOURCE_FORMAT_AND_ORGANIZE_IMPORTS_RUFF: CodeActionKind =
+    CodeActionKind::new("source.formatAndOrganizeImports.ruff");
 const SOURCE_FORMAT_AND_OPTIMIZE_IMPORTS_RUFF: CodeActionKind =
     CodeActionKind::new("source.formatAndOptimizeImports.ruff");
 const NOTEBOOK_SOURCE_FIX_ALL_RUFF: CodeActionKind =

--- a/crates/ruff_server/src/server.rs
+++ b/crates/ruff_server/src/server.rs
@@ -280,6 +280,13 @@ pub(crate) enum SupportedCodeAction {
     /// Maps to the `source.optimizeImports.ruff` code action kind. Sorts imports *and* removes the
     /// ones nothing uses, which is what an editor's *Optimize Imports* means.
     SourceOptimizeImports,
+    /// Maps to the `source.formatAndOrganizeImports.ruff` code action kind. Runs
+    /// [`Self::SourceOrganizeImports`] and the formatter against one buffer, as a single edit.
+    ///
+    /// This is what an editor's *Reformat Code* means for a module whose imports it also keeps in
+    /// order: laying the file out is not licence to delete anything, so unlike
+    /// [`Self::SourceFormatAndOptimizeImports`] it sorts without pruning.
+    SourceFormatAndOrganizeImports,
     /// Maps to the `source.formatAndOptimizeImports.ruff` code action kind. Runs
     /// [`Self::SourceOptimizeImports`] and the formatter against one buffer, as a single edit.
     SourceFormatAndOptimizeImports,
@@ -301,6 +308,7 @@ impl SupportedCodeAction {
             Self::SourceFixAll => crate::SOURCE_FIX_ALL_RUFF,
             Self::SourceOrganizeImports => crate::SOURCE_ORGANIZE_IMPORTS_RUFF,
             Self::SourceOptimizeImports => crate::SOURCE_OPTIMIZE_IMPORTS_RUFF,
+            Self::SourceFormatAndOrganizeImports => crate::SOURCE_FORMAT_AND_ORGANIZE_IMPORTS_RUFF,
             Self::SourceFormatAndOptimizeImports => crate::SOURCE_FORMAT_AND_OPTIMIZE_IMPORTS_RUFF,
             Self::NotebookSourceFixAll => crate::NOTEBOOK_SOURCE_FIX_ALL_RUFF,
             Self::NotebookSourceOrganizeImports => crate::NOTEBOOK_SOURCE_ORGANIZE_IMPORTS_RUFF,
@@ -320,6 +328,7 @@ impl SupportedCodeAction {
             Self::SourceFixAll,
             Self::SourceOrganizeImports,
             Self::SourceOptimizeImports,
+            Self::SourceFormatAndOrganizeImports,
             Self::SourceFormatAndOptimizeImports,
             Self::NotebookSourceFixAll,
             Self::NotebookSourceOrganizeImports,

--- a/crates/ruff_server/src/server/api/requests/code_action.rs
+++ b/crates/ruff_server/src/server/api/requests/code_action.rs
@@ -15,7 +15,8 @@ use crate::session::{Client, DocumentSnapshot};
 
 use super::code_action_resolve::{
     resolve_edit_for_fix_all, resolve_edit_for_format_and_optimize_imports,
-    resolve_edit_for_optimize_imports, resolve_edit_for_organize_imports,
+    resolve_edit_for_format_and_organize_imports, resolve_edit_for_optimize_imports,
+    resolve_edit_for_organize_imports,
 };
 
 pub(crate) struct CodeActions;
@@ -128,6 +129,12 @@ impl super::BackgroundDocumentRequestHandler for CodeActions {
             if named_in(asked_for, &crate::SOURCE_OPTIMIZE_IMPORTS_RUFF) {
                 response
                     .push(optimize_imports(&snapshot).with_failure_code(ErrorCode::InternalError)?);
+            }
+            if named_in(asked_for, &crate::SOURCE_FORMAT_AND_ORGANIZE_IMPORTS_RUFF) {
+                response.push(
+                    format_and_organize_imports(&snapshot)
+                        .with_failure_code(ErrorCode::InternalError)?,
+                );
             }
             if named_in(asked_for, &crate::SOURCE_FORMAT_AND_OPTIMIZE_IMPORTS_RUFF) {
                 response.push(
@@ -373,6 +380,20 @@ fn optimize_imports(snapshot: &DocumentSnapshot) -> crate::Result<CodeActionResp
     Ok(CodeActionResponse::CodeAction(types::CodeAction {
         title: format!("{DIAGNOSTIC_NAME}: Optimize imports"),
         kind: Some(crate::SOURCE_OPTIMIZE_IMPORTS_RUFF),
+        edit,
+        data,
+        ..Default::default()
+    }))
+}
+
+fn format_and_organize_imports(snapshot: &DocumentSnapshot) -> crate::Result<CodeActionResponse> {
+    let (edit, data) = deferred_or_resolved(snapshot, |snapshot| {
+        resolve_edit_for_format_and_organize_imports(snapshot)
+    })?;
+
+    Ok(CodeActionResponse::CodeAction(types::CodeAction {
+        title: format!("{DIAGNOSTIC_NAME}: Format document and organize imports"),
+        kind: Some(crate::SOURCE_FORMAT_AND_ORGANIZE_IMPORTS_RUFF),
         edit,
         data,
         ..Default::default()

--- a/crates/ruff_server/src/server/api/requests/code_action_resolve.rs
+++ b/crates/ruff_server/src/server/api/requests/code_action_resolve.rs
@@ -111,6 +111,10 @@ impl super::BackgroundRequestHandler for CodeActionResolve {
                 )
                 .with_failure_code(ErrorCode::InternalError)?,
             ),
+            SupportedCodeAction::SourceFormatAndOrganizeImports => Some(
+                resolve_edit_for_format_and_organize_imports(&snapshot)
+                    .with_failure_code(ErrorCode::InternalError)?,
+            ),
             SupportedCodeAction::SourceFormatAndOptimizeImports => Some(
                 resolve_edit_for_format_and_optimize_imports(&snapshot)
                     .with_failure_code(ErrorCode::InternalError)?,
@@ -223,6 +227,15 @@ pub(super) fn resolve_edit_for_format_and_optimize_imports(
     Ok(tracker.into_workspace_edit())
 }
 
+pub(super) fn resolve_edit_for_format_and_organize_imports(
+    snapshot: &DocumentSnapshot,
+) -> crate::Result<types::WorkspaceEdit> {
+    let query = snapshot.query();
+    let mut tracker = WorkspaceEditTracker::new(snapshot.resolved_client_capabilities());
+    tracker.set_fixes_for_document(format_and_organize_imports_edit(snapshot)?, query.version())?;
+    Ok(tracker.into_workspace_edit())
+}
+
 fn optimize_imports_settings(query: &DocumentQuery) -> ruff_linter::settings::LinterSettings {
     settings_for_rules(
         query,
@@ -231,6 +244,29 @@ fn optimize_imports_settings(query: &DocumentQuery) -> ruff_linter::settings::Li
 }
 
 /// Optimizes a module's imports and formats it, as a single edit.
+///
+/// See [`format_and_imports_edit`] for why the two are composed here rather than asked for
+/// separately.
+pub(super) fn format_and_optimize_imports_edit(
+    snapshot: &DocumentSnapshot,
+) -> crate::Result<Fixes> {
+    let settings = optimize_imports_settings(snapshot.query());
+    format_and_imports_edit(snapshot, &settings)
+}
+
+/// Sorts a module's imports and formats it, as a single edit.
+///
+/// The same as [`format_and_optimize_imports_edit`] but for F401: laying a file out is not licence
+/// to delete anything from it, so *Reformat Code* sorts imports without pruning them. Dropping the
+/// unused ones is what *Optimize Imports* is for, and the user asks for that separately.
+pub(super) fn format_and_organize_imports_edit(
+    snapshot: &DocumentSnapshot,
+) -> crate::Result<Fixes> {
+    let settings = settings_for_rules(snapshot.query(), import_sorting_rules());
+    format_and_imports_edit(snapshot, &settings)
+}
+
+/// Runs an import pass and the formatter against one buffer, as a single edit.
 ///
 /// Asking a client to run the two separately cannot be made correct: the second request is answered
 /// against whatever text the server last saw, so the client has to wait for the first edit to be
@@ -243,8 +279,9 @@ fn optimize_imports_settings(query: &DocumentQuery) -> ruff_linter::settings::Li
 ///
 /// Notebooks are not handled — their cells are fixed as a group and formatted one at a time, which
 /// a single whole-document diff cannot express. They keep the separate `notebook.source.*` actions.
-pub(super) fn format_and_optimize_imports_edit(
+fn format_and_imports_edit(
     snapshot: &DocumentSnapshot,
+    import_settings: &ruff_linter::settings::LinterSettings,
 ) -> crate::Result<Fixes> {
     let query = snapshot.query();
     let Ok(document) = query.as_single_document() else {
@@ -256,8 +293,8 @@ pub(super) fn format_and_optimize_imports_edit(
 
     let source = document.contents();
 
-    let optimized = crate::fix::fix_all_text(query, &optimize_imports_settings(query))?;
-    let optimized = optimized.as_deref().unwrap_or(source);
+    let sorted = crate::fix::fix_all_text(query, import_settings)?;
+    let sorted = sorted.as_deref().unwrap_or(source);
 
     let settings = query.settings();
     let file_path = query.virtual_file_path();
@@ -272,7 +309,7 @@ pub(super) fn format_and_optimize_imports_edit(
         // The formatter reads a whole document, so the fixed source is handed to it as one. The
         // version is irrelevant here: this document never leaves this function, and the edit is
         // stamped with the real document's version by the caller.
-        let intermediate = TextDocument::new(optimized.to_string(), document.version());
+        let intermediate = TextDocument::new(sorted.to_string(), document.version());
         crate::format::format(
             &intermediate,
             query.source_type_for_format(),
@@ -286,7 +323,7 @@ pub(super) fn format_and_optimize_imports_edit(
         .into_formatted()
     };
 
-    let modified = formatted.as_deref().unwrap_or(optimized);
+    let modified = formatted.as_deref().unwrap_or(sorted);
     if modified == source {
         return Ok(Fixes::default());
     }

--- a/crates/ruff_server/tests/e2e/code_action.rs
+++ b/crates/ruff_server/tests/e2e/code_action.rs
@@ -291,6 +291,7 @@ fn save_time_actions_are_not_offered_unasked() -> Result<()> {
 
     assert!(
         !kinds.contains(&"source.optimizeImports.ruff")
+            && !kinds.contains(&"source.formatAndOrganizeImports.ruff")
             && !kinds.contains(&"source.formatAndOptimizeImports.ruff"),
         "Unasked-for source actions leaked into the menu: {kinds:?}"
     );
@@ -314,6 +315,61 @@ fn optimize_imports_is_answered_when_named() -> Result<()> {
         .expect("Expected Some response");
 
     assert_json_snapshot!(actions);
+
+    Ok(())
+}
+
+/// The *Reformat Code* composite: sorts and formats, and leaves the unused `import os` alone.
+///
+/// This is the whole difference from `formatAndOptimizeImports`, and it is the point of having
+/// both — laying a file out is not licence to delete anything from it.
+#[test]
+fn format_and_organize_imports_is_answered_when_named() -> Result<()> {
+    let mut server = TestServerBuilder::new()?.with_workspace(".")?.build();
+
+    server.open_text_document("test.py", NEEDS_EVERYTHING, 1);
+
+    let actions = server
+        .code_action_request_only(
+            "test.py",
+            vec![CodeActionKind::new("source.formatAndOrganizeImports.ruff")],
+        )
+        .expect("Expected Some response");
+
+    assert_json_snapshot!(actions);
+
+    Ok(())
+}
+
+/// The deferred round trip for the *Reformat Code* composite, which is the path the plugin takes.
+#[test]
+fn format_and_organize_imports_resolves_deferred() -> Result<()> {
+    let mut server = TestServerBuilder::new()?
+        .with_workspace(".")?
+        .enable_code_action_edit_resolution(true)
+        .build();
+
+    server.open_text_document("test.py", NEEDS_EVERYTHING, 1);
+
+    let actions = server
+        .code_action_request_only(
+            "test.py",
+            vec![CodeActionKind::new("source.formatAndOrganizeImports.ruff")],
+        )
+        .expect("Expected Some response");
+
+    let [CodeActionResponse::CodeAction(action)] = actions.as_slice() else {
+        panic!("Expected exactly one code action, got {actions:?}");
+    };
+    assert!(
+        action.edit.is_none(),
+        "A deferred action should carry no edit until it is resolved"
+    );
+
+    let request_id = server.send_request::<CodeActionResolveRequest>(action.clone());
+    let resolved = server.await_response::<CodeActionResolveRequest>(&request_id);
+
+    assert_json_snapshot!(resolved.edit);
 
     Ok(())
 }

--- a/crates/ruff_server/tests/e2e/snapshots/e2e__code_action__format_and_organize_imports_is_answered_when_named.snap
+++ b/crates/ruff_server/tests/e2e/snapshots/e2e__code_action__format_and_organize_imports_is_answered_when_named.snap
@@ -1,0 +1,29 @@
+---
+source: crates/ruff_server/tests/e2e/code_action.rs
+expression: actions
+---
+[
+  {
+    "title": "Ruff: Format document and organize imports",
+    "kind": "source.formatAndOrganizeImports.ruff",
+    "edit": {
+      "changes": {
+        "file://<temp_dir>/test.py": [
+          {
+            "range": {
+              "start": {
+                "line": 0,
+                "character": 0
+              },
+              "end": {
+                "line": 5,
+                "character": 0
+              }
+            },
+            "newText": "import abc\nimport os\nimport sys\n\nx = {\"a\": 1}\n"
+          }
+        ]
+      }
+    }
+  }
+]

--- a/crates/ruff_server/tests/e2e/snapshots/e2e__code_action__format_and_organize_imports_resolves_deferred.snap
+++ b/crates/ruff_server/tests/e2e/snapshots/e2e__code_action__format_and_organize_imports_resolves_deferred.snap
@@ -1,0 +1,23 @@
+---
+source: crates/ruff_server/tests/e2e/code_action.rs
+expression: resolved.edit
+---
+{
+  "changes": {
+    "file://<temp_dir>/test.py": [
+      {
+        "range": {
+          "start": {
+            "line": 0,
+            "character": 0
+          },
+          "end": {
+            "line": 5,
+            "character": 0
+          }
+        },
+        "newText": "import abc\nimport os\nimport sys\n\nx = {\"a\": 1}\n"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Reformat Code and Optimize Imports are different requests and always were, but the server only offered a composite for the second: formatAndOptimizeImports sorts, drops what nothing uses, and formats. There was nothing to answer the first with, so an editor reformatting a file could only ask for the formatter and leave the imports where it found them.

source.formatAndOrganizeImports.ruff is the missing half. It is the same pass composed against the same buffer, minus F401: laying a file out is not licence to delete anything from it, and dropping the unused imports is what the user asks for separately.

The two composites now share one implementation that takes the import rules to run, so the ordering argument — imports move, then the formatter lays out what that left — is stated once rather than twice.