### PR TITLE
fix seven issues

### DIFF
--- a/crates/by_transforms/src/transforms/callable.rs
+++ b/crates/by_transforms/src/transforms/callable.rs
@@ -380,10 +380,13 @@ impl<'src> CallableSyntax<'src> {
                                 format!("**{n}")
                             }
                             _ => {
+                                // the anonymous `*: *Ts` carries the empty name
+                                // marker, and needs a name of its own in python
                                 let n = s
                                     .value
                                     .as_name_expr()
                                     .map(|n| n.id.as_str())
+                                    .filter(|n| !n.is_empty())
                                     .unwrap_or("args");
                                 star_emitted = true;
                                 format!("*{n}")

--- a/crates/by_transforms/src/transforms/main_function.rs
+++ b/crates/by_transforms/src/transforms/main_function.rs
@@ -880,6 +880,17 @@ mod tests {
     }
 
     #[test]
+    fn a_literal_union_admits_the_empty_string() {
+        // `\"\"` is a value like any other: it is a choice the command line can
+        // carry, and the default the parameter falls back to
+        let out = guard("def main(a: \"a\" | \"b\" | \"\" = \"\"):\n    pass\n");
+        assert!(
+            out.contains("(\"a\", str, \"any\", False, (\"a\", \"b\", \"\",)),"),
+            "got:\n{out}"
+        );
+    }
+
+    #[test]
     fn last_main_definition_decides() {
         // the trailing `def main` (with a required arg) is the live binding,
         // so the zero-arg earlier definition does not make it an entry point

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -812,6 +812,7 @@ impl SemanticSyntaxContext for Checker<'_> {
             | SemanticSyntaxErrorKind::ReboundComprehensionVariable
             | SemanticSyntaxErrorKind::LazyImportNotAllowed { .. }
             | SemanticSyntaxErrorKind::LazyImportStar
+            | SemanticSyntaxErrorKind::MethodModifierOutsideClass(_)
             | SemanticSyntaxErrorKind::DiscardedBreakValue
             | SemanticSyntaxErrorKind::LazyFutureImport
             | SemanticSyntaxErrorKind::DuplicateTypeParameter
@@ -923,6 +924,10 @@ impl SemanticSyntaxContext for Checker<'_> {
     fn in_function_scope(&self) -> bool {
         let kind = &self.semantic.current_scope().kind;
         matches!(kind, ScopeKind::Function(_) | ScopeKind::Lambda(_))
+    }
+
+    fn in_class_scope(&self) -> bool {
+        matches!(self.semantic.current_scope().kind, ScopeKind::Class(_))
     }
 
     fn in_notebook(&self) -> bool {

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/parameter_shape.by
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/parameter_shape.by
@@ -20,6 +20,12 @@ type Named = (*args: int, **kwargs: str)
 # a named variadic whose annotation is itself starred — it unpacks a pack
 type UnpackedVariadic = (*args: *Ts)
 
+# and the anonymous spelling of the same thing. wrapping the annotation in one
+# more star would spell the kwargs catch-all, so it takes the named shape with
+# the empty name instead
+type UnpackedAnonymousVariadic = (*: *Ts)
+type UnpackedInCallable = (*: *Ts) -> None
+
 # a bare `*A` splices `A` in rather than annotating each field, so it needs no
 # `:`. the lone-element form drops python's disambiguating comma — the star has
 # already said this is a tuple

--- a/crates/ruff_python_formatter/src/expression/expr_tuple.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_tuple.rs
@@ -349,13 +349,22 @@ impl Format<PyFormatContext<'_>> for ParameterShapeFields<'_> {
                                 }),
                             );
                         }
