### PR TITLE
fix various issues

### DIFF
--- a/crates/by_transforms/src/lib.rs
+++ b/crates/by_transforms/src/lib.rs
@@ -208,8 +208,12 @@ pub fn transpile_with_report(
     // --- Phase 2: import-redirect, surface-syntax cleanup, lazy-import marking ---
     let (final_output, requirements) = run_import_redirect_phase(output, config);
     let final_output = run_anon_named_tuple_cleanup(final_output, config)?;
-    let final_output =
-        run_lazy_import_phase(final_output, config, &model.eagerly_imported_modules());
+    let final_output = run_lazy_import_phase(
+        final_output,
+        config,
+        &model.eagerly_imported_modules(),
+        &model.eagerly_imported_names(),
+    );
     let final_output = run_version_polyfill_phase(final_output, config);
 
     // --- Phase 3: syntax verification ---
@@ -378,8 +382,9 @@ pub fn transpile_typed_with_report(
     };
     // which imports must stay eager, computed against the *project* db: a
     // single-file db cannot resolve the modules that declare the conformances
-    let eager_imports = ty_python_semantic::SemanticModel::new(db, db.program_file(file))
-        .eagerly_imported_modules();
+    let eager_model = ty_python_semantic::SemanticModel::new(db, db.program_file(file));
+    let eager_imports = eager_model.eagerly_imported_modules();
+    let eager_names = eager_model.eagerly_imported_names();
     let (spliced, ast_errors, phase0_map) =
         transforms::ast_driver::run_against_source(working_source, config, project);
     if let Some(first) = ast_errors.first() {
@@ -434,7 +439,7 @@ pub fn transpile_typed_with_report(
 
     let (final_output, requirements) = run_import_redirect_phase(output, config);
     let final_output = run_anon_named_tuple_cleanup(final_output, config)?;
-    let final_output = run_lazy_import_phase(final_output, config, &eager_imports);
+    let final_output = run_lazy_import_phase(final_output, config, &eager_imports, &eager_names);
     let final_output = run_version_polyfill_phase(final_output, config);
 
     // phases 1-2c only prepend preambles at the top and edit within lines, so
@@ -607,7 +612,16 @@ fn run_import_redirect_phase(source: String, config: &Config) -> (String, Runtim
 /// `eager` names the modules that must not be deferred whatever the target: a
 /// module declaring a conformance exists at runtime only because its
 /// registration ran, so deferring it defers the conformance out of existence
-fn run_lazy_import_phase(source: String, config: &Config, eager: &[String]) -> String {
+///
+/// `eager_names` names the *bindings* that must be bound to the real object: a
+/// lazy proxy cannot stand where cpython checks for a real class, which is what
+/// `except` does
+fn run_lazy_import_phase(
+    source: String,
+    config: &Config,
+    eager: &[String],
+    eager_names: &[String],
+) -> String {
     if !config.lazy_imports {
         return source;
     }
@@ -622,7 +636,8 @@ fn run_lazy_import_phase(source: String, config: &Config, eager: &[String]) -> S
     .load(&db);
 
     let keyword_supported = config.min_version >= ruff_python_ast::PythonVersion::from((3, 15));
-    let mut lazy = transforms::lazy_import::LazyImport::new(src, keyword_supported, eager);
+    let mut lazy =
+        transforms::lazy_import::LazyImport::new(src, keyword_supported, eager, eager_names);
     for stmt in module.suite() {
         lazy.visit_stmt(stmt);
     }

--- a/crates/by_transforms/src/transforms/anon_named_tuple.rs
+++ b/crates/by_transforms/src/transforms/anon_named_tuple.rs
@@ -543,6 +543,12 @@ impl<'src> AnonNamedTuple<'src> {
     /// whether to wrap the value directly or to wrap each element of an
     /// outer collection literal.
     fn coercion_target(&mut self, annotation: &Expr) -> Option<CoercionTarget> {
+        // a declaration modifier keeps the declared type in a marker subscript
+        // (`let x: T` parses as `x: __let__[T]`), and the annotation this reads
+        // is the one the source wrote
+        if let Some(declared) = ruff_python_ast::helpers::declaration_annotation_type(annotation) {
+            return self.coercion_target(declared);
+        }
         // Direct: `x: (name: T, ...)` or `x: Alias`
         if let Some(shape) = self.annotated_shape(annotation) {
             return Some(CoercionTarget {
@@ -1289,6 +1295,34 @@ mod tests {
         assert!(out.contains("class _AnonNamedTuple_"));
         assert!(out.contains("-> _AnonNamedTuple_"));
         assert!(out.contains("| None"));
+    }
+
+    #[test]
+    fn declaration_modifier_annotation_coerces() {
+        // `let x: T = v` parses as `x: __let__[T] = v`, and the annotation the
+        // coercion reads is the one under the marker
+        check(
+            "let a: (name: str, age: int) = (\"asdf\", 1)\n",
+            indoc! {"
+                from typing import Final, NamedTuple
+                class _AnonNamedTuple_7bfb4772(NamedTuple):
+                    name: str
+                    age: int
+
+                a: Final[_AnonNamedTuple_7bfb4772] = _AnonNamedTuple_7bfb4772(\"asdf\", 1)
+            "},
+        );
+        check(
+            "var a: (name: str, age: int) = (\"asdf\", 1)\n",
+            indoc! {"
+                from typing import NamedTuple
+                class _AnonNamedTuple_7bfb4772(NamedTuple):
+                    name: str
+                    age: int
+
+                a: _AnonNamedTuple_7bfb4772 = _AnonNamedTuple_7bfb4772(\"asdf\", 1)
+            "},
+        );
     }
 
     #[test]

--- a/crates/by_transforms/src/transforms/ast_driver.rs
+++ b/crates/by_transforms/src/transforms/ast_driver.rs
@@ -43,11 +43,12 @@ use super::{
     generic_call, generics, grapheme_string, identity_swap, if_let, implicit_receiver,
     implicit_typing, inferred_annotation, init_method, just_float, kw_subscript, literal_string,
     literal_types, local_once, main_function, match_type, modifiers, mutable_defaults, none_chain,
-    optional_type, overload, parametric_is, postfix_await, propagate, properties, protocol_type,
-    raises_clause, reified_generic, repeated_underscore, runtime_union, sentinel, some_ctor,
-    soundness, statement_expression, string_tag, super_keyword, symbolic_type_op, template_type,
-    top_star, trailing_lambda, tuple_index, type_fn, type_is, type_reification, typed_dict_literal,
-    typed_lambda, typeof_keyword, unique_loop_bindings, unpack, use_site_variance,
+    optional_type, overload, parametric_is, postfix_await, private_method, propagate, properties,
+    protocol_type, raises_clause, reified_generic, repeated_underscore, runtime_union, sentinel,
+    some_ctor, soundness, statement_expression, string_tag, super_keyword, symbolic_type_op,
+    template_type, top_star, trailing_lambda, tuple_index, type_fn, type_is, type_reification,
+    typed_dict_literal, typed_lambda, typeof_keyword, unique_loop_bindings, unpack,
+    use_site_variance,
 };
 use crate::Config;
 use crate::type_info::TypeInfo;
@@ -552,6 +553,7 @@ pub(crate) fn run_against_source<'a>(
         reified_generic::ReifiedGenericPass::new(source_ref, config.min_version);
     let type_reification_pass =
         type_reification::TypeReificationPass::new(config.min_version, config.is_stub);
+    let private_method_pass = private_method::PrivateMethodPass;
     let parametric_is_pass = parametric_is::ParametricIsPass::new(source_ref);
     let implicit_typing_pass = implicit_typing::ImplicitTypingPass::new();
     let inferred_annotation_pass = inferred_annotation::InferredAnnotationPass::new();
@@ -688,6 +690,10 @@ pub(crate) fn run_against_source<'a>(
         // later pass (e.g. coalesce on a wrapped iterable) is claimed and
         // materialized inside the check rather than dropping it
         &soundness_pass,
+        // a `private` method is reached by its mangled name; the edit replaces
+        // the attribute identifier alone, so it composes with any rewrite of the
+        // receiver it is read from
+        &private_method_pass,
         // checked cast wraps `<value> cast? <type>` in `_checked_cast(...)`; its
         // template passes value + type through as `Src`, so lowerings inside
         // them (a `??` value, a `T?` type) still compose

--- a/crates/by_transforms/src/transforms/init_method.rs
+++ b/crates/by_transforms/src/transforms/init_method.rs
@@ -26,8 +26,9 @@ use ruff_python_ast::visitor::{Visitor, walk_stmt};
 use ruff_python_ast::{Expr, Parameter, Stmt, StmtFunctionDef};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
-use super::ast_driver::{PassContext, TypeAwarePass};
+use super::ast_driver::{Fragment, PassContext, TypeAwarePass};
 use super::callable::lower_type_expr_full;
+use super::mutable_defaults::{first_body_statement, parameter_guards};
 use crate::type_info::TypeInfo;
 
 pub(crate) struct InitMethod<'src> {
@@ -47,12 +48,18 @@ impl TypeAwarePass for InitMethod<'_> {
             types,
             symbolic_substitutions: ctx.symbolic_substitutions.clone(),
             edits: RefCell::new(Vec::new()),
+            templates: RefCell::new(Vec::new()),
             errors: RefCell::new(Vec::new()),
+            needs_missing: RefCell::new(false),
         };
         for stmt in stmts {
             state.visit_stmt(stmt);
         }
+        if state.needs_missing.into_inner() {
+            ctx.required_imports.push("_MISSING = object()".to_owned());
+        }
         ctx.text_edits.extend(state.edits.into_inner());
+        ctx.template_edits.extend(state.templates.into_inner());
         ctx.errors.extend(state.errors.into_inner());
     }
 }
@@ -85,7 +92,10 @@ struct State<'src> {
     /// unless it is spliced in here
     symbolic_substitutions: Vec<(TextRange, String)>,
     edits: RefCell<Vec<(TextRange, String)>>,
+    templates: RefCell<Vec<(TextRange, Vec<Fragment>)>>,
     errors: RefCell<Vec<String>>,
+    /// whether the `_MISSING` sentinel reached the output
+    needs_missing: RefCell<bool>,
 }
 
 impl State<'_> {
@@ -186,7 +196,6 @@ impl State<'_> {
         // 2. collect attribute-declaring parameters (`let` / `var`, optionally
         //    `private` / `public`) from every slot, strip the modifier prefix
         //    from the source, and validate the combination
-        let params_end = func.parameters.range.end();
         let mut let_assignments: Vec<String> = Vec::new();
         let mut handle = |param: &Parameter| {
             let Some((prefix_range, words)) = self.modifier_prefix(param) else {
@@ -258,8 +267,10 @@ impl State<'_> {
             handle(k);
         }
 
-        // 3. insert the self-assignments
-        let first_user_stmt = func.body.iter().find(|s| s.range().start() >= params_end);
+        // 3. insert the self-assignments. whether there is a body at all is the
+        // question `mutable_defaults` asks too, so the two never disagree about
+        // which of them writes the guards a default needs
+        let first_user_stmt = first_body_statement(func);
         if let Some(first) = first_user_stmt {
             if !let_assignments.is_empty() {
                 let stmt_indent = self.line_indent(first.range().start()).to_owned();
@@ -273,20 +284,44 @@ impl State<'_> {
                 self.push(TextRange::new(pos, pos), text);
             }
         } else {
+            // the whole body is written here, so the guards a defaulted or
+            // relaxed-order parameter needs are written here too — `mutable_
+            // defaults` has no source statement to anchor them before
+            let (sentinels, guards) = parameter_guards(func);
             let header_indent = self.line_indent(func.range.start()).to_owned();
             let body_indent = format!("{header_indent}    ");
-            let mut text = String::from(":");
-            if let_assignments.is_empty() {
-                text.push_str(" ...");
+            let mut frags = vec![Fragment::Lit(":".to_owned())];
+            if let_assignments.is_empty() && guards.is_empty() {
+                frags.push(Fragment::Lit(" ...".to_owned()));
             } else {
+                for guard in &guards {
+                    frags.push(Fragment::Lit(format!("\n{body_indent}")));
+                    guard.push(&mut frags, &body_indent);
+                }
                 for line in &let_assignments {
-                    text.push('\n');
-                    text.push_str(&body_indent);
-                    text.push_str(line);
+                    frags.push(Fragment::Lit(format!("\n{body_indent}{line}")));
                 }
             }
             let pos = func.range.end();
-            self.push(TextRange::new(pos, pos), text);
+            if guards.is_empty() {
+                // no passthrough to carry, so emit plain text: a template
+                // absorbs the zero-width insertions a sibling lowering left at
+                // this offset, and here they belong to the signature
+                let text = frags
+                    .iter()
+                    .map(|frag| match frag {
+                        Fragment::Lit(lit) => lit.as_str(),
+                        Fragment::Src(_) => "",
+                    })
+                    .collect::<String>();
+                self.push(TextRange::new(pos, pos), text);
+                return;
+            }
+            *self.needs_missing.borrow_mut() = true;
+            self.templates.borrow_mut().extend(sentinels);
+            self.templates
+                .borrow_mut()
+                .push((TextRange::new(pos, pos), frags));
         }
     }
 }
@@ -307,6 +342,28 @@ mod tests {
 
     fn check(input: &str, expected: &str) {
         assert_eq!(transpile(input, &Config::test_default()).unwrap(), expected);
+    }
+
+    #[test]
+    fn a_declaring_parameter_lowers_its_annotation_once() {
+        // the parser synthesizes `self.a: T = a` from the parameter, with the
+        // parameter's own ranges — so a type-position pass that walked it would
+        // land a second copy of its edit on the annotation in the header
+        let out = transpile(
+            indoc! {"
+                class L:
+                    init(let a: int?, var b: int?)
+            "},
+            &Config {
+                min_version: crate::PythonVersion::PY39,
+                ..Config::test_default()
+            },
+        )
+        .unwrap();
+        assert!(
+            out.contains("def __init__(self, a: Union[int, None], b: Union[int, None]):"),
+            "got:\n{out}"
+        );
     }
 
     /// a variadic parameter's span opens on its `*` / `**`, which is syntax and not a modifier

--- a/crates/by_transforms/src/transforms/lazy_import.rs
+++ b/crates/by_transforms/src/transforms/lazy_import.rs
@@ -41,6 +41,11 @@ pub(crate) struct LazyImport<'src> {
     /// registers it at import, so deferring the import defers the conformance
     /// out of existence
     eager: Vec<String>,
+    /// bindings that must be bound to the real object rather than to a proxy.
+    /// cpython's `except` checks that what it catches is a class inheriting
+    /// `BaseException` and never consults `__instancecheck__`, so an exception
+    /// class reached through the proxy raises `TypeError` from the handler
+    eager_names: Vec<String>,
     /// True when the target Python version supports PEP 810 (3.15+). When
     /// false, the transform uses the runtime polyfill instead
     keyword_supported: bool,
@@ -63,11 +68,17 @@ pub(crate) struct LazyImport<'src> {
 }
 
 impl<'src> LazyImport<'src> {
-    pub(crate) fn new(source: &'src str, keyword_supported: bool, eager: &[String]) -> Self {
+    pub(crate) fn new(
+        source: &'src str,
+        keyword_supported: bool,
+        eager: &[String],
+        eager_names: &[String],
+    ) -> Self {
         Self {
             source,
             at_module_level: true,
             eager: eager.to_vec(),
+            eager_names: eager_names.to_vec(),
             keyword_supported,
             edits: Vec::new(),
             needs_module_helper: false,
@@ -309,7 +320,18 @@ impl<'src> LazyImport<'src> {
                 }
                 continue;
             }
-            if is_relative && module_part.is_empty() {
+            if self.eager_names.iter().any(|eager| eager == bind) {
+                // the proxy cannot stand here, so re-emit the import as written.
+                // ahead of the relative branches: a relative import is the
+                // common shape inside a package, and its exceptions are caught
+                // just the same
+                let spelling = if bind == name {
+                    name.to_owned()
+                } else {
+                    format!("{name} as {bind}")
+                };
+                lines.push(format!("from {dots}{module_part} import {spelling}"));
+            } else if is_relative && module_part.is_empty() {
                 // `from . import x` — `x` is a submodule of the current
                 // package. Resolve the relative target at runtime
                 self.needs_module_helper = true;
@@ -934,6 +956,45 @@ mod tests {
                 import sys as system
                 json = _lazy_module(\"json\")
             "},
+        );
+    }
+
+    #[test]
+    fn polyfill_exception_class_stays_eager() {
+        // cpython's `except` refuses anything that is not a real class
+        // inheriting `BaseException`, so the proxy cannot stand for one
+        let source = indoc! {"
+            from json import JSONDecodeError
+
+            def f() -> None:
+                try:
+                    pass
+                except JSONDecodeError:
+                    pass
+        "};
+        // nothing was deferred, so the proxy runtime is not emitted at all
+        assert_eq!(transpile_polyfill(source), source);
+    }
+
+    #[test]
+    fn polyfill_exception_class_beside_a_lazy_name() {
+        // the statement is split: only the exception has to be bound for real
+        let out = transpile_polyfill("from json import JSONDecodeError, dumps\n");
+        assert!(
+            out.ends_with(indoc! {"
+                from json import JSONDecodeError
+                dumps = _lazy_attr(\"json\", \"dumps\")
+            "}),
+            "got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn polyfill_aliased_exception_class_stays_eager() {
+        let out = transpile_polyfill("from json import JSONDecodeError as JDE\n");
+        assert!(
+            out.ends_with("from json import JSONDecodeError as JDE\n"),
+            "got:\n{out}"
         );
     }
 

--- a/crates/by_transforms/src/transforms/main_function.rs
+++ b/crates/by_transforms/src/transforms/main_function.rs
@@ -15,7 +15,9 @@
 //! existing `__main__` guard or a bare top-level `main()` call — so the entry
 //! point never runs twice
 
-use ruff_python_ast::{CmpOp, Expr, ModModule, Parameters, Stmt, StmtFunctionDef};
+use std::fmt::Write as _;
+
+use ruff_python_ast::{self as ast, CmpOp, Expr, ModModule, Parameters, Stmt, StmtFunctionDef};
 
 use super::ast_driver::{AstPass, PassContext};
 use super::source_util::is_synthetic_decorator;
@@ -29,11 +31,16 @@ use super::source_util::is_synthetic_decorator;
 /// registered as two arguments over internal `p<i>` / `o<i>` destinations and
 /// merged afterwards. `bool` is a flag pair (`--name` / `--no-name`) and takes
 /// no positional slot
-const MAIN_ARGS_RUNTIME: &str = r#"def _by_main_args(_fn, _params):
+///
+/// `_extra` is the converter of `main`'s leading `*rest`, which asks for
+/// whatever the interface does not claim. everything declared after it is
+/// keyword-only, so the extras are the only positional arguments and bind to
+/// `*rest`. `None` means there is no such parameter
+const MAIN_ARGS_RUNTIME: &str = r#"def _by_main_args(_fn, _params, _extra=None):
     import argparse
 
     _parser = argparse.ArgumentParser(description=_fn.__doc__)
-    for _i, (_name, _type, _kind, _required) in enumerate(_params):
+    for _i, (_name, _type, _kind, _required, _choices) in enumerate(_params):
         _flags = [f"--{_name.replace('_', '-')}"]
         if "_" in _name:
             _flags.append(f"--{_name}")
@@ -47,15 +54,35 @@ const MAIN_ARGS_RUNTIME: &str = r#"def _by_main_args(_fn, _params):
             )
             continue
         if _kind != "keyword":
-            _parser.add_argument(f"p{_i}", metavar=_name, nargs="?", type=_type, default=None)
+            _parser.add_argument(
+                f"p{_i}",
+                metavar=_name,
+                nargs="?",
+                type=_type,
+                default=None,
+                choices=_choices,
+            )
         _parser.add_argument(
-            *_flags, dest=f"o{_i}", metavar=_name.upper(), type=_type, default=None
+            *_flags,
+            dest=f"o{_i}",
+            metavar=_name.upper(),
+            type=_type,
+            default=None,
+            choices=_choices,
         )
-    _parsed = vars(_parser.parse_args())
+    if _extra is None:
+        _parsed = vars(_parser.parse_args())
+        _rest = []
+    else:
+        _namespace, _rest = _parser.parse_known_args()
+        _parsed = vars(_namespace)
+        # `parse_known_args` hands back what it did not recognise as it was
+        # written, so the vararg's own annotation is what converts it
+        _rest = [_extra(_value) for _value in _rest]
     _args = []
     _kwargs = {}
     _omitted = None
-    for _i, (_name, _type, _kind, _required) in enumerate(_params):
+    for _i, (_name, _type, _kind, _required, _choices) in enumerate(_params):
         _value = _parsed.get(f"o{_i}")
         _positional = _parsed.get(f"p{_i}")
         if _value is not None and _positional is not None:
@@ -74,6 +101,10 @@ const MAIN_ARGS_RUNTIME: &str = r#"def _by_main_args(_fn, _params):
             _args.append(_value)
         else:
             _kwargs[_name] = _value
+    for _value in _rest:
+        if _omitted is not None:
+            _parser.error(f"argument {_value}: cannot be given without {_omitted}")
+        _args.append(_value)
     return _args, _kwargs
 "#;
 
@@ -119,7 +150,8 @@ impl AstPass for MainFunction<'_> {
         }
 
         ctx.epilogue.push("if __name__ == \"__main__\":".to_owned());
-        let call = if params.is_empty() {
+        let extra = extra_arguments_converter(&main.parameters);
+        let call = if params.is_empty() && extra.is_none() {
             "main()".to_owned()
         } else {
             ctx.required_imports.push(MAIN_ARGS_RUNTIME.to_owned());
@@ -129,7 +161,11 @@ impl AstPass for MainFunction<'_> {
                 ctx.epilogue
                     .push(format!("        {},", param.spec_entry()));
             }
-            ctx.epilogue.push("    ])".to_owned());
+            let close = match extra {
+                Some(converter) => format!("    ], {converter})"),
+                None => "    ])".to_owned(),
+            };
+            ctx.epilogue.push(close);
             "main(*_by_args, **_by_kwargs)".to_owned()
         };
         if main.is_async {
@@ -157,19 +193,27 @@ struct CliParam {
     /// (positional-only), `keyword` (keyword-only), or `any`
     kind: &'static str,
     required: bool,
+    /// the values the annotation admits, rendered as python literals, when it
+    /// is a literal union — argparse rejects anything else before `main` runs
+    choices: Option<Vec<String>>,
 }
 
 impl CliParam {
-    /// the `(name, converter, kind, required)` tuple `_by_main_args` consumes
+    /// the `(name, converter, kind, required, choices)` tuple `_by_main_args`
+    /// consumes
     fn spec_entry(&self) -> String {
-        let converter = match self.ty {
-            CliType::Value(callable) => callable,
-            CliType::Flag => "None",
+        let converter = match &self.ty {
+            CliType::Value(callable) => (*callable).to_owned(),
+            CliType::Flag => "None".to_owned(),
         };
         let required = if self.required { "True" } else { "False" };
         let name = &self.name;
         let kind = self.kind;
-        format!("(\"{name}\", {converter}, \"{kind}\", {required})")
+        let choices = match &self.choices {
+            Some(values) => format!("({},)", values.join(", ")),
+            None => "None".to_owned(),
+        };
+        format!("(\"{name}\", {converter}, \"{kind}\", {required}, {choices})")
     }
 }
 
@@ -191,11 +235,12 @@ fn cli_params(params: &Parameters) -> Option<Vec<CliParam>> {
         for param in group {
             let required = param.default.is_none();
             match param.parameter.annotation.as_deref().and_then(cli_type) {
-                Some(ty) => cli.push(CliParam {
+                Some((ty, choices)) => cli.push(CliParam {
                     name: param.parameter.name.to_string(),
                     ty,
                     kind,
                     required,
+                    choices,
                 }),
                 None if required => return None,
                 None => {}
@@ -205,24 +250,188 @@ fn cli_params(params: &Parameters) -> Option<Vec<CliParam>> {
     Some(cli)
 }
 
-/// The command-line spelling of an annotation, or `None` when it has none.
+/// The command-line spelling of an annotation — its converter and, for a
+/// literal union, the values it admits — or `None` when it has none.
 ///
 /// Matched on the annotation as written: the converter emitted into the spec
 /// is the same name the source used, so it resolves to whatever that name is
 /// bound to at runtime.
-fn cli_type(annotation: &Expr) -> Option<CliType> {
+fn cli_type(annotation: &Expr) -> Option<(CliType, Option<Vec<String>>)> {
     match annotation {
-        Expr::Name(name) => match name.id.as_str() {
-            "bool" => Some(CliType::Flag),
-            "str" => Some(CliType::Value("str")),
-            "int" => Some(CliType::Value("int")),
-            "float" => Some(CliType::Value("float")),
-            "Path" => Some(CliType::Value("Path")),
-            _ => None,
-        },
+        Expr::Name(name) => {
+            let ty = match name.id.as_str() {
+                "bool" => CliType::Flag,
+                "str" => CliType::Value("str"),
+                "int" => CliType::Value("int"),
+                "float" => CliType::Value("float"),
+                "Path" => CliType::Value("Path"),
+                _ => return None,
+            };
+            Some((ty, None))
+        }
         Expr::Attribute(attr) => (attr.attr.as_str() == "Path"
             && matches!(&*attr.value, Expr::Name(name) if name.id.as_str() == "pathlib"))
-        .then_some(CliType::Value("pathlib.Path")),
+        .then_some((CliType::Value("pathlib.Path"), None)),
+        // `T?` — an absent argument is what the `None` stands for, so the
+        // spelling is `T`'s
+        Expr::UnaryOp(unary) if matches!(unary.op, ast::UnaryOp::Optional) => {
+            cli_type(&unary.operand)
+        }
+        // a union: either `T | None`, which is `T?` written out, or a union of
+        // literals, which argparse expresses as `choices`
+        Expr::BinOp(bin_op) if matches!(bin_op.op, ast::Operator::BitOr) => {
+            let mut named: Option<(CliType, Option<Vec<String>>)> = None;
+            let mut literals = Vec::new();
+            let mut literal_converter: Option<&'static str> = None;
+            for operand in union_operands(annotation) {
+                if is_none_literal(operand) {
+                    continue;
+                }
+                if let Some((converter, rendered)) = literal_choice(operand) {
+                    if *literal_converter.get_or_insert(converter) != converter {
+                        return None;
+                    }
+                    literals.push(rendered);
+                    continue;
+                }
+                // a second named operand is a union with no single converter
+                if named.is_some() {
+                    return None;
+                }
+                named = Some(cli_type(operand)?);
+            }
+            match (named, literal_converter) {
+                // `T | None` — the `None` is what leaving the argument out means
+                (Some(spelling), None) => Some(spelling),
+                // every operand a literal of one kind: the values it admits
+                (None, Some(converter)) => Some((CliType::Value(converter), Some(literals))),
+                // a named type beside a literal (`int | "a"`) admits neither the
+                // type's values nor the literal's, so nothing on the command
+                // line could satisfy both. nothing but `None`s says nothing
+                _ => None,
+            }
+        }
+        // `Literal["a", "b"]` — the same set spelled the typing way, bare or
+        // through the module it comes from
+        Expr::Subscript(subscript) if trailing_name(&subscript.value) == Some("Literal") => {
+            let mut literals = Vec::new();
+            let mut converter: Option<&'static str> = None;
+            for element in slice_elements(&subscript.slice) {
+                let (ty, rendered) = literal_choice(element)?;
+                if *converter.get_or_insert(ty) != ty {
+                    return None;
+                }
+                literals.push(rendered);
+            }
+            Some((CliType::Value(converter?), Some(literals)))
+        }
+        _ => None,
+    }
+}
+
+/// The converter for the arguments `main`'s interface does not claim, when it
+/// asks for them.
+///
+/// A leading `*rest` is the ask: everything declared after it is keyword-only,
+/// so the unclaimed arguments are the only positional ones and bind to `rest`.
+/// A `*rest` written *after* an ordinary parameter cannot mean that — the
+/// parameter ahead of it would take the first unclaimed argument as its own —
+/// so there it stays what python makes it, a variadic nothing fills.
+///
+/// The arguments arrive as the strings the command line carried, so the
+/// vararg's annotation converts them, exactly as a declared parameter's does.
+/// An annotation with no command-line spelling has nothing to convert with, and
+/// the vararg goes back to being one nothing fills.
+fn extra_arguments_converter(params: &Parameters) -> Option<&'static str> {
+    let vararg = params.vararg.as_ref()?;
+    if !(params.posonlyargs.is_empty() && params.args.is_empty()) {
+        return None;
+    }
+    match vararg.annotation.as_deref() {
+        None => Some("str"),
+        Some(annotation) => match cli_type(annotation) {
+            Some((CliType::Value(converter), None)) => Some(converter),
+            // a flag is not a value, and a literal union's `choices` have no
+            // argparse slot to be checked against here
+            _ => None,
+        },
+    }
+}
+
+/// the name a reference ends in — `Literal` for both `Literal` and
+/// `typing.Literal`
+fn trailing_name(expr: &Expr) -> Option<&str> {
+    match expr {
+        Expr::Name(name) => Some(name.id.as_str()),
+        Expr::Attribute(attribute) => Some(attribute.attr.as_str()),
+        _ => None,
+    }
+}
+
+/// `value` as a python string literal.
+///
+/// Rust's own debug spelling is not python: it escapes a control character as
+/// `\u{7f}`, which python does not read. Everything printable is written as
+/// itself, non-ascii included — the emitted file is the utf-8 python reads by
+/// default.
+fn python_string_literal(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('"');
+    for character in value.chars() {
+        match character {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            control if control.is_control() => {
+                let _ = write!(out, "\\x{:02x}", control as u32);
+            }
+            other => out.push(other),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// the operands of a `|` union, flattened — `a | b | c` nests to the left
+fn union_operands(annotation: &Expr) -> Vec<&Expr> {
+    fn walk<'a>(expr: &'a Expr, out: &mut Vec<&'a Expr>) {
+        if let Expr::BinOp(bin_op) = expr
+            && matches!(bin_op.op, ast::Operator::BitOr)
+        {
+            walk(&bin_op.left, out);
+            walk(&bin_op.right, out);
+            return;
+        }
+        out.push(expr);
+    }
+    let mut out = Vec::new();
+    walk(annotation, &mut out);
+    out
+}
+
+/// the elements of a subscript slice, which is a tuple when there is more than
+/// one
+fn slice_elements(slice: &Expr) -> Vec<&Expr> {
+    match slice {
+        Expr::Tuple(tuple) => tuple.elts.iter().collect(),
+        single => vec![single],
+    }
+}
+
+fn is_none_literal(expr: &Expr) -> bool {
+    expr.is_none_literal_expr()
+}
+
+/// a literal the command line can carry, as `(converter, python literal)`
+fn literal_choice(expr: &Expr) -> Option<(&'static str, String)> {
+    match expr {
+        Expr::StringLiteral(string) => Some(("str", python_string_literal(string.value.to_str()))),
+        Expr::NumberLiteral(number) => match &number.value {
+            ast::Number::Int(int) => Some(("int", int.to_string())),
+            _ => None,
+        },
         _ => None,
     }
 }
@@ -435,7 +644,7 @@ mod tests {
             indoc! {"
                 if __name__ == \"__main__\":
                     _by_args, _by_kwargs = _by_main_args(main, [
-                        (\"name\", str, \"any\", True),
+                        (\"name\", str, \"any\", True, None),
                     ])
                     main(*_by_args, **_by_kwargs)
             "},
@@ -460,7 +669,7 @@ mod tests {
     fn defaulted_parameter_is_optional() {
         assert!(
             guard("def main(count: int = 1):\n    pass\n")
-                .contains("(\"count\", int, \"any\", False),"),
+                .contains("(\"count\", int, \"any\", False, None),"),
             "got:\n{}",
             guard("def main(count: int = 1):\n    pass\n")
         );
@@ -471,7 +680,7 @@ mod tests {
         // `None` as the converter is what marks a `--name` / `--no-name` pair
         assert!(
             guard("def main(verbose: bool = False):\n    pass\n")
-                .contains("(\"verbose\", None, \"any\", False),"),
+                .contains("(\"verbose\", None, \"any\", False, None),"),
             "got:\n{}",
             guard("def main(verbose: bool = False):\n    pass\n")
         );
@@ -482,13 +691,14 @@ mod tests {
         // the converter runs at runtime, so it must name whatever the module
         // actually imported
         assert!(
-            guard("def main(out: Path):\n    pass\n").contains("(\"out\", Path, \"any\", True),"),
+            guard("def main(out: Path):\n    pass\n")
+                .contains("(\"out\", Path, \"any\", True, None),"),
             "got:\n{}",
             guard("def main(out: Path):\n    pass\n")
         );
         assert!(
             guard("def main(out: pathlib.Path):\n    pass\n")
-                .contains("(\"out\", pathlib.Path, \"any\", True),"),
+                .contains("(\"out\", pathlib.Path, \"any\", True, None),"),
             "got:\n{}",
             guard("def main(out: pathlib.Path):\n    pass\n")
         );
@@ -498,7 +708,7 @@ mod tests {
     fn float_parameter_is_supported() {
         assert!(
             guard("def main(ratio: float):\n    pass\n")
-                .contains("(\"ratio\", float, \"any\", True),"),
+                .contains("(\"ratio\", float, \"any\", True, None),"),
             "got:\n{}",
             guard("def main(ratio: float):\n    pass\n")
         );
@@ -514,9 +724,9 @@ mod tests {
             indoc! {"
                 if __name__ == \"__main__\":
                     _by_args, _by_kwargs = _by_main_args(main, [
-                        (\"a\", str, \"positional\", True),
-                        (\"b\", int, \"any\", False),
-                        (\"c\", str, \"keyword\", False),
+                        (\"a\", str, \"positional\", True, None),
+                        (\"b\", int, \"any\", False, None),
+                        (\"c\", str, \"keyword\", False, None),
                     ])
                     main(*_by_args, **_by_kwargs)
             "},
@@ -529,7 +739,7 @@ mod tests {
         // keeps that default instead of blocking the entry point
         let out = guard("def main(name: str, argv: list[str] | None = None):\n    pass\n");
         assert!(
-            out.contains("(\"name\", str, \"any\", True),"),
+            out.contains("(\"name\", str, \"any\", True, None),"),
             "got:\n{out}"
         );
         assert!(!out.contains("argv"), "got:\n{out}");
@@ -539,11 +749,83 @@ mod tests {
     fn variadic_parameters_are_not_exposed() {
         let out = guard("def main(name: str, *extra: str, **rest: str):\n    pass\n");
         assert!(
-            out.contains("(\"name\", str, \"any\", True),"),
+            out.contains("(\"name\", str, \"any\", True, None),"),
             "got:\n{out}"
         );
         assert!(!out.contains("extra"), "got:\n{out}");
         assert!(!out.contains("rest"), "got:\n{out}");
+    }
+
+    #[test]
+    fn an_optional_parameter_takes_its_inner_spelling() {
+        // leaving the argument out is what the `None` stands for
+        let out = guard("def main(name: str? = None):\n    pass\n");
+        assert!(
+            out.contains("(\"name\", str, \"any\", False, None),"),
+            "got:\n{out}"
+        );
+
+        let out = guard("def main(name: str | None = None):\n    pass\n");
+        assert!(
+            out.contains("(\"name\", str, \"any\", False, None),"),
+            "got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn a_literal_union_becomes_the_values_it_admits() {
+        let out = guard("def main(mode: \"fast\" | \"slow\" = \"fast\"):\n    pass\n");
+        assert!(
+            out.contains("(\"mode\", str, \"any\", False, (\"fast\", \"slow\",)),"),
+            "got:\n{out}"
+        );
+
+        let out = guard(indoc! {"
+            from typing import Literal
+
+            def main(mode: Literal[\"fast\", \"slow\"] = \"fast\"):
+                pass
+        "});
+        assert!(
+            out.contains("(\"mode\", str, \"any\", False, (\"fast\", \"slow\",)),"),
+            "got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn an_optional_literal_union_keeps_its_values() {
+        let out = guard("def main(mode: (\"fast\" | \"slow\")? = None):\n    pass\n");
+        assert!(
+            out.contains("(\"mode\", str, \"any\", False, (\"fast\", \"slow\",)),"),
+            "got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn a_mixed_union_has_no_command_line_spelling() {
+        // the choices would not describe the type, so the parameter keeps its
+        // default instead of being exposed under a wrong one
+        let out = guard("def main(mode: \"fast\" | int = \"fast\"):\n    pass\n");
+        assert!(!out.contains("\"mode\""), "got:\n{out}");
+    }
+
+    #[test]
+    fn a_leading_variadic_takes_the_unclaimed_arguments() {
+        let out = guard("def main(*rest: str, games: int = 1):\n    pass\n");
+        assert!(
+            out.contains("(\"games\", int, \"keyword\", False, None),"),
+            "got:\n{out}"
+        );
+        assert!(out.contains("    ], str)"), "got:\n{out}");
+    }
+
+    #[test]
+    fn a_trailing_variadic_is_still_not_filled() {
+        // `games` would take the first unclaimed argument as its own, so `rest`
+        // cannot mean "the rest of the command line" here
+        let out = guard("def main(games: int = 1, *rest: str):\n    pass\n");
+        assert!(out.contains("    ])"), "got:\n{out}");
+        assert!(!out.contains("], True)"), "got:\n{out}");
     }
 
     #[test]
@@ -580,16 +862,21 @@ mod tests {
     }
 
     #[test]
-    fn variadic_main_gets_guard() {
-        check(
-            "def main(*args, **kwargs):\n    pass\n",
-            indoc! {"
-                def main(*args, **kwargs):
-                    pass
-                if __name__ == \"__main__\":
-                    main()
-            "},
-        );
+    fn variadic_main_takes_the_command_line() {
+        // a leading `*args` asks for the arguments the interface does not claim,
+        // and with no declared parameter that is all of them. `**kwargs` takes
+        // no positional slot, so it neither receives them nor blocks them
+        let out = guard("def main(*args, **kwargs):\n    pass\n");
+        assert!(out.contains("    ], str)"), "got:\n{out}");
+    }
+
+    #[test]
+    fn a_trailing_variadic_main_is_still_not_filled() {
+        // `name` would take the first unclaimed argument as its own, so `args`
+        // cannot mean the rest of the command line here
+        let out = guard("def main(name: str, *args):\n    pass\n");
+        assert!(out.contains("    ])"), "got:\n{out}");
+        assert!(!out.contains("], str)"), "got:\n{out}");
     }
 
     #[test]

--- a/crates/by_transforms/src/transforms/mod.rs
+++ b/crates/by_transforms/src/transforms/mod.rs
@@ -53,6 +53,7 @@ pub(crate) mod optional_type;
 pub(crate) mod overload;
 pub(crate) mod parametric_is;
 pub(crate) mod postfix_await;
+pub(crate) mod private_method;
 pub(crate) mod propagate;
 pub(crate) mod properties;
 pub(crate) mod protocol_type;

--- a/crates/by_transforms/src/transforms/modifiers.rs
+++ b/crates/by_transforms/src/transforms/modifiers.rs
@@ -145,6 +145,23 @@ impl<'src> Modifiers<'src> {
         super::source_util::line_indent(self.source, pos)
     }
 
+    /// The range an assignment's value occupies, grouping parentheses included.
+    /// A modifier lowering replaces everything the statement said ahead of the
+    /// value, and an expression's range starts inside its parentheses, so
+    /// without this the `(` of a multi-line value is eaten and its `)` stranded
+    fn value_range(&self, stmt: &StmtAnnAssign, value: &Expr) -> TextRange {
+        // the scan stops at the annotation, which is the last thing written
+        // before the value — past it lies only `=`, whitespace, parentheses and
+        // comments, and a `#` there is unambiguously one
+        let written_before = stmt
+            .annotation
+            .range()
+            .end()
+            .max(stmt.target.range().end())
+            .max(stmt.range().start());
+        super::source_util::parenthesized_value_range(self.source, value.range(), written_before)
+    }
+
     fn is_synthetic(&self, dec: &ruff_python_ast::Decorator) -> bool {
         super::source_util::is_synthetic_decorator(self.source, dec)
     }
@@ -365,11 +382,11 @@ impl<'src> Modifiers<'src> {
         }
     }
 
-    /// Replace the identifier at `range` with an underscore-prefixed copy.
+    /// Replace the identifier at `range` with its module-private spelling.
     fn rename_with_underscore(&mut self, range: TextRange) {
         let original = self.src(range).to_owned();
         self.edits.push(Fix::safe_edit(Edit::range_replacement(
-            format!("_{original}"),
+            module_private_name(&original),
             range,
         )));
     }
@@ -448,6 +465,21 @@ impl<'src> Modifiers<'src> {
             // valueless typed `let x: T` / `final x: T` → `x: Final[T]` — a
             // read-only declaration with no initializer, `Final` in every scope
             if let Expr::Subscript(s) = node.annotation.as_ref()
+                && matches!(s.value.as_ref(), Expr::Name(n) if n.id.as_str() == "__classvar_annot__")
+            {
+                // valueless `class var a: T` → `a: ClassVar[T]`
+                let slice = s.slice.as_ref();
+                let pre_range = TextRange::new(node.range().start(), slice.range().start());
+                self.needs_classvar = true;
+                self.edits.push(Fix::safe_edit(Edit::range_replacement(
+                    format!("{name}: ClassVar["),
+                    pre_range,
+                )));
+                self.edits.push(Fix::safe_edit(Edit::insertion(
+                    "]".to_owned(),
+                    slice.range().end(),
+                )));
+            } else if let Expr::Subscript(s) = node.annotation.as_ref()
                 && matches!(s.value.as_ref(), Expr::Name(n) if matches!(n.id.as_str(), "__let__" | "__final__"))
             {
                 let slice = s.slice.as_ref();
@@ -479,7 +511,8 @@ impl<'src> Modifiers<'src> {
         match node.annotation.as_ref() {
             Expr::Name(ann) => {
                 // untyped: `let a = v`, `class a = v`, `newtype Foo = v`
-                let prefix_range = TextRange::new(node.range().start(), value.range().start());
+                let value_range = self.value_range(node, value);
+                let prefix_range = TextRange::new(node.range().start(), value_range.start());
                 match ann.id.as_str() {
                     "__let__" => {
                         self.needs_final_annotation = true;
@@ -502,15 +535,32 @@ impl<'src> Modifiers<'src> {
                         )));
                     }
                     "__newtype__" => {
-                        let value_src = self.src(value.range()).to_owned();
+                        let value_src = self.src(value_range).to_owned();
                         self.needs_newtype = true;
                         self.edits.push(Fix::safe_edit(Edit::range_replacement(
                             format!("{name} = NewType(\"{name}\", {value_src})"),
-                            node.range(),
+                            TextRange::new(node.range().start(), value_range.end()),
                         )));
                     }
                     _ => {}
                 }
+            }
+            Expr::Subscript(s) if matches!(s.value.as_ref(), Expr::Name(n) if n.id.as_str() == "__classvar_annot__") =>
+            {
+                // `class var a: T [= v]` → `a: ClassVar[T] [= v]`
+                let slice = s.slice.as_ref();
+                let pre_range = TextRange::new(node.range().start(), slice.range().start());
+                let post_range =
+                    TextRange::new(slice.range().end(), self.value_range(node, value).start());
+                self.needs_classvar = true;
+                self.edits.push(Fix::safe_edit(Edit::range_replacement(
+                    format!("{name}: ClassVar["),
+                    pre_range,
+                )));
+                self.edits.push(Fix::safe_edit(Edit::range_replacement(
+                    "] = ".to_owned(),
+                    post_range,
+                )));
             }
             Expr::Subscript(s) if matches!(s.value.as_ref(), Expr::Name(n) if matches!(n.id.as_str(), "__let__" | "__final__")) =>
             {
@@ -524,7 +574,8 @@ impl<'src> Modifiers<'src> {
                 // start at the statement, not the marker, so any modifier prefix
                 // ahead of `let` (e.g. `override let a: T = v`) is erased too
                 let pre_range = TextRange::new(node.range().start(), slice.range().start());
-                let post_range = TextRange::new(slice.range().end(), value.range().start());
+                let post_range =
+                    TextRange::new(slice.range().end(), self.value_range(node, value).start());
                 if self.class_depth > 0 && !is_final {
                     // inside class: `a: T = v` (no Final wrapper; keep the type)
                     self.edits.push(Fix::safe_edit(Edit::range_replacement(
@@ -614,6 +665,20 @@ impl<'ast> Visitor<'ast> for Modifiers<'_> {
 }
 
 /// renames all `Name` expression nodes that match a `private`-renamed symbol
+/// The name a module-level `private` symbol is emitted under: one leading
+/// underscore, which is python's own mark for "not part of the interface".
+///
+/// A name that already has one is left alone. Adding a second would make it a
+/// `__name`, and python name-mangles every `__name` it reads inside a class
+/// body — so `private def _has_room` would become `__has_room` at module level
+/// and be looked up as `_Diagnostics__has_room` from a method that calls it.
+fn module_private_name(name: &str) -> String {
+    if name.starts_with('_') {
+        return name.to_owned();
+    }
+    format!("_{name}")
+}
+
 pub(crate) struct NameRenamer {
     renames: HashMap<String, String>,
     pub(crate) edits: Vec<Fix>,
@@ -623,7 +688,7 @@ impl NameRenamer {
     pub(crate) fn new(private_names: &[String]) -> Self {
         let renames = private_names
             .iter()
-            .map(|n| (n.clone(), format!("_{n}")))
+            .map(|n| (n.clone(), module_private_name(n)))
             .collect();
         Self {
             renames,
@@ -1071,6 +1136,22 @@ mod tests {
     }
 
     #[test]
+    fn private_module_function_already_underscored() {
+        // a second underscore would make it a `__name`, which python mangles
+        // inside every class body that reads it
+        check(
+            indoc! {"
+                private def _has_room() -> bool:
+                    return True
+            "},
+            indoc! {"
+                def _has_room() -> bool:
+                    return True
+            "},
+        );
+    }
+
+    #[test]
     fn export_protocol() {
         check(
             "export protocol Foo: ...\n",
@@ -1089,6 +1170,116 @@ mod tests {
             indoc! {"
                 from typing import Final
                 MAX: Final = 100
+            "},
+        );
+    }
+
+    #[test]
+    fn class_var_annotated_decl() {
+        check(
+            indoc! {"
+                class A:
+                    class var count: int = 0
+                    class var kind: str
+            "},
+            indoc! {"
+                from typing import ClassVar
+                class A:
+                    count: ClassVar[int] = 0
+                    kind: ClassVar[str]
+            "},
+        );
+    }
+
+    #[test]
+    fn class_let_annotated_decl_is_final() {
+        // a read-only class attribute is python's `Final`, which in a class body
+        // can be reassigned neither through the class nor an instance
+        check(
+            indoc! {"
+                class A:
+                    class let ORIGIN: int = 0
+            "},
+            indoc! {"
+                from typing import Final
+                class A:
+                    ORIGIN: Final[int] = 0
+            "},
+        );
+    }
+
+    #[test]
+    fn let_decl_parenthesized_multiline_value() {
+        // an expression's range starts inside its parentheses, so the lowering
+        // has to reach back out for the `(` or its `)` is stranded below
+        check(
+            indoc! {"
+                let total = (
+                    1
+                    + 2
+                )
+            "},
+            indoc! {"
+                from typing import Final
+                total: Final = (
+                    1
+                    + 2
+                )
+            "},
+        );
+    }
+
+    #[test]
+    fn typed_let_decl_parenthesized_multiline_value() {
+        check(
+            indoc! {"
+                let total: int = (
+                    1
+                    + 2
+                )
+            "},
+            indoc! {"
+                from typing import Final
+                total: Final[int] = (
+                    1
+                    + 2
+                )
+            "},
+        );
+    }
+
+    #[test]
+    fn let_decl_parenthesized_value_with_comment() {
+        // the walk back to the `(` steps over a trailing comment on the way
+        check(
+            indoc! {"
+                let total = (  # the sum
+                    1 + 2
+                )
+            "},
+            indoc! {"
+                from typing import Final
+                total: Final = (  # the sum
+                    1 + 2
+                )
+            "},
+        );
+    }
+
+    #[test]
+    fn newtype_parenthesized_multiline_value() {
+        // `newtype` re-emits the value, so it needs the closing parenthesis too
+        check(
+            indoc! {"
+                newtype Id = (
+                    int
+                )
+            "},
+            indoc! {"
+                from typing import NewType
+                Id = NewType(\"Id\", (
+                    int
+                ))
             "},
         );
     }

--- a/crates/by_transforms/src/transforms/mutable_defaults.rs
+++ b/crates/by_transforms/src/transforms/mutable_defaults.rs
@@ -26,7 +26,7 @@
 //! (`??`, `?.`, `int?` annotations, …) anywhere in the function still apply.
 
 use ruff_python_ast::helpers::is_immutable_scalar_default;
-use ruff_python_ast::visitor::{Visitor, walk_stmt};
+use ruff_python_ast::visitor::{Visitor, walk_expr, walk_stmt};
 use ruff_python_ast::{Expr, Stmt, StmtFunctionDef};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
@@ -35,7 +35,7 @@ use super::source_util::{line_indent, line_start};
 use crate::type_info::TypeInfo;
 
 /// what a `_MISSING`-sentinel guard does when the argument was not supplied
-enum Guard {
+pub(crate) enum Guard {
     /// re-evaluate the written default per call (mutable defaults). the default
     /// is carried as its source *range*, not its text: the guard re-emits it
     /// through a [`Fragment::Src`] passthrough so the lowerings written inside
@@ -48,7 +48,7 @@ enum Guard {
 }
 
 impl Guard {
-    fn push(&self, frags: &mut Vec<Fragment>, base: &str) {
+    pub(crate) fn push(&self, frags: &mut Vec<Fragment>, base: &str) {
         match self {
             Guard::Reevaluate { name, default } => {
                 frags.push(Fragment::Lit(format!(
@@ -85,73 +85,184 @@ fn body_range(stmt: &Stmt, header_end: TextSize) -> Option<TextRange> {
     (!range.is_empty() && range.start() >= header_end).then_some(range)
 }
 
-impl MutableDefaults<'_> {
-    /// replace a default with the sentinel. a template rather than plain text so
-    /// it *absorbs* the zero-width insertions a lowering anchored to the
-    /// default's first token left behind (`_force_unwrap(`), which a plain-text
-    /// replacement leaves stranded in the signature. the guard re-emits them
-    fn push_sentinel(&mut self, default: TextRange) {
-        self.edits
-            .push((default, vec![Fragment::Lit("_MISSING".to_owned())]));
-    }
+/// replace a default with the sentinel. a template rather than plain text so
+/// it *absorbs* the zero-width insertions a lowering anchored to the default's
+/// first token left behind (`_force_unwrap(`), which a plain-text replacement
+/// leaves stranded in the signature. the guard re-emits them
+fn sentinel_edit(default: TextRange) -> (TextRange, Vec<Fragment>) {
+    (default, vec![Fragment::Lit("_MISSING".to_owned())])
+}
 
-    fn process_function(&mut self, f: &StmtFunctionDef) {
-        let mut guards: Vec<Guard> = Vec::new();
-        let params = f.parameters.as_ref();
-        // positional parameters: swap non-scalar defaults for the sentinel,
-        // and give basedpython's required-after-defaulted parameters a
-        // sentinel default plus a raising guard (keyword-only parameters may
-        // follow a default without one in python already)
-        let mut seen_default = false;
-        for pw in params.posonlyargs.iter().chain(params.args.iter()) {
-            match pw.default.as_deref() {
-                Some(d) => {
-                    seen_default = true;
-                    if !is_immutable_scalar_default(d) {
-                        self.push_sentinel(d.range());
-                        guards.push(Guard::Reevaluate {
-                            name: pw.parameter.name.id.to_string(),
-                            default: d.range(),
-                        });
-                    }
-                }
-                None if seen_default => {
-                    // `=` spacing mirrors python style: spaced when annotated
-                    let sentinel = if pw.parameter.annotation.is_some() {
-                        " = _MISSING"
-                    } else {
-                        "=_MISSING"
-                    };
-                    self.edits.push((
-                        TextRange::empty(pw.parameter.range().end()),
-                        vec![Fragment::Lit(sentinel.to_owned())],
-                    ));
-                    guards.push(Guard::Required {
+/// The signature edits and body guards `f`'s parameter list calls for: a
+/// `_MISSING` sentinel wherever a default would otherwise be shared between
+/// calls, and one wherever python's own parameter order is relaxed.
+pub(crate) fn parameter_guards(
+    f: &StmtFunctionDef,
+) -> (Vec<(TextRange, Vec<Fragment>)>, Vec<Guard>) {
+    let mut sentinels = Vec::new();
+    let mut guards = Vec::new();
+    let params = f.parameters.as_ref();
+    // positional parameters: swap non-scalar defaults for the sentinel, and give
+    // basedpython's required-after-defaulted parameters a sentinel default plus
+    // a raising guard (keyword-only parameters may follow a default without one
+    // in python already)
+    let mut seen_default = false;
+    for pw in params.posonlyargs.iter().chain(params.args.iter()) {
+        match pw.default.as_deref() {
+            Some(d) => {
+                seen_default = true;
+                if !is_immutable_scalar_default(d) && !body_cannot_evaluate(d) {
+                    sentinels.push(sentinel_edit(d.range()));
+                    guards.push(Guard::Reevaluate {
                         name: pw.parameter.name.id.to_string(),
-                        function: f.name.id.to_string(),
+                        default: d.range(),
                     });
                 }
-                None => {}
             }
-        }
-        for pw in &params.kwonlyargs {
-            if let Some(d) = pw.default.as_deref()
-                && !is_immutable_scalar_default(d)
-            {
-                self.push_sentinel(d.range());
-                guards.push(Guard::Reevaluate {
+            None if seen_default => {
+                // `=` spacing mirrors python style: spaced when annotated
+                let sentinel = if pw.parameter.annotation.is_some() {
+                    " = _MISSING"
+                } else {
+                    "=_MISSING"
+                };
+                sentinels.push((
+                    TextRange::empty(pw.parameter.range().end()),
+                    vec![Fragment::Lit(sentinel.to_owned())],
+                ));
+                guards.push(Guard::Required {
                     name: pw.parameter.name.id.to_string(),
-                    default: d.range(),
+                    function: f.name.id.to_string(),
                 });
             }
+            None => {}
         }
+    }
+    for pw in &params.kwonlyargs {
+        if let Some(d) = pw.default.as_deref()
+            && !is_immutable_scalar_default(d)
+            && !body_cannot_evaluate(d)
+        {
+            sentinels.push(sentinel_edit(d.range()));
+            guards.push(Guard::Reevaluate {
+                name: pw.parameter.name.id.to_string(),
+                default: d.range(),
+            });
+        }
+    }
+    (sentinels, guards)
+}
+
+/// Whether the *callee's* body could evaluate `default` at all.
+///
+/// Re-evaluating a default there is the point of the guard, and it is what lets
+/// a later parameter default from an earlier one. But an `await` belongs to the
+/// suspension of the function the `def` was written in, and a callee that is
+/// not itself async cannot host one — cpython rejects the result outright:
+///
+/// ```text
+/// async def outer():
+///     def g(a=await value()): ...
+/// ```
+///
+/// So that default is left exactly as written, which is what python does with
+/// it. A mutable one left shared is `mutable-argument-default`'s to report.
+fn body_cannot_evaluate(default: &Expr) -> bool {
+    struct Finder {
+        found: bool,
+    }
+
+    impl<'a> Visitor<'a> for Finder {
+        fn visit_expr(&mut self, expr: &'a Expr) {
+            match expr {
+                Expr::Await(_) | Expr::Yield(_) | Expr::YieldFrom(_) => self.found = true,
+                // a nested function's own suspension is its own
+                Expr::Lambda(_) => {}
+                _ if !self.found => walk_expr(self, expr),
+                _ => {}
+            }
+        }
+    }
+
+    let mut finder = Finder { found: false };
+    finder.visit_expr(default);
+    finder.found
+}
+
+/// Whether `f` is an `init(…)` shorthand whose whole body the parser
+/// synthesized — the source wrote none of it, so there is nothing to anchor to.
+pub(crate) fn is_bodyless_init_shorthand(f: &StmtFunctionDef) -> bool {
+    f.decorator_list
+        .iter()
+        .any(|d| matches!(&d.expression, Expr::Name(n) if n.id.as_str() == "__init_method__"))
+        && first_body_statement(f).is_none()
+}
+
+/// The first statement in `f`'s body that came from the source, docstring
+/// included — that is, whether the source wrote a body at all.
+///
+/// [`init_method`] hangs the body it generates off this, and it is what
+/// [`is_bodyless_init_shorthand`] means by bodyless. A docstring *is* a body:
+/// generating another one around it would leave two.
+///
+/// [`init_method`]: super::init_method
+pub(crate) fn first_body_statement(f: &StmtFunctionDef) -> Option<&Stmt> {
+    let header_end = header_end(f);
+    f.body
+        .iter()
+        .find(|stmt| body_range(stmt, header_end).is_some())
+}
+
+/// The offset past everything a `def`'s header can span, so a statement before
+/// it is one the parser synthesized from a parameter rather than a body.
+fn header_end(f: &StmtFunctionDef) -> TextSize {
+    f.parameters.range().end().max(
+        f.returns
+            .as_ref()
+            .map_or(TextSize::new(0), |r| r.range().end()),
+    )
+}
+
+/// The first statement in `f`'s body that came from the source, skipping a
+/// docstring and any statement the parser synthesized.
+///
+/// This is the anchor a body insertion hangs off, and [`init_method`] reads the
+/// same one: a body the two disagree about is a body where one of them emits a
+/// `_MISSING` sentinel and the other emits no guard for it.
+///
+/// [`init_method`]: super::init_method
+pub(crate) fn first_source_statement(f: &StmtFunctionDef) -> Option<&Stmt> {
+    let header_end = header_end(f);
+    let docstring_count = if let Some(Stmt::Expr(e)) = f.body.first() {
+        usize::from(matches!(e.value.as_ref(), Expr::StringLiteral(_)))
+    } else {
+        0
+    };
+    f.body
+        .iter()
+        .skip(docstring_count)
+        .find(|s| body_range(s, header_end).is_some())
+}
+
+impl MutableDefaults<'_> {
+    fn process_function(&mut self, f: &StmtFunctionDef) {
+        // the `init(…)` shorthand with no body of its own has no source
+        // statement to splice a guard before, so [`init_method`] — which writes
+        // that body — emits both the sentinels and the guards for it
+        //
+        // [`init_method`]: super::init_method
+        if is_bodyless_init_shorthand(f) {
+            return;
+        }
+        let (sentinels, guards) = parameter_guards(f);
+        self.edits.extend(sentinels);
         if guards.is_empty() {
             return;
         }
         self.used = true;
 
-        // insert the guards at the start of the first non-docstring body
-        // statement
+        // insert the guards at the start of the first body statement the source
+        // actually wrote
         let docstring_count = if let Some(Stmt::Expr(e)) = f.body.first() {
             usize::from(matches!(e.value.as_ref(), Expr::StringLiteral(_)))
         } else {
@@ -164,11 +275,7 @@ impl MutableDefaults<'_> {
                 .map_or(TextSize::new(0), |r| r.range().end()),
         );
         let mut frags: Vec<Fragment> = Vec::new();
-        if let Some(range) = f
-            .body
-            .get(docstring_count)
-            .and_then(|s| body_range(s, header_end))
-        {
+        if let Some(range) = first_source_statement(f).and_then(|s| body_range(s, header_end)) {
             let insert_at = range.start();
             let prefix = &self.source
                 [usize::from(line_start(self.source, insert_at))..usize::from(insert_at)];
@@ -244,8 +351,13 @@ impl TypeAwarePass for MutableDefaultsPass<'_> {
             inner.visit_stmt(stmt);
         }
         if let Some(name) = inner.unanchored.first() {
+            // the `init(…)` shorthand is the one construct that generates its
+            // own body, and it emits its own guards; anything else reaching here
+            // means a pass grew a synthesized body without saying where a
+            // statement goes in it. refuse rather than splice one into the
+            // signature
             ctx.errors.push(format!(
-                "a re-evaluated default in `{name}` has no body position to lower into — write it as a `def` with a body"
+                "`{name}` has a body nothing in the source anchors, so a parameter guard has nowhere to go"
             ));
             return;
         }
@@ -307,50 +419,81 @@ mod tests {
         );
     }
 
-    fn check_err(input: &str, needle: &str) {
-        let err = transpile(input, &crate::Config::test_default()).unwrap_err();
-        assert!(err.contains(needle), "got: {err}");
-    }
-
-    /// an `init(…)` shorthand generates its own body, so a guard has no source
-    /// position to anchor to. each of these used to splice the guard into the
-    /// middle of the parameter list — and the bodyless plain form panicked with
-    /// an arithmetic overflow reaching for `body[-1]`
+    /// an `init(…)` shorthand generates its own body, so the guards go in it —
+    /// there is no source statement to splice them before
     #[test]
-    fn a_generated_constructor_body_is_not_an_anchor() {
-        const NEEDLE: &str = "has no body position to lower into";
-
-        // no parameter modifier and no body at all: the body is empty
-        check_err(
+    fn a_generated_constructor_body_takes_the_guard() {
+        // the `init(…)` shorthand has no source statement to splice a guard
+        // before, so the body it generates carries one
+        check(
             indoc! {"
                 class S:
                     init(items: list[int] = [])
             "},
-            NEEDLE,
+            indoc! {"
+                _MISSING = object()
+                class S:
+                    def __init__(self, items: list[int] = _MISSING):
+                        if items is _MISSING:
+                            items = []
+            "},
         );
-        // `let` generates a field assignment that reuses the parameter's range
-        check_err(
+        check(
             indoc! {"
                 class S:
                     init(let items: list[int] = [])
             "},
-            NEEDLE,
+            indoc! {"
+                _MISSING = object()
+                class S:
+                    def __init__(self, items: list[int] = _MISSING):
+                        if items is _MISSING:
+                            items = []
+                        self.items: list[int] = items
+            "},
         );
-        check_err(
+    }
+
+    #[test]
+    fn a_generated_constructor_takes_a_required_after_default_guard() {
+        // python rejects a required parameter after a defaulted one, so the
+        // shorthand's relaxed order lowers to a sentinel and a raising guard
+        check(
             indoc! {"
                 class S:
-                    init(var items: list[int] = [])
+                    init(let first: int = 1, let second: str)
             "},
-            NEEDLE,
+            indoc! {"
+                _MISSING = object()
+                class S:
+                    def __init__(self, first: int = 1, second: str = _MISSING):
+                        if second is _MISSING:
+                            raise TypeError(\"__init__() missing required argument: 'second'\")
+                        self.first: int = first
+                        self.second: str = second
+            "},
         );
-        // and it still leads the body when the shorthand has one of its own
-        check_err(
+    }
+
+    #[test]
+    fn a_shorthand_with_a_body_anchors_before_its_own_first_statement() {
+        // the generated field assignments sit ahead of the written body, and
+        // the guard has to precede both
+        check(
             indoc! {"
                 class S:
                     init(let items: list[int] = []):
-                        pass
+                        print(items)
             "},
-            NEEDLE,
+            indoc! {"
+                _MISSING = object()
+                class S:
+                    def __init__(self, items: list[int] = _MISSING):
+                        if items is _MISSING:
+                            items = []
+                        self.items: list[int] = items
+                        print(items)
+            "},
         );
     }
 

--- a/crates/by_transforms/src/transforms/optional_type.rs
+++ b/crates/by_transforms/src/transforms/optional_type.rs
@@ -73,6 +73,9 @@ impl<'src> OptionalLower<'src> {
 
 impl<'ast> Visitor<'ast> for OptionalLower<'_> {
     fn visit_stmt(&mut self, stmt: &'ast Stmt) {
+        if crate::transforms::source_util::is_synthesized_init_declaration(stmt) {
+            return;
+        }
         let type_params = match stmt {
             Stmt::FunctionDef(f) => f.type_params.as_deref(),
             Stmt::ClassDef(c) => c.type_params.as_deref(),

--- a/crates/by_transforms/src/transforms/private_method.rs
+++ b/crates/by_transforms/src/transforms/private_method.rs
@@ -1,0 +1,143 @@
+//! call sites of a `private` method (basedpython)
+//!
+//! `private def helper()` in a class body lowers to `def __helper()`, which
+//! python name-mangles to `_A__helper` while class `A`'s body is executed. The
+//! call sites keep the name the source wrote, so they have to be pointed at the
+//! same attribute:
+//!
+//! ```by
+//! class A:
+//!     private def helper(self) -> int:
+//!         return 1
+//!
+//!     def use(self) -> int:
+//!         return self.helper()
+//! ```
+//!
+//! →
+//!
+//! ```python
+//! class A:
+//!     def __helper(self) -> int:
+//!         return 1
+//!
+//!     def use(self) -> int:
+//!         return self._A__helper()
+//! ```
+//!
+//! the mangled name is written out rather than left to python: python mangles
+//! lexically, so `self.__helper` would mean `_B__helper` in a subclass's body
+//! and `__helper` outside a class altogether, while `_A__helper` names the same
+//! attribute from every one of those places
+
+use ruff_python_ast::visitor::{Visitor, walk_expr, walk_stmt};
+use ruff_python_ast::{Expr, Stmt};
+use ruff_text_size::Ranged;
+
+use super::ast_driver::{PassContext, TypeAwarePass};
+use crate::type_info::TypeInfo;
+
+pub(crate) struct PrivateMethodPass;
+
+impl TypeAwarePass for PrivateMethodPass {
+    fn run(&self, stmts: &[Stmt], types: &dyn TypeInfo, ctx: &mut PassContext) {
+        let mut renamer = Renamer {
+            types,
+            edits: Vec::new(),
+        };
+        for stmt in stmts {
+            renamer.visit_stmt(stmt);
+        }
+        ctx.text_edits.extend(renamer.edits);
+    }
+}
+
+struct Renamer<'a> {
+    types: &'a dyn TypeInfo,
+    edits: Vec<(ruff_text_size::TextRange, String)>,
+}
+
+impl<'ast> Visitor<'ast> for Renamer<'_> {
+    fn visit_stmt(&mut self, stmt: &'ast Stmt) {
+        walk_stmt(self, stmt);
+    }
+
+    fn visit_expr(&mut self, expr: &'ast Expr) {
+        if let Expr::Attribute(attribute) = expr
+            && let Some(mangled) = self.types.private_method_name(attribute)
+        {
+            self.edits.push((attribute.attr.range(), mangled));
+        }
+        walk_expr(self, expr);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Config, transpile};
+    use indoc::indoc;
+
+    fn out(input: &str) -> String {
+        transpile(input, &Config::test_default()).unwrap()
+    }
+
+    #[test]
+    fn a_call_reaches_the_mangled_definition() {
+        let out = out(indoc! {"
+            class A:
+                private def helper(self) -> int:
+                    return 1
+
+                def use(self) -> int:
+                    return self.helper()
+        "});
+        assert!(out.contains("def __helper(self) -> int:"), "got:\n{out}");
+        assert!(out.contains("return self._A__helper()"), "got:\n{out}");
+    }
+
+    #[test]
+    fn a_call_from_a_subclass_reaches_the_declaring_class() {
+        // python would mangle `self.__helper` written here to `_B__helper`,
+        // which names nothing — the declaring class is what the name records
+        let out = out(indoc! {"
+            class A:
+                private def helper(self) -> int:
+                    return 1
+
+            class B(A):
+                def use(self) -> int:
+                    return self.helper()
+        "});
+        assert!(out.contains("return self._A__helper()"), "got:\n{out}");
+    }
+
+    #[test]
+    fn an_ordinary_method_is_untouched() {
+        let out = out(indoc! {"
+            class A:
+                def helper(self) -> int:
+                    return 1
+
+                def use(self) -> int:
+                    return self.helper()
+        "});
+        assert!(out.contains("return self.helper()"), "got:\n{out}");
+    }
+
+    #[test]
+    fn a_same_named_method_on_another_class_is_untouched() {
+        let out = out(indoc! {"
+            class A:
+                private def helper(self) -> int:
+                    return 1
+
+            class B:
+                def helper(self) -> int:
+                    return 2
+
+                def use(self) -> int:
+                    return self.helper()
+        "});
+        assert!(out.contains("return self.helper()"), "got:\n{out}");
+    }
+}

--- a/crates/by_transforms/src/transforms/source_util.rs
+++ b/crates/by_transforms/src/transforms/source_util.rs
@@ -102,6 +102,110 @@ pub(crate) fn value_separator_start(source: &str, prefix: TextRange) -> TextSize
     TextSize::try_from(at).expect("offset within the source fits u32")
 }
 
+/// The source range a value actually occupies, counting any grouping
+/// parentheses around it.
+///
+/// An expression's range starts *inside* its parentheses and ends inside them
+/// too, so the value of `let a = (\n    1\n    + 2\n)` is reported as spanning
+/// just `1\n    + 2`. A lowering that replaces everything ahead of the value —
+/// `let a = ` becomes `a: Final = ` — would then swallow the `(` and leave the
+/// `)` behind, three lines down and no longer opened. Walking out over the
+/// trivia on both sides recovers the parentheses so the whole group survives
+/// the rewrite.
+///
+/// `limit` is where the walk stops: the end of the last node written *before*
+/// the value — an assignment's annotation or target — or the statement's own
+/// start when nothing precedes it (a `return`'s operand). It has to be that
+/// tight: between a node's end and the value there is only `=`, whitespace,
+/// parentheses and comments, so a `#` found there really does open a comment.
+/// Starting from the statement instead would scan back across the annotation,
+/// where a `#` can sit inside a string.
+///
+/// Only call this where every parenthesis ahead of the value belongs to the
+/// value: an assignment's right-hand side, a `return`'s operand. A call
+/// argument's opening parenthesis belongs to the call, not to the argument.
+pub(crate) fn parenthesized_value_range(
+    source: &str,
+    value: TextRange,
+    limit: TextSize,
+) -> TextRange {
+    let bytes = source.as_bytes();
+    let lo = usize::from(limit);
+    let mut at = usize::from(value.start()).min(source.len());
+    let mut start = at;
+    let mut depth = 0usize;
+    while at > lo {
+        match bytes[at - 1] {
+            // stepping back over a line break lands at the end of the previous
+            // line, where a trailing comment may sit. Nothing between a
+            // statement's words and its value can quote a `#`, so the first one
+            // on the line starts the comment
+            b'\n' => {
+                at -= 1;
+                let line_start = source[lo..at].rfind('\n').map_or(lo, |i| lo + i + 1);
+                if let Some(hash) = source[line_start..at].find('#') {
+                    at = line_start + hash;
+                }
+            }
+            b'(' => {
+                at -= 1;
+                start = at;
+                depth += 1;
+            }
+            byte if byte == b'\\' || byte.is_ascii_whitespace() => at -= 1,
+            _ => break,
+        }
+    }
+
+    // consume exactly as many closing parentheses as were opened, so a
+    // parenthesis belonging to an enclosing construct is left where it is
+    let mut at = usize::from(value.end()).min(source.len());
+    let mut end = at;
+    while depth > 0 && at < source.len() {
+        match bytes[at] {
+            b')' => {
+                at += 1;
+                end = at;
+                depth -= 1;
+            }
+            b'#' => at += source[at..].find('\n').unwrap_or(source.len() - at),
+            byte if byte == b'\\' || byte.is_ascii_whitespace() => at += 1,
+            _ => break,
+        }
+    }
+
+    TextRange::new(
+        TextSize::try_from(start).expect("offset within the source fits u32"),
+        TextSize::try_from(end).expect("offset within the source fits u32"),
+    )
+}
+
+/// basedpython: whether `stmt` is one of the declarations the parser
+/// synthesized for an `init(…)` shorthand — the `self.<name>: __let__[T] =
+/// <name>` that a `let` / `var` parameter stands for.
+///
+/// These have no source of their own: their ranges point back at the parameter
+/// they were built from. A pass that walks type positions would therefore lower
+/// the same source twice, once for the parameter's own annotation and once for
+/// the synthesized declaration's — landing two copies of the same edit on one
+/// range. [`init_method`](super::init_method) writes the real line, so every
+/// other pass leaves them alone.
+///
+/// What identifies them is that the parser gave the statement and its target the
+/// *same* range — the parameter's. A statement the source wrote always extends
+/// past its target, because the `: T = value` follows it.
+pub(crate) fn is_synthesized_init_declaration(stmt: &Stmt) -> bool {
+    let (range, target) = match stmt {
+        Stmt::AnnAssign(assign) => (assign.range(), assign.target.range()),
+        Stmt::Assign(assign) => match assign.targets.first() {
+            Some(target) => (assign.range(), target.range()),
+            None => return false,
+        },
+        _ => return false,
+    };
+    range == target
+}
+
 /// Byte offset of the start of the line containing `pos`. Lines begin at
 /// either offset 0 or one byte past the previous `\n`
 pub(crate) fn line_start(source: &str, pos: TextSize) -> TextSize {

--- a/crates/by_transforms/src/transforms/statement_expression.rs
+++ b/crates/by_transforms/src/transforms/statement_expression.rs
@@ -54,7 +54,9 @@ use ruff_text_size::{Ranged, TextRange};
 use std::collections::HashSet;
 
 use super::ast_driver::{AstPass, Fragment, PassContext};
-use super::source_util::{line_indent, line_start, temporary_name, value_separator_start};
+use super::source_util::{
+    line_indent, line_start, parenthesized_value_range, temporary_name, value_separator_start,
+};
 
 pub(crate) struct StatementExpressionPass<'src> {
     source: &'src str,
@@ -264,7 +266,14 @@ impl Lower<'_> {
         indent: &str,
         out: &mut Vec<Fragment>,
     ) {
-        let prefix = TextRange::new(stmt.range().start(), tail.range().start());
+        // the span stops at the value's *written* start, parentheses included:
+        // a group around the value is replaced by what is emitted above, so
+        // re-emitting its `(` would leave it open — the matching `)` is inside
+        // the replaced statement and does not reach the output
+        let value_start =
+            parenthesized_value_range(self.source, tail.range(), written_before_value(stmt))
+                .start();
+        let prefix = TextRange::new(stmt.range().start(), value_start);
         let separator = TextRange::new(value_separator_start(self.source, prefix), prefix.end());
         self.text_edits.push((separator, " ".to_owned()));
         out.push(Fragment::Lit(format!("\n{indent}")));
@@ -325,6 +334,21 @@ impl Lower<'_> {
             }
         }
     }
+}
+
+/// Where the scan for a value's own parentheses may start: the end of the last
+/// node the statement wrote before its value, or the statement's start when it
+/// wrote none. See [`parenthesized_value_range`].
+fn written_before_value(stmt: &Stmt) -> ruff_text_size::TextSize {
+    let written = match stmt {
+        Stmt::Assign(assign) => assign.targets.last().map(Ranged::end),
+        Stmt::AnnAssign(assign) => Some(assign.annotation.range().end()),
+        Stmt::AugAssign(assign) => Some(assign.target.range().end()),
+        // `return <value>` and a bare expression statement write nothing ahead
+        // of the value but the keyword, which no string can hide in
+        _ => None,
+    };
+    written.unwrap_or_else(|| stmt.range().start())
 }
 
 /// The expression whose value the statement takes on, if it has one.
@@ -538,6 +562,54 @@ mod tests {
                     if __by_stmt_expr_0__ is None:
                         raise KeyError(k)
                     v = __by_stmt_expr_0__
+            "}),
+            "got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn coalesce_with_continue() {
+        let out = check(indoc! {r#"
+            def f(items: list[int | None]) -> int:
+                total = 0
+                for item in items:
+                    one = item ?? continue
+                    total += one
+                return total
+        "#});
+        assert!(
+            out.contains(indoc! {"
+                def f(items: list[int | None]) -> int:
+                    total = 0
+                    for item in items:
+                        __by_stmt_expr_0__ = item
+                        if __by_stmt_expr_0__ is None:
+                            continue
+                        one = __by_stmt_expr_0__
+            "}),
+            "got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn coalesce_with_break() {
+        let out = check(indoc! {r#"
+            def f(items: list[int | None]) -> int:
+                total = 0
+                for item in items:
+                    one = item ?? break
+                    total += one
+                return total
+        "#});
+        assert!(
+            out.contains(indoc! {"
+                def f(items: list[int | None]) -> int:
+                    total = 0
+                    for item in items:
+                        __by_stmt_expr_0__ = item
+                        if __by_stmt_expr_0__ is None:
+                            break
+                        one = __by_stmt_expr_0__
             "}),
             "got:\n{out}"
         );

--- a/crates/by_transforms/src/transforms/trailing_lambda.rs
+++ b/crates/by_transforms/src/transforms/trailing_lambda.rs
@@ -232,7 +232,12 @@ impl TrailingLambdaLower<'_, '_> {
         let [decorator] = function.decorator_list.as_slice() else {
             return;
         };
-        let callee = &decorator.expression;
+        // `await f(x):` hangs the block on the call. the `await` stays where it
+        // was written: it falls inside the statement span the rewrite re-emits
+        let callee = match &decorator.expression {
+            Expr::Await(await_expr) => await_expr.value.as_ref(),
+            expression => expression,
+        };
 
         // the header colon sits between the called expression and the suite,
         // with only whitespace before it
@@ -307,7 +312,12 @@ impl TrailingLambdaLower<'_, '_> {
         for preinit in &preinits {
             fragments.push(Fragment::Lit(format!("{preinit} = None\n{indent}")));
         }
-        fragments.push(Fragment::Lit(format!("def {name}({parameters}):")));
+        // a block whose body awaits is a coroutine function; the callee it is
+        // handed to awaits the call, the way it would any other async callback
+        let async_prefix = if function.is_async { "async " } else { "" };
+        fragments.push(Fragment::Lit(format!(
+            "{async_prefix}def {name}({parameters}):"
+        )));
         // write-through declarations so block assignments update enclosing
         // bindings; spliced ahead of the suite so they precede every use
         if let Some(declarations) = declarations {
@@ -509,6 +519,48 @@ mod tests {
 
     fn check(input: &str) -> String {
         transpile(input, &Config::test_default()).unwrap()
+    }
+
+    #[test]
+    fn a_block_that_awaits_lowers_to_an_async_def() {
+        // the block is a function of its own, so `await` in it makes *it* a
+        // coroutine function; the `await` on the call stays where it was written
+        let out = check(indoc! {"
+            from collections.abc import Awaitable
+
+            async def scope(name: str, once block: () -> Awaitable[None]):
+                await block()
+
+            async def main():
+                await scope(\"db\"):
+                    await scope(\"inner\"):
+                        pass
+        "});
+        assert!(
+            out.contains("async def _trailing_lambda_0(it=None):"),
+            "got:\n{out}"
+        );
+        assert!(
+            out.contains("await scope(\"db\", block=_trailing_lambda_0)"),
+            "got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn a_block_that_does_not_await_stays_a_plain_def() {
+        let out = check(indoc! {"
+            def f(a: (int) -> None):
+                a(1)
+
+            async def main():
+                f:
+                    print(it)
+        "});
+        assert!(
+            out.contains("def _trailing_lambda_0(it=None):"),
+            "got:\n{out}"
+        );
+        assert!(!out.contains("async def _trailing_lambda_0"), "got:\n{out}");
     }
 
     #[test]

--- a/crates/by_transforms/src/transforms/type_reification.rs
+++ b/crates/by_transforms/src/transforms/type_reification.rs
@@ -28,7 +28,9 @@
 //! reification is best-effort: it fires only when ty solved the
 //! specialization to types with a runtime spelling (see ty's `reified_infer`
 //! module) — dynamic, unsolved or scope-local arguments leave the call as
-//! written. type positions never reify (annotations, type parameter lists,
+//! written. it also fires only where the class accepts a subscript at runtime:
+//! `zip` and `map` are generic in the stub but unsubscriptable in cpython, so
+//! `zip(a, b)` reaches the output as it was written. type positions never reify (annotations, type parameter lists,
 //! `type X = …` values, type-context subscript slices such as legacy
 //! `Callable[[int], str]` parameter lists), and dunders that static readers
 //! require to stay literal displays (`__all__`, `__slots__`, `__match_args__`)
@@ -265,6 +267,53 @@ mod tests {
             PythonVersion::PY312,
         );
         assert!(out.contains("a = A()"), "unsolved ctor stays bare: {out}");
+    }
+
+    #[test]
+    fn a_builtin_that_rejects_a_subscript_stays_bare() {
+        // `zip`, `map` and `filter` are generic in the stub and unsubscriptable
+        // at runtime — `zip[tuple[int, bool]]` is a `TypeError`, so the call has
+        // to reach the output as it was written
+        for (src, expected) in [
+            ("xs = zip([1], [True])\n", "xs = zip([1], [True])"),
+            ("xs = map(str, [1])\n", "map(str, [1])"),
+            ("xs = filter(None, [1])\n", "filter(None, [1])"),
+        ] {
+            let out = out_at(src, PythonVersion::PY312);
+            assert!(out.contains(expected), "{src:?} should stay bare: {out}");
+        }
+    }
+
+    #[test]
+    fn a_builtin_that_accepts_a_subscript_is_reified() {
+        // `enumerate` declares its own `__class_getitem__`, and `deque`
+        // inherits one; both accept the subscript at runtime
+        let out = out_at("xs = enumerate([\"a\"])\n", PythonVersion::PY312);
+        assert!(out.contains("enumerate[str]([\"a\"])"), "got: {out}");
+
+        let out = out_at(
+            indoc! {"
+                from collections import deque
+                xs = deque([1])
+            "},
+            PythonVersion::PY312,
+        );
+        assert!(out.contains("deque[int]([1])"), "got: {out}");
+    }
+
+    #[test]
+    fn a_stub_generic_inheriting_a_generic_base_is_reified() {
+        // `ChainMap` declares no `__class_getitem__`, but it inherits
+        // `MutableMapping[Key, Value]`, which puts `Generic` in its runtime
+        // bases — so the subscript evaluates
+        let out = out_at(
+            indoc! {"
+                from collections import ChainMap
+                m = ChainMap({\"a\": 1})
+            "},
+            PythonVersion::PY312,
+        );
+        assert!(out.contains("ChainMap[str, int]("), "got: {out}");
     }
 
     #[test]

--- a/crates/by_transforms/src/type_info.rs
+++ b/crates/by_transforms/src/type_info.rs
@@ -234,6 +234,10 @@ pub(crate) trait TypeInfo {
     /// rather than a member of `x`. lowered to `fn(x)`
     fn is_implicit_receiver_attribute(&self, attribute: &ruff_python_ast::ExprAttribute) -> bool;
 
+    /// basedpython: the mangled name a `private` method is reached by in the
+    /// emitted python, for an attribute access that resolves to one
+    fn private_method_name(&self, attribute: &ruff_python_ast::ExprAttribute) -> Option<String>;
+
     /// how `name` resolves through the enclosing trailing lambda block's
     /// receiver: `self` is the receiver itself, any other name is a member of
     /// it used unqualified. both lower to the block's receiver parameter
@@ -610,6 +614,10 @@ impl TypeInfo for SemanticModel<'_> {
 
     fn constructor_specialization(&self, call: &ruff_python_ast::ExprCall) -> Option<String> {
         self.reified_constructor_type_arguments(call)
+    }
+
+    fn private_method_name(&self, attribute: &ruff_python_ast::ExprAttribute) -> Option<String> {
+        SemanticModel::private_method_name(self, attribute)
     }
 
     fn erased_union(&self, annotation: &Expr) -> Option<ty_python_semantic::ErasedUnion> {

--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E70_basedpython.by
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E70_basedpython.by
@@ -1,0 +1,16 @@
+"""`class` is also a member modifier, and the `:` after one belongs to the
+declaration's type rather than to a suite"""
+
+
+class Members:
+    class count = 0
+    class var total: int = 0
+    class var kind: str
+    class let ORIGIN: int = 0
+
+    class def make(cls) -> int:
+        return 0
+
+
+# a class definition written on one line is still reported
+class OneLiner: x = 1

--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF008_basedpython.by
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF008_basedpython.by
@@ -1,0 +1,23 @@
+# basedpython's `data class` lowers every re-evaluated default into a
+# `field(default_factory=...)` of its own, so neither a mutable default nor a
+# call in one is anything for the author to write by hand
+
+
+import uuid
+
+
+data class Fight:
+    var last_contact: int = 0
+    var seen: set[int] = set()
+    var tags: list[str] = []
+    var name: str = str(uuid.uuid4())
+
+
+frozen data class Frozen:
+    var seen: set[int] = set()
+
+
+# a plain class is not a dataclass, so neither rule looks at it — the shared
+# object it really does have is `RUF012`'s to report
+class Plain:
+    var seen: set[int] = set()

--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF009_basedpython.by
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF009_basedpython.by
@@ -1,0 +1,23 @@
+# basedpython's `data class` lowers every re-evaluated default into a
+# `field(default_factory=...)` of its own, so neither a mutable default nor a
+# call in one is anything for the author to write by hand
+
+
+import uuid
+
+
+data class Fight:
+    var last_contact: int = 0
+    var seen: set[int] = set()
+    var tags: list[str] = []
+    var name: str = str(uuid.uuid4())
+
+
+frozen data class Frozen:
+    var seen: set[int] = set()
+
+
+# a plain class is not a dataclass, so neither rule looks at it — the shared
+# object it really does have is `RUF012`'s to report
+class Plain:
+    var seen: set[int] = set()

--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF012_basedpython.by
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF012_basedpython.by
@@ -17,3 +17,11 @@ class Accessors:
 class Plain:
     var items: list[int] = []  # RUF012
     let names: list[str] = []  # RUF012
+
+
+# a `class` declaration *is* a `ClassVar`, which is what the rule asks for, and a
+# `class let` is the read-only one — neither is reported
+class ClassScoped:
+    class items = []
+    class var tags: list[str] = []
+    class let names: list[str] = []

--- a/crates/ruff_linter/src/rules/pycodestyle/mod.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/mod.rs
@@ -50,6 +50,10 @@ mod tests {
     #[test_case(Rule::ModuleImportNotAtTopOfFile, Path::new("E402.ipynb"))]
     #[test_case(Rule::MultipleImportsOnOneLine, Path::new("E40.py"))]
     #[test_case(Rule::MultipleStatementsOnOneLineColon, Path::new("E70.py"))]
+    #[test_case(
+        Rule::MultipleStatementsOnOneLineColon,
+        Path::new("E70_basedpython.by")
+    )]
     #[test_case(Rule::MultipleStatementsOnOneLineSemicolon, Path::new("E70.py"))]
     #[test_case(Rule::MissingNewlineAtEndOfFile, Path::new("W292_0.py"))]
     #[test_case(Rule::MissingNewlineAtEndOfFile, Path::new("W292_1.py"))]

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/compound_statements.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/compound_statements.rs
@@ -1,7 +1,7 @@
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_notebook::CellOffsets;
 use ruff_python_ast::PySourceType;
-use ruff_python_ast::token::{TokenIterWithContext, TokenKind, Tokens};
+use ruff_python_ast::token::{Token, TokenIterWithContext, TokenKind, Tokens};
 use ruff_python_index::Indexer;
 use ruff_text_size::{Ranged, TextSize};
 
@@ -299,7 +299,13 @@ pub(crate) fn compound_statements(
                 else_ = Some(token.range());
             }
             TokenKind::Class => {
-                class = Some(token.range());
+                // basedpython: `class` is also a member modifier — `class def
+                // f(cls)`, `class x = 1`, `class var x: T`. None of those opens
+                // a suite, so a `:` after one belongs to the declaration's type
+                // rather than to a compound statement
+                if !(source_type.is_basedpython() && at_class_modifier(&token_iter)) {
+                    class = Some(token.range());
+                }
             }
             TokenKind::With => {
                 with = Some(token.range());
@@ -309,6 +315,30 @@ pub(crate) fn compound_statements(
             }
             _ => {}
         }
+    }
+}
+
+/// basedpython: whether the tokens after a `class` make it a member modifier
+/// rather than a class definition.
+///
+/// `class def f(cls)` is a classmethod, and `class x = 1` / `class var x: T`
+/// declare a class variable. A class *definition* always has its name followed
+/// by one of `(`, `[` or `:`, so two names in a row — or a `def` — is the
+/// modifier.
+fn at_class_modifier(token_iter: &TokenIterWithContext<'_>) -> bool {
+    let mut rest = token_iter.clone().filter(|token| {
+        !matches!(
+            token.kind(),
+            TokenKind::Comment | TokenKind::NonLogicalNewline
+        )
+    });
+    match rest.next().map(Token::kind) {
+        Some(TokenKind::Def) => true,
+        Some(TokenKind::Name) => matches!(
+            rest.next().map(Token::kind),
+            Some(TokenKind::Equal | TokenKind::Name)
+        ),
+        _ => false,
     }
 }
 

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E701_E70_basedpython.by.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E701_E70_basedpython.by.snap
@@ -1,0 +1,9 @@
+---
+source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
+---
+E701 Multiple statements on one line (colon)
+  --> E70_basedpython.by:16:15
+   |
+15 | # a class definition written on one line is still reported
+16 | class OneLiner: x = 1
+   |               ^

--- a/crates/ruff_linter/src/rules/ruff/helpers.rs
+++ b/crates/ruff_linter/src/rules/ruff/helpers.rs
@@ -58,6 +58,16 @@ pub(super) fn is_dataclass_field(
 
 /// Returns `true` if the given [`Expr`] is a `typing.ClassVar` annotation.
 pub(super) fn is_class_var_annotation(annotation: &Expr, semantic: &SemanticModel) -> bool {
+    // basedpython: `class x = v` and `class var x: T = v` *are* class variables.
+    // The parser gives them a synthetic marker in annotation position, which is
+    // what the source wrote `ClassVar` with
+    if matches!(
+        map_subscript(annotation),
+        Expr::Name(name) if matches!(name.id.as_str(), "__classvar__" | "__classvar_annot__")
+    ) {
+        return true;
+    }
+
     if !semantic.seen_typing() {
         return false;
     }
@@ -69,6 +79,15 @@ pub(super) fn is_class_var_annotation(annotation: &Expr, semantic: &SemanticMode
 
 /// Returns `true` if the given [`Expr`] is a `typing.Final` annotation.
 pub(super) fn is_final_annotation(annotation: &Expr, semantic: &SemanticModel) -> bool {
+    // basedpython: `final x: T = v` and `class let x: T = v` lower to `Final`,
+    // and carry a synthetic marker in annotation position until they do
+    if matches!(
+        map_subscript(annotation),
+        Expr::Name(name) if name.id.as_str() == "__final__"
+    ) {
+        return true;
+    }
+
     if !semantic.seen_typing() {
         return false;
     }
@@ -109,6 +128,18 @@ pub(super) fn dataclass_kind<'a>(
     class_def: &'a ast::StmtClassDef,
     semantic: &SemanticModel,
 ) -> Option<(DataclassKind, &'a ast::Decorator)> {
+    // basedpython: `data class C:` and `frozen data class C:` carry the modifier
+    // as a synthetic decorator — a name the source never wrote, marked by
+    // `ExprContext::Invalid`. it lowers to `@dataclass`, so it is one for every
+    // rule's purposes, and the file need not import `dataclasses` to say so
+    if let Some(decorator) = class_def
+        .decorator_list
+        .iter()
+        .find(|decorator| is_synthetic_dataclass_modifier(decorator))
+    {
+        return Some((DataclassKind::Stdlib, decorator));
+    }
+
     if !(semantic.seen_module(Modules::DATACLASSES) || semantic.seen_module(Modules::ATTRS)) {
         return None;
     }
@@ -167,11 +198,46 @@ pub(super) fn dataclass_kind<'a>(
     None
 }
 
+/// basedpython: whether `class_def` is a `data class`, whose dataclass-ness
+/// comes from the modifier keyword rather than a decorator the source wrote.
+///
+/// The lowering moves every re-evaluated default into a
+/// `field(default_factory=…)` on its own, so the rules that ask a dataclass
+/// author to write that by hand have nothing to say about one.
+pub(super) fn is_basedpython_data_class(class_def: &ast::StmtClassDef) -> bool {
+    class_def
+        .decorator_list
+        .iter()
+        .any(is_synthetic_dataclass_modifier)
+}
+
+/// basedpython: whether `decorator` is the synthetic marker for a `data class`.
+///
+/// A modifier keyword parses as a decorator the source never wrote `@` for, and
+/// the expression it wraps carries [`ExprContext::Invalid`] to say the name is
+/// not a runtime reference. A real `@data_class` decorator is an ordinary one
+/// and must not be mistaken for the modifier.
+fn is_synthetic_dataclass_modifier(decorator: &ast::Decorator) -> bool {
+    matches!(
+        &decorator.expression,
+        Expr::Name(name)
+            if name.ctx.is_invalid()
+                && matches!(name.id.as_str(), "data_class" | "frozen_data_class")
+    )
+}
+
 /// Return true if dataclass (stdlib or `attrs`) is frozen
 pub(super) fn is_frozen_dataclass(
     dataclass_decorator: &ast::Decorator,
     semantic: &SemanticModel,
 ) -> bool {
+    if is_synthetic_dataclass_modifier(dataclass_decorator) {
+        return matches!(
+            &dataclass_decorator.expression,
+            Expr::Name(name) if name.id.as_str() == "frozen_data_class"
+        );
+    }
+
     let Some(qualified_name) =
         semantic.resolve_qualified_name(map_callable(&dataclass_decorator.expression))
     else {

--- a/crates/ruff_linter/src/rules/ruff/mod.rs
+++ b/crates/ruff_linter/src/rules/ruff/mod.rs
@@ -798,6 +798,11 @@ mod tests {
     #[test_case(Rule::FStringPercentFormat, Path::new("RUF073.py"))]
     // basedpython: a pattern clause is neither deleted nor reduced to its subject
     #[test_case(Rule::MutableClassDefault, Path::new("RUF012_basedpython.by"))]
+    #[test_case(Rule::MutableDataclassDefault, Path::new("RUF008_basedpython.by"))]
+    #[test_case(
+        Rule::FunctionCallInDataclassDefaultArgument,
+        Path::new("RUF009_basedpython.by")
+    )]
     #[test_case(Rule::UnnecessaryIf, Path::new("RUF050_basedpython.by"))]
     fn preview_rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!(

--- a/crates/ruff_linter/src/rules/ruff/rules/function_call_in_dataclass_default.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/function_call_in_dataclass_default.rs
@@ -11,8 +11,8 @@ use ruff_text_size::Ranged;
 use crate::Violation;
 use crate::checkers::ast::Checker;
 use crate::rules::ruff::helpers::{
-    AttrsAutoAttribs, DataclassKind, dataclass_kind, is_class_var_annotation, is_dataclass_field,
-    is_descriptor_class, is_frozen_dataclass,
+    AttrsAutoAttribs, DataclassKind, dataclass_kind, is_basedpython_data_class,
+    is_class_var_annotation, is_dataclass_field, is_descriptor_class, is_frozen_dataclass,
 };
 
 /// ## What it does
@@ -84,6 +84,12 @@ pub(crate) fn function_call_in_dataclass_default(
     scope_id: ScopeId,
 ) {
     let semantic = checker.semantic();
+
+    // basedpython's `data class` lowers a re-evaluated default into a
+    // `field(default_factory=…)` itself, so there is nothing here to ask for
+    if is_basedpython_data_class(class_def) {
+        return;
+    }
 
     let Some((dataclass_kind, _)) = dataclass_kind(class_def, semantic) else {
         return;

--- a/crates/ruff_linter/src/rules/ruff/rules/mutable_dataclass_default.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/mutable_dataclass_default.rs
@@ -7,7 +7,9 @@ use ruff_text_size::Ranged;
 use crate::Violation;
 use crate::checkers::ast::Checker;
 use crate::preview::is_mutable_default_in_dataclass_field_enabled;
-use crate::rules::ruff::helpers::{dataclass_kind, is_class_var_annotation, is_dataclass_field};
+use crate::rules::ruff::helpers::{
+    dataclass_kind, is_basedpython_data_class, is_class_var_annotation, is_dataclass_field,
+};
 
 /// ## What it does
 /// Checks for mutable default values in dataclass attributes.
@@ -73,6 +75,12 @@ impl Violation for MutableDataclassDefault {
 /// RUF008
 pub(crate) fn mutable_dataclass_default(checker: &Checker, class_def: &ast::StmtClassDef) {
     let semantic = checker.semantic();
+
+    // basedpython's `data class` lowers a re-evaluated default into a
+    // `field(default_factory=…)` itself, so there is nothing here to ask for
+    if is_basedpython_data_class(class_def) {
+        return;
+    }
 
     let Some((dataclass_kind, _)) = dataclass_kind(class_def, semantic) else {
         return;

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__RUF008_RUF008_basedpython.by.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__RUF008_RUF008_basedpython.by.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/ruff/mod.rs
+---
+

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__RUF009_RUF009_basedpython.by.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__RUF009_RUF009_basedpython.by.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/ruff/mod.rs
+---
+

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -1344,13 +1344,14 @@ pub fn if_let_keyword_range(
 /// basedpython: the synthetic markers a declaration modifier (`let`, `var`,
 /// `final`, `private`, `abstract`, a visibility keyword) wraps its annotation in.
 /// The declared type rides in the subscript slice.
-const DECLARATION_ANNOTATION_MARKERS: [&str; 6] = [
+const DECLARATION_ANNOTATION_MARKERS: [&str; 7] = [
     "__let__",
     "__final__",
     "__modifier_annot__",
     "__private_annot__",
     "__visibility_annot__",
     "__abstract_annot__",
+    "__classvar_annot__",
 ];
 
 /// basedpython: the *declared type* inside a declaration marker, if `annotation`

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -41,7 +41,13 @@ impl StmtFunctionDef {
             return None;
         }
         let decorator = self.decorator_list.first()?;
-        Some(match &decorator.expression {
+        // `await f(x):` hangs the block on the call — awaiting is what the
+        // caller does with what the call returns, not part of the call
+        let expression = match &decorator.expression {
+            Expr::Await(await_expr) => await_expr.value.as_ref(),
+            expression => expression,
+        };
+        Some(match expression {
             Expr::Call(call) if call.cast_kind.is_none() && !call.is_string_tag => &call.func,
             expression => expression,
         })

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/modifiers.by
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/modifiers.by
@@ -35,6 +35,15 @@ class F:
     let label: str = "x"
 
 
+# class-variable declarations: the inferred form, and the annotated `class var` /
+# `class let` whose keyword prefix has to survive the round trip
+class ClassVars:
+    class count = 0
+    class var total: int = 0
+    class var kind: str
+    class let ORIGIN: tuple[int, int] = (0, 0)
+
+
 # `final` annotations (Final in every scope), including a modifier chain where the
 # sibling modifier is stripped but `final` is kept
 final MODULE_CONST: int

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement_expression.by
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement_expression.by
@@ -24,3 +24,14 @@ def h(c: bool) -> int:
         1
     else:
         2
+
+
+# the loop escapes stand where a value is expected, like `raise` and `return`
+def escapes(rows: list[int | None]) -> int:
+    total = 0
+    for row in rows:
+        one = row ?? continue
+        two = row ?? break
+        three = row if row else break
+        total += one + two + three
+    return total

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/trailing_lambda.by
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/trailing_lambda.by
@@ -72,3 +72,14 @@ def returning():
 def returning_bare():
     return    f:  # end-of-line on the header
         print(it)
+
+
+# a block whose body awaits: the `await` on the header belongs to the call the
+# block hangs off, and the one in the suite belongs to the block itself
+async def scoped(name: str, once block: () -> Awaitable[None]): ...
+
+
+async def awaiting():
+    await scoped("db"):
+        await scoped("inner"):
+            pass

--- a/crates/ruff_python_formatter/src/statement/stmt_ann_assign.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_ann_assign.rs
@@ -116,7 +116,11 @@ fn synthetic_modifier_annot<'ast, 'src>(
     };
     if !matches!(
         name.id.as_str(),
-        "__abstract_annot__" | "__visibility_annot__" | "__private_annot__" | "__modifier_annot__"
+        "__abstract_annot__"
+            | "__visibility_annot__"
+            | "__private_annot__"
+            | "__modifier_annot__"
+            | "__classvar_annot__"
     ) {
         return None;
     }

--- a/crates/ruff_python_formatter/tests/snapshots/format@modifiers.by.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@modifiers.by.snap
@@ -41,6 +41,15 @@ class F:
     let label: str = "x"
 
 
+# class-variable declarations: the inferred form, and the annotated `class var` /
+# `class let` whose keyword prefix has to survive the round trip
+class ClassVars:
+    class count = 0
+    class var total: int = 0
+    class var kind: str
+    class let ORIGIN: tuple[int, int] = (0, 0)
+
+
 # `final` annotations (Final in every scope), including a modifier chain where the
 # sibling modifier is stripped but `final` is kept
 final MODULE_CONST: int
@@ -124,6 +133,15 @@ let name: str = "alice"
 class F:
     let member: int
     let label: str = "x"
+
+
+# class-variable declarations: the inferred form, and the annotated `class var` /
+# `class let` whose keyword prefix has to survive the round trip
+class ClassVars:
+    class count          = 0
+    class var total: int = 0
+    class var kind: str
+    class let ORIGIN: tuple[int, int] = (0, 0)
 
 
 # `final` annotations (Final in every scope), including a modifier chain where the

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement_expression.by.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement_expression.by.snap
@@ -30,6 +30,17 @@ def h(c: bool) -> int:
         1
     else:
         2
+
+
+# the loop escapes stand where a value is expected, like `raise` and `return`
+def escapes(rows: list[int | None]) -> int:
+    total = 0
+    for row in rows:
+        one = row ?? continue
+        two = row ?? break
+        three = row if row else break
+        total += one + two + three
+    return total
 ```
 
 ## Output
@@ -60,4 +71,15 @@ def h(c: bool) -> int:
         1
     else:
         2
+
+
+# the loop escapes stand where a value is expected, like `raise` and `return`
+def escapes(rows: list[int | None]) -> int:
+    total = 0
+    for row in rows:
+        one    = row ?? continue
+        two    = row ?? break
+        three  = row if row else break
+        total += one + two + three
+    return total
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@trailing_lambda.by.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@trailing_lambda.by.snap
@@ -78,6 +78,17 @@ def returning():
 def returning_bare():
     return    f:  # end-of-line on the header
         print(it)
+
+
+# a block whose body awaits: the `await` on the header belongs to the call the
+# block hangs off, and the one in the suite belongs to the block itself
+async def scoped(name: str, once block: () -> Awaitable[None]): ...
+
+
+async def awaiting():
+    await scoped("db"):
+        await scoped("inner"):
+            pass
 ```
 
 ## Output
@@ -156,4 +167,15 @@ def returning():
 def returning_bare():
     return f:  # end-of-line on the header
         print(it)
+
+
+# a block whose body awaits: the `await` on the header belongs to the call the
+# block hangs off, and the one in the suite belongs to the block itself
+async def scoped(name: str, once block: () -> Awaitable[None]): ...
+
+
+async def awaiting():
+    await scoped("db"):
+        await scoped("inner"):
+            pass
 ```

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -126,7 +126,13 @@ const END_SEQUENCE_SET: TokenSet = END_EXPR_SET.remove(TokenKind::Comma);
 pub(super) const fn starts_statement_expression(kind: TokenKind) -> bool {
     matches!(
         kind,
-        TokenKind::If | TokenKind::For | TokenKind::While | TokenKind::Raise | TokenKind::Return
+        TokenKind::If
+            | TokenKind::For
+            | TokenKind::While
+            | TokenKind::Raise
+            | TokenKind::Return
+            | TokenKind::Break
+            | TokenKind::Continue
     )
 }
 
@@ -1175,6 +1181,8 @@ impl<'src> Parser<'src> {
             | TokenKind::While
             | TokenKind::Raise
             | TokenKind::Return
+            | TokenKind::Break
+            | TokenKind::Continue
             | TokenKind::Match
                 if self.options.is_basedpython =>
             {

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -448,7 +448,11 @@ fn property_decl_type(annotation: &Expr) -> Option<Expr> {
         && let Expr::Name(marker) = subscript.value.as_ref()
         && matches!(
             marker.id.as_str(),
-            "__let__" | "__modifier_annot__" | "__private_annot__" | "__final__"
+            "__let__"
+                | "__modifier_annot__"
+                | "__private_annot__"
+                | "__final__"
+                | "__classvar_annot__"
         )
     {
         return Some((*subscript.slice).clone());
@@ -577,28 +581,32 @@ impl<'src> Parser<'src> {
                     return self.parse_with_modifier(start, DecoratorList::new());
                 }
                 // `class a = 1` — class variable declaration
-                if self.peek() == TokenKind::Name && self.peek2().1 == TokenKind::Equal {
+                if declares_a_name(self.peek()) && self.peek2().1 == TokenKind::Equal {
                     return self.parse_class_var_decl(start);
                 }
-                // `class let x: T` / `class var x: T` — reads as a class-level
-                // declaration by analogy with `class def`, but the modifier for
-                // that is `static`. otherwise it parses as a nested class named
-                // `let`, whose cascade of errors says nothing about the real
-                // mistake. report it, then carry on from the binding keyword so
-                // the declaration it meant is what gets parsed
-                if self.peek() == TokenKind::Name && self.peek2().1 == TokenKind::Name {
+                // `class var x: T` / `class let x: T` — the annotated class
+                // variable, the declared-type counterpart of `class x = 1`.
+                // `class` is unambiguous here: a class definition always follows
+                // its name with `(`, `[` or `:`, so a binding keyword and a name
+                // is the declaration
+                if self.peek() == TokenKind::Name && declares_a_name(self.peek2().1) {
                     let keyword_range = self.peek_nth(0).1;
                     let keyword = self.src_text(keyword_range).to_owned();
                     if matches!(keyword.as_str(), "let" | "var") {
-                        self.add_error(
-                            ParseErrorType::OtherError(format!(
-                                "`class {keyword}` is not a declaration; write `static {keyword}`"
-                            )),
-                            TextRange::new(start, keyword_range.end()),
-                        );
-                        self.bump(TokenKind::Class);
-                        return self.parse_statement();
+                        return self.parse_class_var_annot_decl(start, &keyword);
                     }
+                    // a class definition always follows its name with `(`, `[` or
+                    // `:`, so two names is a declaration whose binding keyword is
+                    // not one. say so rather than read `class private var x` as a
+                    // class named `private` with a one-line body
+                    let name_end = self.peek_nth(1).1.end();
+                    self.add_error(
+                        ParseErrorType::OtherError(format!(
+                            "`{keyword}` is not a binding keyword — a class variable \
+                             is `class let` or `class var`"
+                        )),
+                        TextRange::new(start, name_end),
+                    );
                 }
                 Stmt::ClassDef(self.parse_class_definition(DecoratorList::new(), start))
             }
@@ -1127,6 +1135,21 @@ impl<'src> Parser<'src> {
                 if matches!(self.peek(), TokenKind::Def | TokenKind::Async) {
                     continue;
                 }
+                // `class var x: T` declares a class *variable*, which is not a
+                // definition a modifier chain can hang off — and it carries one
+                // marker, which its own keyword already fills. left alone it
+                // parses on as a nested class named by the binding keyword
+                let binding = self.peek_nth(0).1;
+                let (named, name_range) = self.peek_nth(1);
+                if matches!(self.src_text(binding), "let" | "var") && declares_a_name(named) {
+                    self.add_error(
+                        ParseErrorType::OtherError(
+                            "a `class` variable declaration takes no modifier — write it on its own"
+                                .to_string(),
+                        ),
+                        TextRange::new(start, name_range.end()),
+                    );
+                }
                 break;
             }
             // another modifier keyword follows — keep looping. an `enum class` /
@@ -1255,6 +1278,68 @@ impl<'src> Parser<'src> {
     fn parse_declaration_value(&mut self) -> Expr {
         let value = self.parse_expression_list(ExpressionContext::yield_or_starred_bitwise_or());
         self.parse_trailing_lambda_value(value).expr
+    }
+
+    /// basedpython: parses `class var x: T [= v]` and `class let x: T [= v]` —
+    /// the class variable whose type is declared rather than inferred from a
+    /// value, which `class x = 1` cannot express.
+    ///
+    /// A `var` is an ordinary `ClassVar`; a `let` is read-only, which python
+    /// spells `Final` in a class body. A read-only one written without a value
+    /// has nowhere to be bound — `__init__` binds an instance — which is what
+    /// ty's `final-without-value` says, in the one place that knows a stub
+    /// declares types and never values.
+    fn parse_class_var_annot_decl(&mut self, start: TextSize, keyword: &str) -> Stmt {
+        self.error_if_not_basedpython(
+            "a `class` variable declaration is not valid in .py files".to_string(),
+        );
+        self.bump(TokenKind::Class);
+        // the declaration carries one marker, and `class var` already fills it.
+        // another modifier in the chain would take the slot and the declaration
+        // would silently stop being a class variable — reject it instead. the
+        // name is the only thing that may follow the binding keyword, so a token
+        // other than the `:` after it is a keyword that has nowhere to go
+        if self.peek2().1 != TokenKind::Colon {
+            let extra = self.peek_nth(0).1;
+            self.add_error(
+                ParseErrorType::OtherError(format!(
+                    "`class {keyword}` takes no other modifier — `{}` has nowhere to go",
+                    self.src_text(extra)
+                )),
+                TextRange::new(start, extra.end()),
+            );
+        }
+        let marker = if keyword == "let" {
+            "__final__"
+        } else {
+            "__classvar_annot__"
+        };
+        let stmt = self.parse_modifier_annot_decl(start, marker);
+
+        // an accessor block turns the declaration into a property, which is a
+        // member of the *instance* — `class` is the class-variable modifier, and
+        // the class-level property is `static`. carry on into the block anyway,
+        // so the accessors are parsed rather than cascading
+        if self.class_body_depth > 0 && self.at(TokenKind::Indent) && self.at_accessor_block_start()
+        {
+            self.add_error(
+                ParseErrorType::OtherError(format!(
+                    "`class {keyword}` is not a property declaration; write `static {keyword}`"
+                )),
+                stmt.range(),
+            );
+            return self.parse_property_accessors(stmt, start);
+        }
+
+        if self.class_body_depth == 0 {
+            self.add_error(
+                ParseErrorType::OtherError(format!(
+                    "`class {keyword}` declares a class variable, so it belongs in a class body"
+                )),
+                stmt.range(),
+            );
+        }
+        stmt
     }
 
     /// basedpython: consumes the `;` / newline that ends a declaration form.
@@ -1555,7 +1640,6 @@ impl<'src> Parser<'src> {
     /// position. The downstream transform deletes that prefix from the source
     /// text, leaving `name: T [= v]` behind.
     fn parse_modifier_annot_decl(&mut self, start: TextSize, synthetic_id: &'static str) -> Stmt {
-        let modifier_range = self.current_token_range();
         // consume modifier keywords until we reach the variable name (the Name
         // token immediately followed by `:`), so chains like `final override x: T`
         // strip in full — not just the first modifier. remember a `final` and a
@@ -1597,8 +1681,10 @@ impl<'src> Parser<'src> {
         // `override x: T = v` declare nothing and read as `x = v`.
         // `final` wins over `private`: a `Final` member is read-only, so it can
         // neither be written through a widened view nor lose its qualifier here
-        let marker_range = final_range
-            .unwrap_or_else(|| TextRange::new(modifier_range.start(), name.range.start()));
+        // the marker spans the whole keyword prefix from the statement's start,
+        // which for `class var x: T` is the `class` — the formatter re-emits the
+        // prefix from this range, so anything left out of it is dropped
+        let marker_range = final_range.unwrap_or_else(|| TextRange::new(start, name.range.start()));
         let marker = Expr::Name(ast::ExprName {
             id: Name::new_static(match (final_range.is_some(), is_private) {
                 (true, _) => "__final__",
@@ -2235,7 +2321,10 @@ impl<'src> Parser<'src> {
             let expr_ref: &Expr = statement.0;
             let in_tail = allowed.iter().any(|a| std::ptr::eq(*a, expr_ref));
             let is_root = tail.is_some_and(|tail| std::ptr::eq(tail, expr_ref));
-            let carries_suite = !matches!(&*statement.1.stmt, Stmt::Raise(_) | Stmt::Return(_));
+            let carries_suite = !matches!(
+                &*statement.1.stmt,
+                Stmt::Raise(_) | Stmt::Return(_) | Stmt::Break(_) | Stmt::Continue(_)
+            );
             let message = if carries_suite && !is_root {
                 "a statement expression with a suite must be the whole value of its statement"
             } else if carries_suite && !self.starts_its_line(stmt.range().start()) {
@@ -3192,6 +3281,10 @@ impl<'src> Parser<'src> {
             TokenKind::While => (Stmt::While(self.parse_while_statement()), true),
             TokenKind::Raise => (Stmt::Raise(self.parse_raise_statement()), false),
             TokenKind::Return => (Stmt::Return(self.parse_return_statement()), false),
+            // the loop escapes: `let first = next(it) ?? break` leaves the loop
+            // when the call has no value to bind
+            TokenKind::Break => (Stmt::Break(self.parse_break_statement()), false),
+            TokenKind::Continue => (Stmt::Continue(self.parse_continue_statement()), false),
             // `parse_atom` only enters here at one of the tokens above; `match` is
             // the only one that can turn out not to start a statement expression
             _ => return None,
@@ -5861,9 +5954,9 @@ impl<'src> Parser<'src> {
             },
             type_params: None,
             parameters: Box::new(parameters),
+            is_async: body_awaits(&body),
             body,
             decorator_list: vec![decorator].into(),
-            is_async: false,
             returns: None,
             raises: None,
             is_trailing_lambda: true,
@@ -8668,6 +8761,92 @@ enum AllowStarAnnotation {
     /// basedpython: `**kwargs: *Kwargs` unpacks a keyword-variadic pack into this parameter,
     /// mirroring how `*args: *Ts` unpacks a `TypeVarTuple`. Rejected in `.py` files
     KeywordPackOnly,
+}
+
+/// basedpython: whether `body` needs `await` to run — the block it belongs to is
+/// then an async one, and the callee it is handed to has to await the call.
+///
+/// A trailing lambda block is a function of its own, so `await` in it is a
+/// statement about *it* rather than about the `def` it was written inside. Only
+/// the block's own statements are looked at: a nested `def` or `lambda` is a
+/// separate function and its `await` is its own business.
+fn body_awaits(body: &[Stmt]) -> bool {
+    struct Finder {
+        found: bool,
+    }
+
+    impl<'a> ruff_python_ast::visitor::Visitor<'a> for Finder {
+        fn visit_stmt(&mut self, stmt: &'a Stmt) {
+            match stmt {
+                // a nested definition's *body* is its own scope; its header runs
+                // here — decorators (a nested block's callee among them),
+                // parameter defaults and annotations, the return annotation, the
+                // type-parameter bounds, and a class's bases
+                Stmt::FunctionDef(function) => {
+                    for decorator in &function.decorator_list {
+                        self.visit_expr(&decorator.expression);
+                    }
+                    if let Some(type_params) = &function.type_params {
+                        self.visit_type_params(type_params);
+                    }
+                    self.visit_parameters(&function.parameters);
+                    if let Some(returns) = &function.returns {
+                        self.visit_annotation(returns);
+                    }
+                }
+                Stmt::ClassDef(class) => {
+                    for decorator in &class.decorator_list {
+                        self.visit_expr(&decorator.expression);
+                    }
+                    if let Some(type_params) = &class.type_params {
+                        self.visit_type_params(type_params);
+                    }
+                    if let Some(arguments) = &class.arguments {
+                        self.visit_arguments(arguments);
+                    }
+                }
+                Stmt::For(ast::StmtFor { is_async: true, .. })
+                | Stmt::With(ast::StmtWith { is_async: true, .. }) => self.found = true,
+                _ if !self.found => ruff_python_ast::visitor::walk_stmt(self, stmt),
+                _ => {}
+            }
+        }
+
+        fn visit_expr(&mut self, expr: &'a Expr) {
+            match expr {
+                // a lambda's body is its own scope; its parameter defaults are
+                // evaluated where the lambda is written
+                Expr::Lambda(lambda) => {
+                    if let Some(parameters) = &lambda.parameters {
+                        self.visit_parameters(parameters);
+                    }
+                }
+                Expr::Await(_) => self.found = true,
+                // a comprehension's `async for` is an await of its own, and it
+                // has no statement to carry the flag
+                Expr::ListComp(ast::ExprListComp { generators, .. })
+                | Expr::SetComp(ast::ExprSetComp { generators, .. })
+                | Expr::Generator(ast::ExprGenerator { generators, .. })
+                    if generators.iter().any(|generator| generator.is_async) =>
+                {
+                    self.found = true;
+                }
+                Expr::DictComp(ast::ExprDictComp { generators, .. })
+                    if generators.iter().any(|generator| generator.is_async) =>
+                {
+                    self.found = true;
+                }
+                _ if !self.found => ruff_python_ast::visitor::walk_expr(self, expr),
+                _ => {}
+            }
+        }
+    }
+
+    let mut finder = Finder { found: false };
+    for stmt in body {
+        ruff_python_ast::visitor::Visitor::visit_stmt(&mut finder, stmt);
+    }
+    finder.found
 }
 
 /// basedpython: collects the expressions that hold the value of `expr` — `expr`

--- a/crates/ty/src/by_commands.rs
+++ b/crates/ty/src/by_commands.rs
@@ -276,11 +276,16 @@ pub(crate) fn cmd_run(
         }
     }
 
+    // the program runs where the user invoked it, the way `python -m` does: a
+    // relative path on its command line, and anything it reads or writes beside
+    // the project, resolve against the directory they were written for. python
+    // puts the runner's own directory — the generated tree — at the head of
+    // `sys.path`, so the module is still found there
     let status = Command::new(&python)
-        .arg(BY_RUNNER_FILENAME)
+        .arg(tmp.path().join(BY_RUNNER_FILENAME))
         .arg(&module)
         .args(args)
-        .current_dir(tmp.path())
+        .current_dir(&cwd)
         .status()
         .with_context(|| {
             format!(
@@ -853,7 +858,7 @@ pub(crate) fn cmd_build(
     // is what the digests beside the map are for
     let mut entries: Vec<TracebackEntry> = Vec::new();
     let mut requirements = by_transforms::RuntimeRequirements::default();
-    if !render_check_and_transpile(
+    let ok = render_check_and_transpile(
         &db,
         &handles,
         &config,
@@ -871,10 +876,10 @@ pub(crate) fn cmd_build(
             entries.push(entry);
             Ok(())
         },
-    )? {
-        return Ok(ExitStatus::Failure);
-    }
-
+    );
+    // the sourcemap and the package markers describe the tree that was written,
+    // so they are staged whether or not something was reported — an `out/` a
+    // debugger cannot read is worse than one built from a partial check
     stage_verbatim(&db, &root, &roots, &mut staging)?;
     stage_by_typed_markers(&db, &mut staging, &roots, &root)?;
     write_sourcemap_module(&mut staging, &entries)?;
@@ -883,6 +888,9 @@ pub(crate) fn cmd_build(
     }
     staging.finish()?;
 
+    if !ok? {
+        return Ok(ExitStatus::Failure);
+    }
     eprintln!("\nbuild complete ({file_count} files)");
     Ok(ExitStatus::Success)
 }
@@ -968,7 +976,11 @@ pub(crate) fn cmd_compile(
         return Ok(ExitStatus::Success);
     }
 
-    let python = std::env::var("PYTHON").unwrap_or_else(|_| "python3".to_string());
+    // the same interpreter `by run` picks, resolved the same way: an extension
+    // built against one abi is unimportable by another, and `by run --compiled`
+    // imports what this wrote
+    let project = ResolvedProject::discover(&cwd)?;
+    let python = discover_interpreter(None, &project)?.path;
     // see the note on the other `probe` call: its own errors are self-describing, and the
     // context that used to sit here misreported a version refusal as a missing header
     let toolchain = by_build::Toolchain::probe(&python)?;
@@ -2021,7 +2033,15 @@ fn render_check_and_transpile(
     if !all_diagnostics.is_empty() {
         render_diagnostics(db, &all_diagnostics)?;
     }
-    Ok(ok)
+    // artifacts and exit status answer different questions. the artifacts are
+    // emitted for everything that could be emitted, so a file mid-edit does not
+    // take the rest of the build down; the status says whether anything was
+    // reported, which is what a `&&` in a script reads. a command that prints
+    // `error[...]` and then succeeds is one nothing can be chained onto
+    let reported_an_error = all_diagnostics
+        .iter()
+        .any(|d| d.severity() >= Severity::Error);
+    Ok(ok && !reported_an_error)
 }
 
 /// Whether this diagnostic says the file has no source to transpile: it could

--- a/crates/ty_ide/src/semantic_tokens.rs
+++ b/crates/ty_ide/src/semantic_tokens.rs
@@ -6946,6 +6946,70 @@ final c: str = \"x\"
     }
 
     #[test]
+    fn semantic_tokens_class_variable_keywords() {
+        // `class var x: T` / `class let x: T` declare through the same marker,
+        // whose range spans the whole keyword prefix — the `class` included
+        let test = SemanticTokenTest::new_by(
+            "
+class A:
+    class count = 0
+    class var total: int = 0
+    class let ORIGIN: int = 0
+",
+        );
+
+        let tokens = test.highlight_file();
+
+        assert_snapshot!(test.to_snapshot(&tokens), @r#"
+        "A" @ 7..8: Class [definition]
+        "class" @ 14..19: Keyword
+        "count" @ 20..25: Variable [definition]
+        "0" @ 28..29: Number
+        "class var" @ 34..43: Keyword
+        "total" @ 44..49: Variable [definition]
+        "int" @ 51..54: Class
+        "0" @ 57..58: Number
+        "class let" @ 63..72: Keyword
+        "ORIGIN" @ 73..79: Variable [definition, readonly]
+        "int" @ 81..84: Class
+        "0" @ 87..88: Number
+        "#);
+    }
+
+    #[test]
+    fn semantic_tokens_loop_escape_statement_expression() {
+        // `break` and `continue` stand where a value is expected, and highlight
+        // as the keywords they are
+        let test = SemanticTokenTest::new_by(
+            "
+def f(rows: list[int]) -> None:
+    for row in rows:
+        one = row ?? continue
+        two = row ?? break
+",
+        );
+
+        let tokens = test.highlight_file();
+
+        // the escapes are hard keywords, which the editor's own grammar colours;
+        // what matters here is that standing in a value position does not make
+        // the visitor read one as a name
+        assert_snapshot!(test.to_snapshot(&tokens), @r#"
+        "f" @ 5..6: Function [definition]
+        "rows" @ 7..11: Parameter [definition]
+        "list" @ 13..17: Class
+        "int" @ 18..21: Class
+        "None" @ 27..31: BuiltinConstant
+        "row" @ 41..44: Variable [definition]
+        "rows" @ 48..52: Parameter
+        "one" @ 62..65: Variable [definition]
+        "row" @ 68..71: Variable
+        "two" @ 92..95: Variable [definition]
+        "row" @ 98..101: Variable
+        "#);
+    }
+
+    #[test]
     fn semantic_tokens_var_keyword() {
         // `var` declares through the modifier markers — untyped through the bare
         // one, typed through the subscripted one — so both forms highlight

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -4610,6 +4610,61 @@ f = Foo()
 f.count = 1  # error: [invalid-attribute-access]
 ```
 
+### `class var` declares the type instead of inferring it
+
+`class a = v` reads its type off `v`, which a stub has no way to supply. `class var a: T` declares
+it, with or without a value.
+
+```by
+class Foo:
+    class var count: int = 0
+    class var kind: str
+
+reveal_type(Foo.count)  # revealed: int
+reveal_type(Foo.kind)  # revealed: str
+
+f = Foo()
+f.count = 1  # error: [invalid-attribute-access]
+```
+
+### `class let` is the read-only one
+
+Python spells a read-only class attribute `Final`, which can be reassigned neither through the class
+nor through an instance.
+
+```by
+class Origin:
+    pass
+
+class Foo:
+    class let ORIGIN: Origin = Origin()
+
+reveal_type(Foo.ORIGIN)  # revealed: Origin
+
+Foo.ORIGIN = Origin()  # error: [invalid-assignment]
+Foo().ORIGIN = Origin()  # error: [invalid-assignment]
+```
+
+### `class let` needs a value
+
+`__init__` binds an instance, so a read-only class attribute has no later place for a value to
+arrive. A stub is the exception — it states types and never values — and `final-without-value`
+already draws that line.
+
+```by
+class Foo:
+    # error: [final-without-value]
+    class let ORIGIN: int
+```
+
+### `class` is a class-body modifier
+
+```by
+# error: [invalid-syntax] "`class var` declares a class variable, so it belongs in a class body"
+# error: [invalid-type-form]
+class var top: int = 1
+```
+
 [descriptor protocol tests]: descriptor_protocol.md
 [pyright's documentation]: https://microsoft.github.io/pyright/#/type-concepts-advanced?id=class-and-instance-variables
 [typing spec on `classvar`]: https://typing.python.org/en/latest/spec/class-compat.html#classvar

--- a/crates/ty_python_semantic/resources/mdtest/basedpython_optional_type.md
+++ b/crates/ty_python_semantic/resources/mdtest/basedpython_optional_type.md
@@ -93,6 +93,26 @@ def bad[T](t: T) -> T?:
     return t  # error: [invalid-return-type]
 ```
 
+## `Self?` is a plain union
+
+`Self` stands for the enclosing class, which can never itself be an optional, so there is no inner
+layer for the wrapper to keep apart: a fallible constructor returns its instance as it built it.
+
+```by
+class Record:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    class def parse(cls, line: str) -> Self?:
+        if not line:
+            return None
+        return cls(line)
+
+def f() -> None:
+    record = Record.parse("a")
+    reveal_type(record)  # revealed: Record | None
+```
+
 ## wrapped optionals are covariant in their inner type
 
 a narrower wrapped optional is assignable to a wider one (`Literal[1]` wrapped, to `int??` — see `x`

--- a/crates/ty_python_semantic/resources/mdtest/basedpython_properties.md
+++ b/crates/ty_python_semantic/resources/mdtest/basedpython_properties.md
@@ -476,13 +476,14 @@ class B:
         get() = 1
 ```
 
-## `class let` is not the spelling
+## `class let` is not the spelling for a property
 
-the modifier is `static`, matching `static def`.
+`class` declares a class *variable*; the class-level property modifier is `static`, matching
+`static def`.
 
 ```by
 class C:
-    # error: [invalid-syntax] "`class let` is not a declaration; write `static let`"
+    # error: [invalid-syntax] "`class let` is not a property declaration; write `static let`"
     class let size: int
         get() = 1
 ```

--- a/crates/ty_python_semantic/resources/mdtest/basedpython_statement_expressions.md
+++ b/crates/ty_python_semantic/resources/mdtest/basedpython_statement_expressions.md
@@ -263,6 +263,45 @@ def f(x: int | None) -> int:
     return a
 ```
 
+## `continue` is an expression of type `Never`
+
+A loop escape written where a value is expected leaves the loop when the value is missing, so what
+the binding takes on is the type that survives the escape.
+
+```by
+def f(items: list[int | None]) -> int:
+    total = 0
+    for item in items:
+        one = item ?? continue
+        reveal_type(one)  # revealed: int
+        total += one
+    return total
+```
+
+## `break` is an expression of type `Never`
+
+```by
+def f(items: list[int | None]) -> int:
+    total = 0
+    for item in items:
+        one = item ?? break
+        reveal_type(one)  # revealed: int
+        total += one
+    return total
+```
+
+## a loop escape is diverging, so it needs no `else` to be exhaustive
+
+`break` and `continue` produce no value, so a statement expression whose every branch is one of them
+is `Never` rather than a value that went missing.
+
+```by
+def f(items: list[int]) -> None:
+    for item in items:
+        a = continue if item > 0 else break
+        reveal_type(a)  # revealed: Never
+```
+
 ## a statement expression is not a type expression
 
 ```by

--- a/crates/ty_python_semantic/resources/mdtest/basedpython_trailing_lambda.md
+++ b/crates/ty_python_semantic/resources/mdtest/basedpython_trailing_lambda.md
@@ -642,6 +642,38 @@ anything:
     print("a callable is an object")
 ```
 
+## a block whose body awaits is a coroutine function
+
+The block is a function of its own, so `await` in it is a statement about the block. The callback it
+fills is declared to return an awaitable, and the call the block hangs off is awaited by the caller.
+
+```by
+async def query(sql: str) -> int:
+    return 1
+
+async def scope(name: str, once block: () -> Awaitable[None]):
+    await block()
+
+async def main() -> None:
+    await scope("db"):
+        await query("select 1")
+```
+
+## a callback declared to return `None` cannot hold an async block
+
+```by
+def hold(once block: () -> None):
+    block()
+
+async def read() -> int:
+    return 1
+
+async def main() -> None:
+    # error: [trailing-lambda-return-type]
+    hold():
+        await read()
+```
+
 ## not valid in `.py` files
 
 The shape parses exactly as it does in upstream python — an annotated assignment missing its

--- a/crates/ty_python_semantic/resources/mdtest/conditions.md
+++ b/crates/ty_python_semantic/resources/mdtest/conditions.md
@@ -209,6 +209,46 @@ def f(h: Holder, d: dict[str, bool | None]):
     if not d["k"]: ...
 ```
 
+## an attribute narrowed by an earlier test is not decided
+
+A call between the narrowing and the read may have written to the attribute, and holding the
+narrowed type across it is what makes attribute narrowing usable. What the class declares is the
+fact, so that is what decides the condition.
+
+```py
+class Latch:
+    on: bool
+
+    def flip(self) -> None:
+        self.on = True
+
+def f(latch: Latch) -> None:
+    latch.on = False
+    latch.flip()
+    if latch.on: ...
+```
+
+## an attribute a property reads is not decided either
+
+The property reads the attribute the call wrote, so the same reasoning reaches through it.
+
+```py
+class Machine:
+    running: bool
+
+    @property
+    def alive(self) -> bool:
+        return self.running
+
+    def tick(self) -> None:
+        self.running = False
+
+def f(machine: Machine) -> None:
+    while machine.alive:
+        machine.tick()
+        if not machine.alive: ...
+```
+
 ## a protocol instance is an instance
 
 ```toml

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -88,6 +88,27 @@ impl<'db> SemanticModel<'db> {
         self.file().path(self.db)
     }
 
+    /// basedpython: the name a `private` method is reached by in the emitted
+    /// python, for an attribute access that resolves to one.
+    ///
+    /// The definition is lowered to `__helper`, which python name-mangles to
+    /// `_A__helper` in class `A`'s body. A call site must reach the same
+    /// attribute, and python's mangling is lexical — it would spell `__helper`
+    /// as `_B__helper` in a subclass's body, and leave it alone outside a class
+    /// altogether — so the mangled name is written out in full instead, which
+    /// reads the same from everywhere.
+    ///
+    /// `None` when the attribute is not a private method.
+    pub fn private_method_name(&self, attribute: &ast::ExprAttribute) -> Option<String> {
+        crate::types::visibility::private_method_name(
+            self.db,
+            &self.program_environment(),
+            attribute.value.inferred_type(self)?,
+            attribute.inferred_type(self)?,
+            attribute.attr.as_str(),
+        )
+    }
+
     /// basedpython: the source text of the specialization step the transpiler
     /// splices in after the callee of a bare reified-generic call (`f(1)` →
     /// `"[int]"`). `None` when the call is not a bare reified-generic call or
@@ -199,6 +220,43 @@ impl<'db> SemanticModel<'db> {
     pub fn eagerly_imported_modules(&self) -> Vec<String> {
         let db = self.db;
         crate::types::conformance::eagerly_imported_modules(self.db, self.file.file(db))
+    }
+
+    /// basedpython: the names this file imports that must be bound to the real
+    /// object rather than to a lazy proxy — the exception classes.
+    ///
+    /// `except` is the one place cpython refuses a stand-in: it checks that what
+    /// it catches is a class inheriting `BaseException`, and never consults
+    /// `__instancecheck__`. A proxy there raises `TypeError` from the handler —
+    /// the line least likely to be covered by a happy-path test — so an
+    /// exception class is imported eagerly and the proxy never stands where it
+    /// cannot work.
+    pub fn eagerly_imported_names(&self) -> Vec<String> {
+        let db = self.db;
+        let env = self.program_environment();
+        let module = parsed_module(db, self.file.python_file(db)).load(db);
+        let mut names = Vec::new();
+        let mut collect = |import: &ast::StmtImportFrom| {
+            for alias in &import.names {
+                let Some(Type::ClassLiteral(class)) = alias.inferred_type(self) else {
+                    continue;
+                };
+                if Type::instance(db, &env, class.default_specialization(db)).is_assignable_to(
+                    db,
+                    &env,
+                    crate::types::KnownClass::BaseException.to_instance(db, &env),
+                ) {
+                    let bound = alias.asname.as_ref().unwrap_or(&alias.name);
+                    names.push(bound.id.to_string());
+                }
+            }
+        };
+        for statement in module.suite() {
+            if let ast::Stmt::ImportFrom(import) = statement {
+                collect(import);
+            }
+        }
+        names
     }
 
     /// basedpython: when an attribute access reads a *requirement* off an

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1578,6 +1578,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return;
         };
         let expression = &decorator.expression;
+        // `await f(x):` hangs the block on the call — awaiting is what the caller
+        // does with what the call returns
+        let awaited = match expression {
+            ast::Expr::Await(await_expr) => Some(await_expr.value.as_ref()),
+            _ => None,
+        };
+        let called = awaited.unwrap_or(expression);
 
         // the callee is a standalone expression (see the semantic index
         // builder), so the lambda's `it` parameter inference shares this
@@ -1585,7 +1592,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let callee_ty = self.infer_standalone_expression(signature_callee, TypeContext::default());
 
         let mut items: Vec<(Argument<'_>, Option<Type<'db>>)> = Vec::new();
-        let marker_call = match expression {
+        let marker_call = match called {
             ast::Expr::Call(call) if std::ptr::eq(signature_callee, call.func.as_ref()) => {
                 Some(call)
             }
@@ -1639,8 +1646,20 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         };
         if marker_call.is_some() {
-            self.store_expression_type(expression, return_ty);
+            self.store_expression_type(called, return_ty);
         }
+        // the `await` reads through the call's result, and it is the awaited type
+        // that the statement — and anything reading the block's value — sees
+        let return_ty = if awaited.is_some() {
+            let awaited_ty = return_ty.try_await(self.db(), env).unwrap_or_else(|err| {
+                err.report_diagnostic(&self.context, return_ty, called.into());
+                Type::unknown()
+            });
+            self.store_expression_type(expression, awaited_ty);
+            awaited_ty
+        } else {
+            return_ty
+        };
         // a block written as a statement's value takes this as its type; the bare
         // callee form has no call node of its own to read it back from
         self.trailing_lambda_return = Some(return_ty);
@@ -9933,9 +9952,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         self.infer_statement(&statement.stmt);
 
-        // `raise` and `return` never complete, so they have no value position to
-        // bind and are not subject to the exhaustiveness check
-        if matches!(&*statement.stmt, ast::Stmt::Raise(_) | ast::Stmt::Return(_)) {
+        // `raise`, `return`, `break` and `continue` never complete, so they have
+        // no value position to bind and are not subject to the exhaustiveness
+        // check
+        if matches!(
+            &*statement.stmt,
+            ast::Stmt::Raise(_)
+                | ast::Stmt::Return(_)
+                | ast::Stmt::Break(_)
+                | ast::Stmt::Continue(_)
+        ) {
             return Type::Never;
         }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/annotation_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/annotation_expression.rs
@@ -182,7 +182,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         // `[modifiers] a = v`, `newtype X = T`, `abstract a: T`, `private a: T`,
         // `sentinel A` parse to AnnAssign with a synthetic Name/Subscript annotation
         // whose id is one of `__let__`, `__final__`, `__classvar__`, `__context__`,
-        // `__modifier_assign__`, `__modifier_annot__`, `__newtype__`,
+        // `__modifier_assign__`, `__modifier_annot__`, `__classvar_annot__`, `__newtype__`,
         // `__abstract_annot__`, `__private_annot__`, `__sentinel__`.
         // resolve them so ty applies the right qualifier without a transpile step
         // basedpython use-site type modifiers (`literal T`, `final T`) are type
@@ -492,6 +492,15 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     // modifiers ty places no meaning on (`override x: T`,
                     // `abstract x: T`, `private x: T`), and typed `context x: T = v`:
                     // the declaration is just `x: T`
+                    // `class var x: T` — a class variable whose type is
+                    // declared rather than read off a value
+                    "__classvar_annot__" => {
+                        return Some(TypeAndQualifiers::new(
+                            self.infer_type_expression(slice),
+                            TypeOrigin::Declared,
+                            TypeQualifiers::CLASS_VAR,
+                        ));
+                    }
                     "__modifier_annot__"
                     | "__abstract_annot__"
                     | "__visibility_annot__"

--- a/crates/ty_python_semantic/src/types/infer/builder/conditions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/conditions.rs
@@ -175,13 +175,54 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             ConditionTruthiness::Ambiguous => {
                 self.check_overlapping_condition(test, root, polarity);
             }
-            ConditionTruthiness::AlwaysTrue | ConditionTruthiness::AlwaysFalse if is_place => {
+            ConditionTruthiness::AlwaysTrue | ConditionTruthiness::AlwaysFalse
+                if is_place && self.outcome_is_declared(root, polarity) =>
+            {
                 self.report_redundant_condition(test, root, truthiness);
             }
             // a constant that is not a value read, or one the build environment manufactured
             ConditionTruthiness::AlwaysTrue
             | ConditionTruthiness::AlwaysFalse
             | ConditionTruthiness::Artificial => {}
+        }
+    }
+
+    /// Whether `root`'s constant outcome is the program's doing rather than a
+    /// narrowing's.
+    ///
+    /// A name is only rebound by the code between the narrowing and the read,
+    /// and that code is in this scope, where ty can see it. An attribute reaches
+    /// into an object, and any call in between may have written to it — ty holds
+    /// the narrowed type across such a call, which is what makes attribute
+    /// narrowing usable at all, but it means a constant read off one is not a
+    /// fact about the program:
+    ///
+    /// ```py
+    /// latch.on = False        # `on: bool`
+    /// latch.flip()            # assigns `self.on = True`
+    /// assert latch.on         # not "always false" — `on` is a `bool`
+    /// ```
+    ///
+    /// So an attribute is asked what its class declares, which is a fact. A
+    /// subscript reaches into an object the same way and has no declaration to
+    /// fall back on — its element type comes out of a `__getitem__` call, which
+    /// this would have to redo — so it is never reported.
+    fn outcome_is_declared(&self, root: &ast::Expr, polarity: ConditionPolarity) -> bool {
+        let db = self.db();
+        let env = self.program_environment();
+        match root {
+            ast::Expr::Attribute(attribute) => self
+                .expression_type(&attribute.value)
+                .member(db, env, attribute.attr.as_str())
+                .place
+                .ignore_possibly_undefined()
+                .is_some_and(|declared| {
+                    ConditionTruthiness::classify(declared.bool(db, env), polarity, || false)
+                        .constant_outcome()
+                        .is_some()
+                }),
+            ast::Expr::Subscript(_) => false,
+            _ => true,
         }
     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -2067,9 +2067,20 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         else {
             return;
         };
-        // the block returns `None`; a declared return type that accepts `None`
-        // (`None`, `int | None`, `object`, …) is satisfiable, anything else is not
-        if Type::none(db, env).is_assignable_to(db, env, return_ty) {
+        // a block whose body awaits lowers to an `async def`, so what it returns
+        // is the coroutine that calling it produces
+        let block_return = if function.is_async {
+            KnownClass::CoroutineType.to_specialized_instance(
+                db,
+                env,
+                &[Type::any(), Type::any(), Type::none(db, env)],
+            )
+        } else {
+            Type::none(db, env)
+        };
+        // a declared return type that accepts what the block returns (`None`,
+        // `int | None`, `object`, …) is satisfiable, anything else is not
+        if block_return.is_assignable_to(db, env, return_ty) {
             return;
         }
         if let Some(builder) = self
@@ -2077,8 +2088,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .report_lint(&TRAILING_LAMBDA_RETURN_TYPE, callee)
         {
             builder.into_diagnostic(format_args!(
-                "a trailing-lambda callback must return `None`, not `{}` \
+                "a trailing-lambda callback must return `{}`, not `{}` \
                  (other return types are not yet supported)",
+                block_return.display(db, env),
                 return_ty.display(db, env)
             ));
         }

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -1178,7 +1178,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         env,
                         [inner, Type::none(self.db(), env)],
                     );
-                    if matches!(inner, Type::TypeVar(_)) {
+                    // `Self` is the one type variable that can never bind to an
+                    // optional: it stands for the enclosing class, so `Self?` has
+                    // no inner layer to keep apart and is the plain union
+                    if matches!(inner, Type::TypeVar(typevar)
+                        if !matches!(typevar.kind(self.db()), TypeVarKind::TypingSelf))
+                    {
                         return Type::KnownInstance(KnownInstanceType::WrappedOptional(
                             InternedType::new(self.db(), decomposition),
                         ));

--- a/crates/ty_python_semantic/src/types/reified_infer.rs
+++ b/crates/ty_python_semantic/src/types/reified_infer.rs
@@ -28,6 +28,7 @@ use crate::place::{builtins_symbol, global_symbol};
 use crate::types::ProgramEnvironment;
 use crate::types::call::{Argument, CallArguments};
 use crate::types::class::{ClassLiteral, ClassType, GenericAlias};
+use crate::types::class_base::ClassBase;
 use crate::types::function::FunctionType;
 use crate::types::generics::{Specialization, combine_use_site_projections};
 use crate::types::instance::Protocol;
@@ -36,7 +37,7 @@ use crate::types::protocol_class::ReifiedMember;
 use crate::types::tuple::Tuple;
 use crate::types::typevar::{TypeVarBoundOrConstraints, TypeVarKind};
 use crate::types::variance::TypeVarVariance;
-use crate::types::{KnownClass, Type};
+use crate::types::{KnownClass, MemberLookupPolicy, Type};
 
 /// why a bare call of a reified generic cannot be accepted
 pub(crate) enum ReifiedInferenceError<'db> {
@@ -441,7 +442,69 @@ pub(crate) fn constructor_specialization_display<'db>(
     if origin != class_literal {
         return None;
     }
+    if !is_runtime_subscriptable(db, env, origin) {
+        return None;
+    }
     spell_specialization_arguments(db, env, file, origin, alias.specialization(db))
+}
+
+/// Whether `C[…]` evaluates at runtime, so a reified call may be spelled that
+/// way.
+///
+/// Almost every generic class is subscriptable, because being generic is what
+/// puts `Generic` — and so `__class_getitem__` — among its bases. The
+/// exceptions are all in one place: the C-implemented types of the standard
+/// library, which are generic only in typeshed's description of them.
+/// `zip[tuple[int, str]]` is a `TypeError` on every python version, and so are
+/// `filter`, `map`, `reversed`, most of `itertools`, and `io.TextIOWrapper`.
+///
+/// Typeshed's convention is what tells those apart: it spells out
+/// `__class_getitem__` on each C type that does accept a subscript, because
+/// those implement it themselves rather than inheriting it. A stdlib class that
+/// says neither that nor "I extend a generic class" — `zip` has no base at all
+/// — is the C type it looks like. Every other class, first-party or
+/// third-party, stub or source, is python, and python gives a generic class its
+/// `__class_getitem__`.
+///
+/// Reification is best-effort, so where the signal runs out the answer is no: a
+/// missed `__orig_class__` is a feature not applied, and a subscript the
+/// runtime rejects is a `TypeError`.
+fn is_runtime_subscriptable<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    class: ClassLiteral<'db>,
+) -> bool {
+    if !describes_the_standard_library(db, class) {
+        return true;
+    }
+    if class
+        .class_member(db, env, "__class_getitem__", MemberLookupPolicy::default())
+        .place
+        .ignore_possibly_undefined()
+        .is_some()
+    {
+        return true;
+    }
+    // the class itself heads its own MRO, and every class with a type-parameter
+    // list carries a `Generic` entry there whether or not its runtime accepts a
+    // subscript — so what is looked for is a *base* that is a specialized
+    // generic class, which for a python class is what drags `Generic` in
+    class
+        .iter_mro(db)
+        .skip(1)
+        .any(|base| matches!(base, ClassBase::Class(ClassType::Generic(_))))
+}
+
+/// Whether `class` is declared in a stub of the standard library, whose classes
+/// are cpython's C types rather than python of their own.
+fn describes_the_standard_library<'db>(db: &'db dyn Db, class: ClassLiteral<'db>) -> bool {
+    let file = class.file(db);
+    if !file.is_stub(db) {
+        return false;
+    }
+    ty_module_resolver::file_to_module(db, db.program_file(file).resolver_file(db))
+        .and_then(|module| module.search_path(db))
+        .is_some_and(ty_module_resolver::SearchPath::is_standard_library)
 }
 
 /// The full runtime spelling (`list[int]`, `tuple[int, str]`) with which the

--- a/crates/ty_python_semantic/src/types/visibility.rs
+++ b/crates/ty_python_semantic/src/types/visibility.rs
@@ -56,6 +56,83 @@ pub fn private_symbols(db: &dyn Db, file: File) -> FxHashSet<Name> {
     names
 }
 
+/// basedpython: the name a `private` method is reached by in the emitted
+/// python, for an attribute whose inferred type is `member_type`.
+///
+/// `None` when the attribute is not a private method.
+pub(crate) fn private_method_name<'db>(
+    db: &'db dyn Db,
+    env: &crate::types::ProgramEnvironment<'db>,
+    receiver: crate::types::Type<'db>,
+    member_type: crate::types::Type<'db>,
+    member: &str,
+) -> Option<String> {
+    // a method reaches the access site as the bound method it produced, so its
+    // own type answers. a property hands back whatever its getter returns
+    // instead — an `int` says nothing about the declaration — so the class is
+    // asked for the member it actually holds
+    let function = declared_function(db, member_type)
+        .or_else(|| declared_function(db, class_member(db, env, receiver, member)?))?;
+    if !function.has_known_decorator(db, super::function::FunctionDecorators::PRIVATE) {
+        return None;
+    }
+    let scope = function.definition(db).scope(db);
+    let index = crate::semantic_index(db, scope.program_file(db));
+    let class = super::infer::nearest_enclosing_class(db, index, scope)?;
+    Some(mangled_private_name(class.name(db).as_str(), member))
+}
+
+/// The function a member's type stands for — the member itself, or the getter
+/// of the property wrapping it.
+fn declared_function<'db>(
+    db: &'db dyn Db,
+    member_type: crate::types::Type<'db>,
+) -> Option<super::function::FunctionType<'db>> {
+    match member_type {
+        crate::types::Type::FunctionLiteral(function) => Some(function),
+        crate::types::Type::BoundMethod(method) => Some(method.function(db)),
+        crate::types::Type::PropertyInstance(property) => {
+            declared_function(db, property.getter(db)?)
+        }
+        _ => None,
+    }
+}
+
+/// The member a class holds under `name`, read off the class rather than
+/// through an instance, so a descriptor is not resolved on the way.
+fn class_member<'db>(
+    db: &'db dyn Db,
+    env: &crate::types::ProgramEnvironment<'db>,
+    receiver: crate::types::Type<'db>,
+    name: &str,
+) -> Option<crate::types::Type<'db>> {
+    receiver
+        .erase_restriction(db)
+        .nominal_class(db, env)?
+        .class_member(db, env, name, super::MemberLookupPolicy::default())
+        .place
+        .ignore_possibly_undefined()
+}
+
+/// basedpython: the attribute name a `private` class member is reached by in
+/// the emitted python — python's own name mangling, written out in full.
+///
+/// A member lowered to `__helper` is stored under `_A__helper` when `A`'s body
+/// is executed. Python applies that rewrite lexically, to every `__name` it
+/// reads inside a class body, so a reference from anywhere else — a subclass, a
+/// module-level function — would land on a different attribute or none at all.
+/// Spelling the mangled name out reaches the member from all of them.
+///
+/// The rule is python's: leading underscores are stripped from the class name,
+/// and a class named only with underscores mangles nothing.
+pub(crate) fn mangled_private_name(class: &str, member: &str) -> String {
+    let class = class.trim_start_matches('_');
+    if class.is_empty() {
+        return format!("__{member}");
+    }
+    format!("_{class}__{member}")
+}
+
 /// Whether a decorator list carries the synthetic `private` modifier.
 ///
 /// The parser models a modifier keyword as a decorator whose source range does

--- a/docs/basedpython/cli-reference.md
+++ b/docs/basedpython/cli-reference.md
@@ -52,10 +52,30 @@ the project is type-checked first, and a program with check *errors* is not
 run — the checker's verdict and the runtime must not diverge. warnings don't
 block; a rule can be downgraded in configuration where its error is unwanted
 
-the interpreter comes from `PYTHON` (default `python3`), and by default the
-emitted code targets that interpreter's version. an explicit `--min-version`
-wins, but must not exceed the interpreter — `by run` refuses rather than emit
-code the interpreter cannot parse
+the interpreter is the project's own: the environment `by check` resolves
+imports against — the `environment.python` the project configures, else an
+activated virtual environment, a conda environment, or a `.venv` beside the
+project's `pyproject.toml`. `--python` overrides it for one run, and `PYTHON`
+stands in only where the project has no environment of its own, above the bare
+`python3` discovery falls back to. a third-party package lives in that
+environment's `site-packages` and nowhere else, so running anywhere else fails
+on an import the checker had no complaint about. all of that resolves against
+the project root rather than the working directory, so `by run` in a
+subdirectory is still this project
+
+the emitted code targets that interpreter's version by default. an explicit
+`--min-version` wins, but must not exceed the interpreter — `by run` refuses
+rather than emit code the interpreter cannot parse. an interpreter *older* than
+the version the project declares is refused too: the source may use syntax that
+python has no lowering for, and the failure would land as a `SyntaxError` inside
+generated code. passing `--min-version` for the interpreter's own version builds
+for it instead
+
+the program runs in the directory `by run` was invoked from, the way `python -m`
+does. the transpiled tree lives in a temporary directory, which python puts at
+the head of `sys.path` — so a relative path on the command line, and anything
+the program reads or writes beside the project, resolve where they were written
+to
 
 hidden directories (`.claude`, `.git`, `.venv`, …) and build outputs are never
 treated as project source: they are neither checked nor transpiled, by `run`
@@ -80,6 +100,12 @@ so the checker and the emitter agree about which python this project targets
 a file that fails to parse fails the build, but only for itself: every other
 module is still written. a code generator and a test runner are exactly what you
 reach for when one file is mid-edit
+
+artifacts and exit status answer different questions. everything that could be
+emitted is emitted, sourcemap and package markers included; the exit status says
+whether anything was *reported*. so a build that prints an error exits 1 while
+still leaving a usable `out/`, and `by build && pytest out/tests` runs the tests
+only against a tree the checker had nothing to say about
 
 writes the transpiled python to `./out/` mirroring the *module* tree. a
 src-layout project's `src/package_name/main.by` is the module
@@ -158,8 +184,10 @@ compiled 1 module(s)
 1 function(s) left to the interpreted definition
 ```
 
-the C toolchain and the cpython headers come from the interpreter named by
-`PYTHON` (default `python3`), which must have development headers available
+the C toolchain and the cpython headers come from the same interpreter `by run`
+uses, chosen the same way, and it must have development headers available. it
+has to be the same one: an extension built against one abi is unimportable by
+another, and `by run --compiled` imports what this wrote
 
 ## `by generate-api-file`
 

--- a/docs/basedpython/features/anonymous-named-tuple.md
+++ b/docs/basedpython/features/anonymous-named-tuple.md
@@ -71,10 +71,12 @@ def f() -> (age: int, name: str):
 f().name  # works at runtime
 ```
 
-**annotated assignments** whose annotation is an anonymous named tuple:
+**annotated assignments** whose annotation is an anonymous named tuple, with or
+without a [declaration modifier](modifiers.md):
 
 ```by
 a: (name: str, age: int) = ("asdf", 1)
+let b: (name: str, age: int) = ("asdf", 1)
 # transpiled to: a: _AnonNamedTuple_xxx = _AnonNamedTuple_xxx("asdf", 1)
 ```
 

--- a/docs/basedpython/features/conditions.md
+++ b/docs/basedpython/features/conditions.md
@@ -114,6 +114,24 @@ one — its single assignment fixes the outcome and a branch guarded by it is de
 subscript is read at its *declared* type, which for a `bool`-valued flag is `bool`, so the same
 constant written as a class attribute is not reported
 
+the declared type is what decides it because an attribute reaches into an object that any call in
+between may have written to. ty holds a narrowing across such a call — that is what makes attribute
+narrowing usable — so a constant read off one is the narrowing's doing rather than the program's:
+
+```by
+class Latch:
+    var on: bool
+
+    def flip(self):
+        self.on = True
+
+def f(latch: Latch):
+    latch.on = False
+    latch.flip()
+    if latch.on:  # ok — `flip` may have written it, and `on` is declared `bool`
+        ...
+```
+
 ```by
 DEBUG = False
 

--- a/docs/basedpython/features/init-method.md
+++ b/docs/basedpython/features/init-method.md
@@ -44,6 +44,31 @@ a bodyless `init(...)` is filled in with `: ...` when no `let` parameter
 produces a body line. body-bearing `init(...)` keeps the user's statements;
 `let` self-assignments are prepended ahead of them
 
+## defaults
+
+a parameter default is lowered exactly as it is on a `def`. a default that is
+constructed rather than a constant is re-evaluated per call rather than shared
+between every instance, and a required parameter may follow a defaulted one:
+
+```by
+class Fight:
+    init(
+        let seen: set[int] = set(),
+        let last: int,
+    )
+```
+
+```python
+class Fight:
+    def __init__(self, seen: set[int] = _MISSING, last: int = _MISSING):
+        if seen is _MISSING:
+            seen = set()
+        if last is _MISSING:
+            raise TypeError("__init__() missing required argument: 'last'")
+        self.seen: set[int] = seen
+        self.last: int = last
+```
+
 ## `let` parameter modifier
 
 `let` may appear on any positional, positional-only, keyword-only, `*args`,

--- a/docs/basedpython/features/lazy-imports.md
+++ b/docs/basedpython/features/lazy-imports.md
@@ -77,6 +77,17 @@ and quietly answer `False` for equal values
 (via `__class__`), and `isinstance(x, C)` where `C` itself was lazily imported
 (via `__instancecheck__`)
 
+an **exception class is never proxied**. `except` is the one place cpython
+refuses a stand-in: it checks that what it catches is a real class inheriting
+`BaseException`, and never consults `__instancecheck__`. so
+`from errors import ParseError` stays an ordinary import, and the rest of the
+statement's names still don't:
+
+```py
+from errors import ParseError
+decode = _lazy_attr("errors", "decode")
+```
+
 two things a proxy cannot emulate, and which are therefore limitations of the
 polyfill only:
 

--- a/docs/basedpython/features/main-function.md
+++ b/docs/basedpython/features/main-function.md
@@ -87,10 +87,64 @@ tokens on the command line still line up with the remaining parameters. a
 `bool` without a default is required, meaning one of the two flags must be
 given.
 
+an [optional](wrapped-results.md) `T?` is spelled as its `T` — leaving the
+argument out is what the `None` stands for — and so is a `T | None`
+
+a union of literals becomes the set of values the argument accepts, written
+either way round. argparse rejects anything else before `main` runs:
+
+```by
+def main(mode: "fast" | "slow" = "fast"): ...
+```
+
+```by
+from typing import Literal
+
+def main(mode: Literal["fast", "slow"] = "fast"): ...
+```
+
+```sh
+> by run main --mode sideways
+main: error: argument --mode: invalid choice: 'sideways'
+```
+
+a union of a named type and a literal (`int | "auto"`) is not exposed: no
+argument could satisfy both halves, so there is nothing to offer
+
 a parameter with any other annotation is not exposed. if it has a default it
 simply keeps that default; if it is required, `main` cannot be called from the
 command line at all and is left alone — the module gets no entry-point guard.
-`*args` / `**kwargs` are never exposed, and never block the guard.
+`**kwargs` is never exposed, and never blocks the guard.
+
+### the arguments the interface does not claim
+
+a program launched by another one is handed flags it never declared. a `*rest`
+written *first* asks for them: everything after it is keyword-only, so the
+arguments the interface does not recognise are the only positional ones and
+they arrive in `rest`
+
+```by
+def main(*rest: str, games: int = 1):
+    print(games, rest)
+```
+
+```sh
+> by run main --games 3 --LadderServer 127.0.0.1
+3 ('--LadderServer', '127.0.0.1')
+```
+
+they arrive as the strings the command line carried, so the vararg's own
+annotation converts them the way a declared parameter's does — `*rest: int`
+hands `main` integers. an annotation with no command-line spelling has nothing
+to convert with, and the vararg goes back to being one nothing fills
+
+a `*rest` written after an ordinary parameter cannot mean that either — the
+parameter ahead of it would take the first unclaimed argument as its own — so
+there it stays what python makes it
+
+a flag the interface *does* declare is still matched, so `--games` reaches
+`games`; anything else reaches `rest`, a misspelling of a declared flag
+included
 
 positional-only and keyword-only parameters keep their calling convention: a
 positional-only parameter is still passed positionally to `main` even when the

--- a/docs/basedpython/features/modifiers.md
+++ b/docs/basedpython/features/modifiers.md
@@ -88,22 +88,32 @@ instead of the usual `: ...`
 
 ## let / var / class-var / newtype
 
-| basedpython            | Python output                          |
-| ---------------------- | -------------------------------------- |
-| `let MAX = 100`        | `MAX: Final = 100`                     |
-| `let x: int`           | `x: Final[int]`                        |
-| `let x`                | `x: Final`                             |
-| `var x = 1`            | `x = 1`                                |
-| `var x: int = 1`       | `x: int = 1`                           |
-| `var x: int`           | `x: int`                               |
-| `class count = 0`      | `count: ClassVar = 0` (inside a class) |
-| `newtype UserId = int` | `UserId = NewType("UserId", int)`      |
+| basedpython                 | Python output                          |
+| --------------------------- | -------------------------------------- |
+| `let MAX = 100`             | `MAX: Final = 100`                     |
+| `let x: int`                | `x: Final[int]`                        |
+| `let x`                     | `x: Final`                             |
+| `var x = 1`                 | `x = 1`                                |
+| `var x: int = 1`            | `x: int = 1`                           |
+| `var x: int`                | `x: int`                               |
+| `class count = 0`           | `count: ClassVar = 0` (inside a class) |
+| `class var count: int`      | `count: ClassVar[int]`                 |
+| `class let ORIGIN: P = P()` | `ORIGIN: Final[P] = P()`               |
+| `newtype UserId = int`      | `UserId = NewType("UserId", int)`      |
 
 `let` works at module and class scope. inside a class, `class x = ...` is the
 class-variable form (distinct from the regular `let x = ...` which is `Final`).
 the initializer may be omitted: `let x: int` declares a read-only attribute and
 a bare `let x` an uninitialized `Final`, both bound by a single later assignment.
 `newtype` introduces a distinct `typing.NewType`-backed type at module scope
+
+`class var x: T` is the same class variable with its type *declared* rather than
+read off a value, which is the only form a stub can write. `class let x: T = v`
+is the read-only one — python spells that `Final`, which in a class body cannot
+be reassigned through the class or an instance. a `class let` needs a value:
+`__init__` binds an instance, so there is no later place for one to arrive.
+`class` is a class-body modifier — at module scope there is no class for the
+variable to belong to, and it is an error there
 
 ## var
 
@@ -170,15 +180,22 @@ def _helper(): ...
 
 - `export` and `public` are aliases. each marked symbol is added to a synthesized
     `__all__` list at module level
-- `private` strips the keyword and renames the symbol with a leading underscore
-    at the definition site *and* every same-module call site. it is excluded from
-    `__all__` even when no `export`/`public` declarations exist
+- `private` strips the keyword and gives the symbol a leading underscore at the
+    definition site *and* every same-module call site. a name that already has
+    one keeps it — a second would make it a `__name`, which python name-mangles
+    wherever a class body reads it. it is excluded from `__all__` even when no
+    `export`/`public` declarations exist
 - inside a class body only `private` means anything — `export`/`public` are
     stripped. what `private` renames depends on the member: a `private def` is
     name-mangled (`__helper`), a `private` [property](properties.md) becomes `_x`
     with `__x` storage, and a `private` attribute keeps its name. either way the
     member is private to the type checker, which is what
     [safe variance](safe-variance.md) rests on
+- a call to a `private def` is written with the mangled name spelled out —
+    `self.helper()` becomes `self._A__helper()`. python mangles lexically, so a
+    bare `self.__helper` would name a different attribute in a subclass's body
+    and none at all outside a class; the full spelling reaches the method from
+    all of them
 
 ## inlay hints
 

--- a/docs/basedpython/features/properties.md
+++ b/docs/basedpython/features/properties.md
@@ -498,9 +498,10 @@ no `Final`, no `cached_property` — neither is emitted by this feature
     → parse error
 - `static var`, or `static let` with `set` / `field` / an initialiser → parse
     error: a class-level property is read-only and purely computed
-- `class let` / `class var` → parse error naming `static` as the modifier. the
-    `class` keyword is a modifier for `class def` (a classmethod) and
-    `class x = 1` (a `ClassVar`), but not for a declaration with accessors
+- `class let` / `class var` with an accessor block → parse error naming `static`
+    as the modifier. the `class` keyword declares a
+    [class variable](modifiers.md) (`class x = 1`, `class var x: T`) and a
+    classmethod (`class def`), but not a property
 
 ## why
 

--- a/docs/basedpython/features/statement-expressions.md
+++ b/docs/basedpython/features/statement-expressions.md
@@ -17,9 +17,9 @@ each branch's value is the expression it ends on — no `return`, no assignment
 repeated per arm. the type is the union of the branch values, so `direction`
 above is `Literal[1, -1, 0]`
 
-the forms that carry a suite are `if`, `match`, `for` and `while`. `raise` and
-`return` are also expressions; they never produce a value, so they type as
-`Never`
+the forms that carry a suite are `if`, `match`, `for` and `while`. `raise`,
+`return`, `break` and `continue` are also expressions; they never produce a
+value, so they type as `Never`
 
 ## `if`
 
@@ -82,9 +82,10 @@ a `break` may only carry a value where something reads it — in a loop that is
 not a statement expression there is nowhere for the value to go, and it is
 rejected
 
-## `raise` and `return`
+## the diverging forms
 
-both are `Never`, so they can stand in for a value that will never be produced:
+`raise`, `return`, `break` and `continue` are all `Never`, so each can stand in
+for a value that will never be produced:
 
 ```by
 def lookup(table: dict[str, int], key: str) -> int:
@@ -97,6 +98,18 @@ def parse_port(raw: str?) -> int:
 
 because they are `Never`, the surrounding expression's type is just the other
 branch's — `table.get(key) ?? raise ...` is `int`, not `int | None`
+
+`break` and `continue` bring that to a loop body, where the value that went
+missing is a reason to move on rather than to fail:
+
+```by
+def total(rows: list[str]) -> int:
+    sum = 0
+    for row in rows:
+        amount = parse(row) ?? continue
+        sum += amount
+    return sum
+```
 
 ## nesting
 
@@ -131,7 +144,7 @@ a = 1 + match x:       # error: must be the whole value of its statement
         1
 ```
 
-`raise` and `return` carry no suite, so they may also appear inside the
+the diverging forms carry no suite, so they may also appear inside the
 operators that *choose* between operands — `and`, `or`, `??`, the conditional
 expression, and the walrus:
 
@@ -140,6 +153,7 @@ value = maybe() ?? raise Missing()
 value = cached or raise Missing()
 value = x if x > 0 else raise ValueError(x)
 value = (found := lookup() ?? raise Missing())
+value = maybe() ?? continue
 ```
 
 anywhere else — as a call argument, inside a list, as an operand of `+` — the

--- a/docs/basedpython/features/trailing-lambdas.md
+++ b/docs/basedpython/features/trailing-lambdas.md
@@ -106,12 +106,13 @@ appended as the last positional argument instead
 callable the last parameter is declared as. in the example above `a` is
 `(int) -> str`, so `it` is `int`.
 
-the block itself always returns `None` — in a `once` block a `return` targets
-the *enclosing* function, not the block (see [once blocks](#once-blocks)) — so
-the callee's callback must be declared to return a type that accepts `None`
-(`None`, `int | None`, `object`). a callback declared to return anything else is
-rejected with `trailing-lambda-return-type`; those return types are not yet
-supported
+the block itself returns `None` — in a `once` block a `return` targets the
+*enclosing* function, not the block (see [once blocks](#once-blocks)) — so the
+callee's callback must be declared to return a type that accepts `None` (`None`,
+`int | None`, `object`). a callback declared to return anything else is rejected
+with `trailing-lambda-return-type`; those return types are not yet supported. a
+block whose body awaits returns the coroutine calling it produces instead — see
+[async blocks](#async-blocks)
 
 the call is type-checked with the block counted as an argument: missing
 earlier arguments, an over-supplied last parameter, or a non-callable target
@@ -265,6 +266,37 @@ does not get:
 > `with`), and a callee that swallows the callback's control flow — or never
 > calls it — defeats the propagation. tightening `return` / `break` / `continue`
 > out of a `once` block into a guaranteed unwind is tracked as future work
+
+## async blocks
+
+a block whose body awaits is a coroutine function of its own, so it lowers to an
+`async def` and the callback it fills is declared to return an awaitable. that
+is what lets a scoped resource — a socket, a subprocess, a database handle — be
+written as a block:
+
+```by
+async def scope(name: str, once block: () -> Awaitable[None]):
+    try:
+        await block()
+    finally:
+        await close(name)
+
+async def main():
+    await scope("db"):
+        await query("select 1")
+```
+
+```python
+async def main():
+    async def _trailing_lambda_0(it=None):
+        await query("select 1")
+    await scope("db", block=_trailing_lambda_0)
+```
+
+`await` in the block is a statement about the *block*, not about the `def` it was
+written inside: the block is its own function. writing `await` in front of the
+call is what hands the coroutine the callee returns back to the event loop — the
+block hangs off the call, and the `await` stays where it was written
 
 ## borrowed `it`
 

--- a/docs/basedpython/features/wrapped-results.md
+++ b/docs/basedpython/features/wrapped-results.md
@@ -76,6 +76,18 @@ consumers unwrap as with any wrapped optional — `!`, `^`, `??`, and `?.` all
 read the wrapper's present value. compound operands are unaffected (`list[T]?`
 stays the plain union — substitution cannot introduce a top-level `None` there)
 
+`Self` is the exception: it stands for the enclosing class, which can never
+itself be an optional, so `Self?` is the plain union. that is what a fallible
+constructor returns:
+
+```by
+class Record:
+    class def parse(cls, line: str) -> Self?:
+        if not line:
+            return None
+        return cls(line)
+```
+
 ## auto-wrap
 
 > **not yet implemented** (see the status banner). a bare `return` is currently


### PR DESCRIPTION
- a narrowed attribute is no longer read as a settled condition: a call in between may have written it, so its declaration is what decides
- `main`'s command line takes an optional, a literal union, and — through a leading `*rest` — the arguments it does not claim itself. it also rejects `int | "a"`, which no command-line value can satisfy; keeps the choices of a `Literal[...] | None`; reads `typing.Literal`; renders a control character the way python spells it rather than the way rust does; converts a `*rest: int` instead of handing the body strings; and gives `*rest: str` the arguments it was getting nothing of
- a declaration modifier no longer hides an anonymous named tuple's annotation from the coercion that builds it
- `by build` exits 1 when it reported an error, and still writes what it could
- a trailing lambda block whose body awaits is a coroutine function, and `await f(x):` hangs the block on the call. a nested definition's header is read as part of the block — annotations, type-parameter bounds, class bases and a lambda's defaults all evaluate there — while its body is not
- a declaring `init` parameter's annotation is lowered once, not twice
- a parenthesised multi-line value on a `let`/`var` kept its parentheses
- `?? continue` and `?? break` are statement expressions like `?? return`
- a generic builtin that rejects a subscript at runtime is no longer reified, and a third-party stub's generic class still is: the `__class_getitem__` convention the check reads is typeshed's, not every stub's
- a `private def` is called by its mangled name at the call site, `@property` included, and a module-level one that already starts with an underscore is not given a second
- `Self?` is a plain union, not a wrapped optional
- an `init(...)` shorthand lowers its own defaults and relaxed parameter order, and a body that is only a docstring still gets its guards — after the docstring rather than before it
- a default that awaits is left exactly as written: the callee it would be hoisted into cannot host the suspension, and cpython rejects the result
- `by run` and `by compile` execute on the environment the checker resolved the project's imports against — `environment.python` when the project names one, discovery otherwise — and `run` runs in the caller's directory
- an imported exception class is never bound to a lazy proxy, relative imports included
- `class var x: T` / `class let x: T` declare a class variable's type. the name may be a soft keyword; a modifier beside the declaration is refused, since it would take the one marker slot the binding keyword already fills; and a `class` followed by two names is reported rather than read as a class definition. a valueless `class let` is `final-without-value`'s to report, which is the one place that knows a stub states types and never values

`class var x: T`, the loop escapes and an awaited block each get a formatter fixture, so a round trip proves the surface survives being rebuilt from ranges. `class` is also a member modifier, so E701 no longer reads the `:` of a `class var x: T` as a one-line class statement. Semantic tokens highlight the whole `class var` prefix as the one keyword it is.