-                        // `*name: T`
+                        // `*name: T`, and the anonymous `*: *Ts` — whose name is
+                        // the empty marker, so there is nothing to write between
+                        // the star and the colon
                         _ => {
+                            let anonymous = matches!(
+                                starred.value.as_ref(),
+                                Expr::Name(name)
+                                    if name.id.is_empty() && name.ctx.is_invalid()
+                            );
                             joiner.entry(
                                 elt,
                                 &format_with(|f| {
                                     token("*").fmt(f)?;
-                                    starred.value.format().fmt(f)?;
+                                    if !anonymous {
+                                        starred.value.format().fmt(f)?;
+                                    }
                                     token(":").fmt(f)?;
                                     space().fmt(f)?;
                                     named.value.format().fmt(f)

--- a/crates/ruff_python_formatter/tests/snapshots/format@parameter_shape.by.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@parameter_shape.by.snap
@@ -26,6 +26,12 @@ type Named = (*args: int, **kwargs: str)
 # a named variadic whose annotation is itself starred — it unpacks a pack
 type UnpackedVariadic = (*args: *Ts)
 
+# and the anonymous spelling of the same thing. wrapping the annotation in one
+# more star would spell the kwargs catch-all, so it takes the named shape with
+# the empty name instead
+type UnpackedAnonymousVariadic = (*: *Ts)
+type UnpackedInCallable = (*: *Ts) -> None
+
 # a bare `*A` splices `A` in rather than annotating each field, so it needs no
 # `:`. the lone-element form drops python's disambiguating comma — the star has
 # already said this is a tuple
@@ -70,6 +76,12 @@ type Named = (*args: int, **kwargs: str)
 
 # a named variadic whose annotation is itself starred — it unpacks a pack
 type UnpackedVariadic = (*args: *Ts)
+
+# and the anonymous spelling of the same thing. wrapping the annotation in one
+# more star would spell the kwargs catch-all, so it takes the named shape with
+# the empty name instead
+type UnpackedAnonymousVariadic = (*: *Ts)
+type UnpackedInCallable = (*: *Ts) -> None
 
 # a bare `*A` splices `A` in rather than annotating each field, so it needs no
 # `:`. the lone-element form drops python's disambiguating comma — the star has

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -943,8 +943,9 @@ impl<'src> Parser<'src> {
                 parameter_borrow: ParameterBorrow::None,
             };
         }
+        // a variadic's annotation may itself be starred (`*: *Ts`), just as in a `def`
         self.parse_conditional_expression_or_higher_impl(
-            ExpressionContext::default().with_in_type_expression(),
+            ExpressionContext::starred_bitwise_or().with_in_type_expression(),
         )
     }
 
@@ -4275,15 +4276,45 @@ impl<'src> Parser<'src> {
             else if self.at(TokenKind::Star) && self.peek() == TokenKind::Colon {
                 let starred_start = self.node_start();
                 self.bump(TokenKind::Star);
+                let star_range = self.node_range(starred_start);
                 self.expect(TokenKind::Colon);
                 let inner = self.parse_parameter_field_annotation();
                 let range = self.node_range(starred_start);
-                elts.push(Expr::Starred(ast::ExprStarred {
-                    value: Box::new(inner.expr),
-                    ctx: ExprContext::Load,
-                    range,
-                    node_index: AtomicNodeIndex::NONE,
-                }));
+                // `*: *Ts` — an anonymous variadic whose annotation is itself an
+                // unpack, exactly as `*args: *Ts` is in a `def`. wrapping the
+                // annotation in one more `Starred` would spell the same shape the
+                // kwargs catch-all `**: T` uses, so this takes the `*name: T`
+                // shape instead, with the empty name that marks an anonymous
+                // field everywhere else in a parameter shape. the bare `*` type is
+                // a marker rather than an unpack, so `*: *` keeps its own encoding
+                if matches!(&inner.expr, Expr::Starred(_))
+                    && !ruff_python_ast::helpers::is_top_star_marker(&inner.expr)
+                {
+                    let anonymous = Expr::Name(ast::ExprName {
+                        range: TextRange::empty(star_range.end()),
+                        id: Name::empty(),
+                        ctx: ExprContext::Invalid,
+                        node_index: AtomicNodeIndex::NONE,
+                    });
+                    elts.push(Expr::Named(ast::ExprNamed {
+                        target: Box::new(Expr::Starred(ast::ExprStarred {
+                            value: Box::new(anonymous),
+                            ctx: ExprContext::Load,
+                            range: star_range,
+                            node_index: AtomicNodeIndex::NONE,
+                        })),
+                        value: Box::new(inner.expr),
+                        range,
+                        node_index: AtomicNodeIndex::NONE,
+                    }));
+                } else {
+                    elts.push(Expr::Starred(ast::ExprStarred {
+                        value: Box::new(inner.expr),
+                        ctx: ExprContext::Load,
+                        range,
+                        node_index: AtomicNodeIndex::NONE,
+                    }));
+                }
             }
             // `*name: T` — named variadic
             else if self.at(TokenKind::Star)

--- a/crates/ruff_python_parser/src/semantic_errors.rs
+++ b/crates/ruff_python_parser/src/semantic_errors.rs
@@ -11,7 +11,7 @@ use ruff_python_ast::{
     helpers,
     visitor::{Visitor, walk_expr, walk_stmt},
 };
-use ruff_text_size::{Ranged, TextRange, TextSize};
+use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use rustc_hash::{FxBuildHasher, FxHashSet};
 use std::cell::RefCell;
 use std::fmt::Display;
@@ -222,16 +222,13 @@ impl SemanticSyntaxChecker {
                     Self::check_pattern_bindings(pattern, ctx);
                 }
             }
-            Stmt::FunctionDef(ast::StmtFunctionDef {
-                type_params,
-                parameters,
-                ..
-            }) => {
-                if let Some(type_params) = type_params {
+            Stmt::FunctionDef(function) => {
+                if let Some(type_params) = &function.type_params {
                     Self::duplicate_type_parameter_name(type_params, ctx);
                     Self::type_parameter_default_order(type_params, ctx);
                 }
-                Self::duplicate_parameter_name(parameters, ctx);
+                Self::duplicate_parameter_name(&function.parameters, ctx);
+                Self::method_modifier_outside_class(function, ctx);
             }
             Stmt::Global(ast::StmtGlobal { names, .. }) => {
                 for name in names {
@@ -770,6 +767,50 @@ impl SemanticSyntaxChecker {
             if has_default {
                 seen_default = true;
             }
+        }
+    }
+
+    /// basedpython: `class def`, `static def` and `override def` say how a class
+    /// dispatches one of its members, or that the member replaces one it
+    /// inherits. a `def` no class owns is not a member of anything, so there is
+    /// nothing for them to say about it
+    ///
+    /// the parser carries every modifier keyword as a synthetic decorator named
+    /// after what it lowers to, over the keyword's own text — an
+    /// [`Invalid`](ExprContext::Invalid) context is what marks a decorator as one
+    /// of those rather than a real `@classmethod` the user wrote
+    fn method_modifier_outside_class<Ctx: SemanticSyntaxContext>(
+        function: &StmtFunctionDef,
+        ctx: &Ctx,
+    ) {
+        if !ctx.is_basedpython() || ctx.in_class_scope() {
+            return;
+        }
+
+        for decorator in &function.decorator_list {
+            let Expr::Name(marker) = &decorator.expression else {
+                continue;
+            };
+            if marker.ctx != ExprContext::Invalid
+                || !matches!(marker.id.as_str(), "classmethod" | "static" | "override")
+            {
+                continue;
+            }
+
+            // the decorator spans the keyword plus the whitespace up to the
+            // `def`, which is not part of what the user wrote
+            let Some(text) = ctx
+                .source()
+                .get(marker.range().start().to_usize()..marker.range().end().to_usize())
+            else {
+                continue;
+            };
+            let keyword = text.trim_end();
+            Self::add_error(
+                ctx,
+                SemanticSyntaxErrorKind::MethodModifierOutsideClass(keyword.to_string()),
+                TextRange::at(marker.range().start(), keyword.text_len()),
+            );
         }
     }
 
@@ -1504,6 +1545,9 @@ impl Display for SemanticSyntaxError {
             SemanticSyntaxErrorKind::LazyImportStar => {
                 f.write_str("lazy from ... import * is not allowed")
             }
+            SemanticSyntaxErrorKind::MethodModifierOutsideClass(keyword) => {
+                write!(f, "`{keyword}` is only a modifier on a method")
+            }
             SemanticSyntaxErrorKind::LazyFutureImport => {
                 f.write_str("lazy from __future__ import is not allowed")
             }
@@ -1547,6 +1591,16 @@ pub enum SemanticSyntaxErrorKind {
 
     /// Represents the use of `lazy from ... import *`.
     LazyImportStar,
+
+    /// basedpython: represents a *method* modifier — `class def`, `static def`,
+    /// `override def` — on a function that no class body owns.
+    ///
+    /// ## Examples
+    ///
+    /// ```by
+    /// static def f(): ...  # nothing to be static on
+    /// ```
+    MethodModifierOutsideClass(String),
 
     /// basedpython: represents a `break <value>` whose value nothing reads,
     /// because the loop it leaves is not used as a
@@ -2813,6 +2867,10 @@ pub trait SemanticSyntaxContext {
     /// Returns `true` if the visitor is in a function scope.
     fn in_function_scope(&self) -> bool;
 
+    /// Returns `true` if the visitor is in a class scope — that is, a `def`
+    /// visited now is a method of that class.
+    fn in_class_scope(&self) -> bool;
+
     /// Returns `true` if the visitor is within a generator scope.
     ///
     /// Note that this refers to an `Expr::Generator` precisely, not to comprehensions more
@@ -2894,6 +2952,9 @@ impl SemanticSyntaxContext for CollectMatchErrors {
         false
     }
     fn in_function_scope(&self) -> bool {
+        false
+    }
+    fn in_class_scope(&self) -> bool {
         false
     }
     fn in_generator_context(&self) -> bool {

--- a/crates/ruff_python_parser/tests/fixtures.rs
+++ b/crates/ruff_python_parser/tests/fixtures.rs
@@ -681,6 +681,10 @@ impl SemanticSyntaxContext for SemanticSyntaxCheckerVisitor<'_> {
         true
     }
 
+    fn in_class_scope(&self) -> bool {
+        false
+    }
+
     fn in_notebook(&self) -> bool {
         false
     }

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -7153,6 +7153,38 @@ def function():
         ");
     }
 
+    /// `**Name` declares a keyword-variadic pack in a basedpython file, not a
+    /// `ParamSpec` — python builds a `ParamSpec` object for it at runtime, but
+    /// naming the hover after that describes none of what the pack does
+    #[test]
+    fn hover_basedpython_keyword_pack_declaration() {
+        let test = CursorTest::builder()
+            .source(
+                "main.by",
+                r#"
+                type Alias[**Kwarg<CURSOR>s] = int
+                "#,
+            )
+            .build();
+
+        assert_snapshot!(test.hover(), @"
+        KeywordPack
+        ---------------------------------------------
+        ```python
+        KeywordPack
+        ```
+        ---------------------------------------------
+        info[hover]: Hovered content is
+         --> main.by:2:14
+          |
+        2 | type Alias[**Kwargs] = int
+          |              ^^^^^-
+          |              |    |
+          |              |    Cursor offset
+          |              source
+        ");
+    }
+
     #[test]
     fn hover_dunder_file() {
         let test = hover_test(

--- a/crates/ty_ide/src/inlay_hints.rs
+++ b/crates/ty_ide/src/inlay_hints.rs
@@ -1086,12 +1086,14 @@ impl<'a, 'db> InlayHintVisitor<'a, 'db> {
             return;
         };
 
-        // only look the owner up once, and only when something could be hinted
+        // only look the owner up once, and only when something could be hinted.
+        // a variadic or keyword-variadic pack has no variance syntax of its own,
+        // so its variance is always inferred and always worth showing
         let undeclared = || {
-            type_params
-                .iter()
-                .filter_map(ast::TypeParam::as_type_var)
-                .filter(|type_var| type_var.variance.is_none())
+            type_params.iter().filter(|type_param| match type_param {
+                ast::TypeParam::TypeVar(type_var) => type_var.variance.is_none(),
+                ast::TypeParam::TypeVarTuple(_) | ast::TypeParam::ParamSpec(_) => true,
+            })
         };
 
         if undeclared().next().is_none() {
@@ -1102,15 +1104,15 @@ impl<'a, 'db> InlayHintVisitor<'a, 'db> {
             return;
         };
 
-        for type_var in undeclared() {
+        for type_param in undeclared() {
             let Some(variance) =
-                inferred_type_param_variance(self.db, owner, type_var.name.as_str())
+                inferred_type_param_variance(self.db, owner, type_param.name().as_str())
             else {
                 continue;
             };
 
             self.hints.push(InlayHint::inferred_variance(
-                type_var.range().start(),
+                type_param.range().start(),
                 variance,
             ));
         }
@@ -1602,6 +1604,20 @@ impl<'a> SourceOrderVisitor<'a> for InlayHintVisitor<'a, '_> {
 
                 return;
             }
+            // basedpython: a declaration that names no type is hinted like the
+            // assignment it is — the type goes where the declaration would
+            // write it, after the name
+            Stmt::AnnAssign(assign) if let Some(value) = untyped_declaration_value(assign) => {
+                if !type_hint_is_excessive_for_expr(value) {
+                    self.assignment_rhs = Some(value);
+                }
+                self.visit_expr(&assign.target);
+                self.assignment_rhs = None;
+
+                self.visit_expr(value);
+
+                return;
+            }
             Stmt::Expr(expr) => {
                 self.visit_expr(&expr.value);
                 return;
@@ -1976,6 +1992,29 @@ fn type_hint_is_excessive_for_expr(expr: &Expr) -> bool {
 
 fn should_skip_import(db: &dyn Db, module: ty_module_resolver::Module, ty: Type) -> bool {
     module.is_known(db, ty_module_resolver::KnownModule::Builtins) || ty.is_none(db)
+}
+
+/// basedpython: the initializer of a declaration that names no type — `let a = v`,
+/// `var a = v`, `context a = v` and the modifier chains that lower like `var`
+///
+/// the parser models a declaration as an annotated assignment whose annotation is
+/// a synthetic marker spanning the keyword text. a declaration that *does* name a
+/// type keeps it under the marker — `let a: T = v` parses as `a: __let__[T] = v`
+/// — so a bare marker is exactly what says the type is unwritten, and the name is
+/// where writing it would go
+fn untyped_declaration_value(assign: &ast::StmtAnnAssign) -> Option<&Expr> {
+    let Expr::Name(marker) = assign.annotation.as_ref() else {
+        return None;
+    };
+    if !marker.ctx.is_invalid() {
+        return None;
+    }
+    matches!(
+        marker.id.as_str(),
+        "__let__" | "__modifier_assign__" | "__context__"
+    )
+    .then(|| assign.value.as_deref())
+    .flatten()
 }
 
 fn annotations_are_valid_syntax(stmt_assign: &ruff_python_ast::StmtAssign) -> bool {
@@ -9930,6 +9969,52 @@ Source with applied edits:
 
         assert_snapshot!(test.inlay_hints_with_settings(&InlayHintSettings {
             inferred_variance: true,
+            ..InlayHintSettings::none()
+        }));
+    }
+
+    /// a pack declares no variance of its own — there is no `out *Ts` to write —
+    /// so the variance it is inferred to have is always worth showing
+    #[test]
+    fn basedpython_inferred_variance_of_a_pack() {
+        let mut test = basedpython_inlay_hint_test(
+            "
+            class Source[*Ts]:
+                def get(self) -> (*Ts,): ...
+
+            class Sink[**Kwargs]:
+                def put(self) -> (**Kwargs) -> None: ...
+            ",
+        );
+
+        assert_snapshot!(test.inlay_hints_with_settings(&InlayHintSettings {
+            inferred_variance: true,
+            ..InlayHintSettings::none()
+        }));
+    }
+
+    /// a declaration that names no type is where the type would be written, so it
+    /// is hinted like the assignment it is. a declaration that already names one
+    /// has nothing to add
+    #[test]
+    fn basedpython_declaration_variable_types() {
+        let mut test = basedpython_inlay_hint_test(
+            "
+            def foo() -> int:
+                return 1
+
+            let a = foo()
+            var b = foo()
+            context c = foo()
+            final d = foo()
+            let e: int = foo()
+            var f: int = foo()
+            let g
+            ",
+        );
+
+        assert_snapshot!(test.inlay_hints_with_settings(&InlayHintSettings {
+            variable_types: true,
             ..InlayHintSettings::none()
         }));
     }

--- a/crates/ty_ide/src/semantic_tokens.rs
+++ b/crates/ty_ide/src/semantic_tokens.rs
@@ -363,12 +363,13 @@ fn accessor_content(statement: &Stmt) -> Vec<AccessorContent<'_>> {
 /// how a format spec clause is coloured: the counts read as numbers, the fill
 /// as the character it is, and the flags and presentation type as the operators
 /// of the mini-language
+///
+/// the `0` of `{x:06}` is a fill, not a count — it is the shorthand that writes
+/// `0=` before the width — so it is coloured as the character it pads with
 fn format_spec_token_type(component: FormatSpecComponent) -> SemanticTokenType {
     match component {
-        FormatSpecComponent::Fill => SemanticTokenType::String,
-        FormatSpecComponent::Zero | FormatSpecComponent::Width | FormatSpecComponent::Precision => {
-            SemanticTokenType::Number
-        }
+        FormatSpecComponent::Fill | FormatSpecComponent::Zero => SemanticTokenType::String,
+        FormatSpecComponent::Width | FormatSpecComponent::Precision => SemanticTokenType::Number,
         FormatSpecComponent::Conversion
         | FormatSpecComponent::Align
         | FormatSpecComponent::Sign
@@ -1369,7 +1370,20 @@ impl<'db> SemanticTokenVisitor<'db> {
             return;
         }
 
-        self.add_token(label.range(), label_type, SemanticTokenModifier::DEFINITION);
+        // the anonymous `*: *Ts` labels itself with the empty name marker, so its
+        // label spans the bare star and there is no name under it to colour —
+        // just as there is none in the `*: T` it is the starred spelling of
+        let anonymous = matches!(
+            label,
+            Expr::Starred(starred)
+                if starred
+                    .value
+                    .as_name_expr()
+                    .is_some_and(|name| name.id.is_empty())
+        );
+        if !anonymous {
+            self.add_token(label.range(), label_type, SemanticTokenModifier::DEFINITION);
+        }
         if let Some(ty) = ty {
             self.visit_annotation(ty);
         }
@@ -5281,6 +5295,8 @@ def route(path: f"/{str}", version: f"v{int}") -> f"{str}-ok":
         "#);
     }
 
+    /// each clause of the spec is coloured for what it is — the `0` among them is
+    /// the fill the padding is written with, not one of the counts
     #[test]
     fn fstring_format_spec_clauses() {
         let test = SemanticTokenTest::new(
@@ -5300,7 +5316,7 @@ f"{value:*^+#08_.3f}"
         "^" @ 22..23: Keyword
         "+" @ 23..24: Keyword
         "#" @ 24..25: Keyword
-        "0" @ 25..26: Number
+        "0" @ 25..26: String
         "8" @ 26..27: Number
         "_" @ 27..28: Keyword
         ".3" @ 28..30: Number
@@ -6046,6 +6062,23 @@ class A:
         "P" @ 32..33: TypeParameter
         "kwargs" @ 37..43: Parameter [definition]
         "P" @ 47..48: TypeParameter
+        "#);
+    }
+
+    /// the anonymous spelling of the same thing has no name under its star, so
+    /// the star itself is not coloured as a parameter
+    #[test]
+    fn semantic_tokens_anonymous_forwarded_pack() {
+        let test = SemanticTokenTest::new_by("def f[*Ts](fn: (*: *Ts) -> None): ...\n");
+
+        let tokens = test.highlight_file();
+
+        assert_snapshot!(test.to_snapshot(&tokens), @r#"
+        "f" @ 4..5: Function [definition]
+        "Ts" @ 7..9: TypeParameter [definition]
+        "fn" @ 11..13: Parameter [definition]
+        "Ts" @ 20..22: TypeParameter
+        "None" @ 27..31: BuiltinConstant
         "#);
     }
 

--- a/crates/ty_ide/src/snapshots/ty_ide__inlay_hints__tests__basedpython_declaration_variable_types.snap
+++ b/crates/ty_ide/src/snapshots/ty_ide__inlay_hints__tests__basedpython_declaration_variable_types.snap
@@ -1,0 +1,76 @@
+---
+source: crates/ty_ide/src/inlay_hints.rs
+expression: "test.inlay_hints_with_settings(&InlayHintSettings\n{ variable_types: true, ..InlayHintSettings::none() })"
+---
+
+def foo() -> int:
+    return 1
+
+let a[: int] = foo()
+var b[: int] = foo()
+context c[: int] = foo()
+final d[: int] = foo()
+let e: int = foo()
+var f: int = foo()
+let g
+
+---------------------------------------------
+info[inlay-hint-location]: Inlay Hint Target
+  --> stdlib/builtins.byi:LL:7
+   |
+LL | class int:
+   |       ^^^
+info: Source
+  --> main2.py:LL:9
+   |
+LL | let a[: int] = foo()
+   |         ^^^
+
+info[inlay-hint-location]: Inlay Hint Target
+  --> stdlib/builtins.byi:LL:7
+   |
+LL | class int:
+   |       ^^^
+info: Source
+  --> main2.py:LL:9
+   |
+LL | var b[: int] = foo()
+   |         ^^^
+
+info[inlay-hint-location]: Inlay Hint Target
+  --> stdlib/builtins.byi:LL:7
+   |
+LL | class int:
+   |       ^^^
+info: Source
+  --> main2.py:LL:13
+   |
+LL | context c[: int] = foo()
+   |             ^^^
+
+info[inlay-hint-location]: Inlay Hint Target
+  --> stdlib/builtins.byi:LL:7
+   |
+LL | class int:
+   |       ^^^
+info: Source
+  --> main2.py:LL:11
+   |
+LL | final d[: int] = foo()
+   |           ^^^
+
+---------------------------------------------
+info[inlay-hint-edit]: Inlay hint edits
+--> main.by:1:1
+  |
+4 |
+  - let a = foo()
+  - var b = foo()
+  - context c = foo()
+  - final d = foo()
+5 + let a: int = foo()
+6 + var b: int = foo()
+7 + context c: int = foo()
+8 + final d: int = foo()
+9 | let e: int = foo()
+  |

--- a/crates/ty_ide/src/snapshots/ty_ide__inlay_hints__tests__basedpython_inferred_variance_of_a_pack.snap
+++ b/crates/ty_ide/src/snapshots/ty_ide__inlay_hints__tests__basedpython_inferred_variance_of_a_pack.snap
@@ -1,0 +1,10 @@
+---
+source: crates/ty_ide/src/inlay_hints.rs
+expression: "test.inlay_hints_with_settings(&InlayHintSettings\n{ inferred_variance: true, ..InlayHintSettings::none() })"
+---
+
+class Source[[out ]*Ts]:
+    def get(self) -> (*Ts,): ...
+
+class Sink[[in ]**Kwargs]:
+    def put(self) -> (**Kwargs) -> None: ...

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -6348,6 +6348,10 @@ impl SemanticSyntaxContext for SemanticIndexBuilder<'_, '_> {
         matches!(kind, ScopeKind::Function | ScopeKind::Lambda)
     }
 
+    fn in_class_scope(&self) -> bool {
+        self.scopes[self.current_scope()].kind() == ScopeKind::Class
+    }
+
     fn in_generator_context(&self) -> bool {
         for scope_info in &self.scope_stack {
             let scope = &self.scopes[scope_info.file_scope_id];

--- a/crates/ty_python_semantic/resources/mdtest/basedpython_callable.md
+++ b/crates/ty_python_semantic/resources/mdtest/basedpython_callable.md
@@ -214,6 +214,20 @@ def f[*Args](fn: (*args: *Args) -> object): ...
 f[int, str](lambda a, b: reveal_type((a, b)))  # revealed: (int, str)
 ```
 
+## unpacked `TypeVarTuple` as an anonymous variadic's annotation
+
+`*: *Args` is the anonymous spelling of `*args: *Args`, and means the same thing. wrapping the
+annotation in one more star would spell the kwargs catch-all `**: T`, so the two are kept apart by
+the shape the parser gives them, not by the star count alone
+
+```by
+def f[*Args](fn: (*: *Args) -> object): ...
+
+f[int, str](lambda a, b: reveal_type((a, b)))  # revealed: (int, str)
+
+reveal_type(f)  # revealed: def f[*Args](fn: (*Args) -> object)
+```
+
 ## `Unpack` in a callable parameter list
 
 ```by

--- a/crates/ty_python_semantic/resources/mdtest/basedpython_method_modifiers.md
+++ b/crates/ty_python_semantic/resources/mdtest/basedpython_method_modifiers.md
@@ -1,0 +1,75 @@
+# basedpython: method modifiers
+
+`class def`, `static def` and `override def` say how a class dispatches one of its members, or that
+the member replaces one it inherits. A `def` that no class body owns is not a member of anything, so
+there is nothing for them to say about it.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+## a method modifier needs a class body
+
+```by
+class def make()  # error: [invalid-syntax] "`class` is only a modifier on a method"
+
+static def helper()  # error: [invalid-syntax] "`static` is only a modifier on a method"
+
+override def replace()  # error: [invalid-syntax] "`override` is only a modifier on a method"
+```
+
+## a function nested in a method is not itself a method
+
+the class owns the method, not the functions the method makes
+
+```by
+class A:
+    def run(self):
+        static def inner()  # error: [invalid-syntax] "`static` is only a modifier on a method"
+```
+
+## a modifier that reads on a class too is left alone
+
+`abstract` and the visibility keywords modify a `def` wherever it is written, so a module-level
+function may carry them
+
+```by
+abstract def f()
+
+private def g() -> str:
+    return "g"
+```
+
+## inside a class body each modifier is what it says
+
+```by
+class A:
+    class def make(cls) -> A:
+        return cls()
+
+    static def helper(x: int) -> int:
+        return x
+
+    def described(self) -> str:
+        return "A"
+
+class B(A):
+    override def described(self) -> str:
+        return "B"
+
+reveal_type(A.make())  # revealed: A
+reveal_type(A.helper(1))  # revealed: int
+```
+
+## an extension body owns its members too
+
+an `extension` declares members of the type it extends, so it is a class body like any other
+
+```by
+extension str:
+    static def joined(parts: list[str]) -> str:
+        return "".join(parts)
+
+reveal_type(str.joined(["a"]))  # revealed: str
+```

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -4625,7 +4625,13 @@ impl<'db> FmtDetailed<'db> for DisplayKnownInstanceRepr<'_, 'db> {
             // it as an instance of `typing.TypeVar`. Inside of a generic class or function, we'll
             // have a `Type::TypeVar(_)`, which is rendered as the typevar's name.
             KnownInstanceType::TypeVar(typevar_instance) => {
-                if typevar_instance.kind(self.db).is_parameter_pack() {
+                // basedpython spells a keyword-variadic pack the way python spells a
+                // `ParamSpec`, and python builds a real `ParamSpec` object for it — but
+                // it is specialized by keyword and forwards no parameter list, so naming
+                // it after the runtime object would describe none of what it does
+                if typevar_instance.kind(self.db).is_keyword_variadic() {
+                    f.with_type(ty).write_str("KeywordPack")
+                } else if typevar_instance.kind(self.db).is_parameter_pack() {
                     f.with_type(ty).write_str("ParamSpec")
                 } else if typevar_instance.kind(db).is_typevartuple() {
                     f.with_type(ty).write_str("TypeVarTuple")

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -4359,10 +4359,14 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                                             .unwrap_or("kwargs")
                                             .to_owned()
                                     }
+                                    // the anonymous `*: *Ts` carries the empty
+                                    // name marker, and reads as the `*: T` it is
+                                    // the starred spelling of
                                     _ => starred
                                         .value
                                         .as_name_expr()
                                         .map(|n| n.id.as_str())
+                                        .filter(|name| !name.is_empty())
                                         .unwrap_or("args")
                                         .to_owned(),
                                 };

--- a/docs/basedpython/features/callable.md
+++ b/docs/basedpython/features/callable.md
@@ -81,6 +81,16 @@ f: (*: int) -> int             # anonymous
 g: (*args: int) -> int         # named
 ```
 
+a variadic's type may itself be an unpack, which types the positional
+parameters as the tuple it names rather than typing each one:
+
+```by
+type Args = (int, str)
+
+f: (*: *Args) -> None          # anonymous
+g: (*args: *Args) -> None      # named
+```
+
 ### kwargs `**kwargs`
 
 ```by

--- a/docs/basedpython/features/modifiers.md
+++ b/docs/basedpython/features/modifiers.md
@@ -86,6 +86,18 @@ individual pydantic fields marked `Field(frozen=True)`
 `abstract def` with no body is filled in with `: raise NotImplementedError`
 instead of the usual `: ...`
 
+`override`, `static` and `class` are *method* modifiers: they say how a class
+dispatches one of its members, or that the member replaces one it inherits. a
+`def` that no class body owns is not a member of anything, so writing one on it
+is an error:
+
+```by
+static def helper()   # error: `static` is only a modifier on a method
+```
+
+`final`, `abstract` and the visibility keywords read on a function wherever it
+is written
+
 ## let / var / class-var / newtype
 
 | basedpython                 | Python output                          |


### PR DESCRIPTION
- a declaration that names no type (`let a = v`, `var a = v`, `context a = v`) is hinted with the type it would write, like the assignment it is
- `*: *Ts` parses: an anonymous variadic whose annotation is itself an unpack. it takes the `*name: T` shape with an empty name so it stays apart from the kwargs catch-all `**: T`, which spells the same star nesting
- a variadic or keyword-variadic pack gets an inferred-variance hint; there is no `out *Ts` to write, so its variance is only ever inferred
- a keyword-variadic pack hovers as `KeywordPack`, not `ParamSpec`
- the `0` of `{x:06}` highlights as the fill it is, not as a count
- `class def`, `static def` and `override def` outside a class body are rejected: a `def` no class owns is not a member of anything
- a literal union admitting `""` keeps it as a command-line choice